### PR TITLE
Fixes bug where a signed receipt would return false when checking if signed

### DIFF
--- a/lib/payment.spec.js
+++ b/lib/payment.spec.js
@@ -62,7 +62,7 @@ describe('Payment', () => {
         );
 
         return hash(amountCurrencyHash, senderHash, recipientHash);
-    }
+    };
 
     beforeEach(() => {
         unsignedPayload = {

--- a/lib/receipt.js
+++ b/lib/receipt.js
@@ -45,7 +45,7 @@ const PAYMENT_RECEIPT_HASH_PARTS = [
     [
         'recipient.nonce',
         'recipient.balances.current',
-        'recipient.balances.previous',
+        'recipient.balances.previous'
     ],
     [
         'transfers.single',
@@ -227,13 +227,14 @@ class Receipt {
 
 function hashReceipt(serializedReceipt) {
     // Due to how Solidity encodes and hashes uint8 values, we must explicitly
-    // define them as uint8 values to avoid Solidity encoding and hashing them
+    // hash them as uint8 values to avoid Solidity encoding and hashing them
     // as uint256 values
-    serializedReceipt.seals.wallet.signature.v = {
-        type: 'uint8', value: serializedReceipt.seals.wallet.signature.v
+    const receiptCopy = JSON.parse(JSON.stringify(serializedReceipt));
+    receiptCopy.seals.wallet.signature.v = {
+        type: 'uint8', value: receiptCopy.seals.wallet.signature.v
     };
     const hashes = PAYMENT_RECEIPT_HASH_PARTS.map(properties => {
-        return hashObject(serializedReceipt, properties);
+        return hashObject(receiptCopy, properties);
     });
     return hash(...hashes);
 }

--- a/lib/receipt.spec.js
+++ b/lib/receipt.spec.js
@@ -9,7 +9,7 @@ chai.use(sinonChai);
 const Receipt = require('./receipt');
 
 const {privateToAddress} = require('ethereumjs-util');
-const {hash, prefix0x, sign} = require('./utils');
+const {hash, prefix0x} = require('./utils');
 const Payment = require('./payment');
 
 const amount = '1000';
@@ -66,7 +66,7 @@ describe('Receipt', () => {
         const walletSeal = paymentJSON.seals.wallet;
 
         json.seals.wallet = walletSeal;
-    }
+    };
 
     beforeEach(() => {
         unsignedPayload = {
@@ -204,6 +204,7 @@ describe('Receipt', () => {
         it('can be signed', () => {
             receipt.sign(operatorKey);
             expect(receipt.toJSON()).to.eql(signedPayload);
+            expect(receipt.isSigned()).to.eql(true);
         });
     });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nahmii-sdk",
-  "version": "1.0.0-beta.9",
+  "version": "1.0.0-beta.10",
   "description": "Javascript SDK for using hubii nahmii APIs",
   "main": "index.js",
   "scripts": {
@@ -16,7 +16,9 @@
     "test:watch": "nyc mocha lib/**/*.spec.js --exit --watch",
     "lint": "eslint --ignore-path .gitignore --fix ."
   },
-  "pre-commit": ["lint"],
+  "pre-commit": [
+    "lint"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/hubiinetwork/nahmii-sdk.git"


### PR DESCRIPTION
When we started wrapping the `signature.v` field, we introduced a bug where the wrapping of this field when hashing the receipt, also affected the serialised JSON version of the receipt, which again invalidated the signature field.