### PR TITLE
Add script that runs mocha with --watch

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "build:docs:receipt": "jsdoc2md lib/receipt.js > Docs/receipt.md",
     "build:docs:monetary-amount": "jsdoc2md lib/monetary-amount.js > Docs/monetary-amount.md",
     "build:docs:utils": "jsdoc2md lib/utils.js > Docs/utils.md",
-    "test": "nyc mocha lib/**/*.spec.js --exit"
+    "test": "nyc mocha lib/**/*.spec.js --exit",
+    "test:dev": "nyc mocha lib/**/*.spec.js --exit --watch"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nahmii-sdk",
-  "version": "1.0.0-beta.6",
+  "version": "1.0.0-beta.7",
   "description": "Javascript SDK for using hubii nahmii APIs",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build:docs:monetary-amount": "jsdoc2md lib/monetary-amount.js > Docs/monetary-amount.md",
     "build:docs:utils": "jsdoc2md lib/utils.js > Docs/utils.md",
     "test": "nyc mocha lib/**/*.spec.js --exit",
-    "test:dev": "nyc mocha lib/**/*.spec.js --exit --watch"
+    "test:watch": "nyc mocha lib/**/*.spec.js --exit --watch"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
exec `nyc mocha lib/**/*.spec.js --exit --watch` with `npm run test:dev`

Executes tests on changes to JavaScript in the CWD, and once initially. Saves needing to manually run tests after code changes.