### PR TITLE
Update v8 contract Ropsten addresses

### DIFF
--- a/lib/abis/BalanceTracker.json
+++ b/lib/abis/BalanceTracker.json
@@ -15842,7 +15842,7 @@
     },
     "networks": {
         "3": {
-            "address": "0x9f3233356a1664361b9702d3e2aa114a08d9a2f7"
+            "address": "0xf5c063ee9e40363bdba3cfb49023bf2fe66e12bb"
         }
     },
     "schemaVersion": "2.0.1",

--- a/lib/abis/ClientFund.json
+++ b/lib/abis/ClientFund.json
@@ -55541,7 +55541,7 @@
         "SafeMathIntLib": "0xbb382264780f52dadb4be9bd5618ca4acb054356",
         "InUseCurrencyLib": "0xeb64fb344de63c578ac387836448bbbff2ce8c76"
       },
-      "address": "0x03e55d1305d1c57f3b73ec9ebee867186ba8621d"
+      "address": "0xed74b22fc99a4be0d2dfeff2b15c2409d56678f5"
     }
   },
   "schemaVersion": "2.0.1",

--- a/lib/abis/DriipSettlement.json
+++ b/lib/abis/DriipSettlement.json
@@ -48527,7 +48527,7 @@
   },
   "networks": {
     "3": {
-      "address": "0xe5ef4898a4bfb56803fbe2c54fd67cdf91ab4dcc"
+      "address": "0x6c16bd90709284dd4a6b4f657e37818e7d0c0269"
     }
   },
   "schemaVersion": "2.0.1",

--- a/lib/abis/DriipSettlementChallenge.json
+++ b/lib/abis/DriipSettlementChallenge.json
@@ -57138,7 +57138,7 @@
       "links": {
         "SafeMathIntLib": "0xbb382264780f52dadb4be9bd5618ca4acb054356"
       },
-      "address": "0x43b686856d358443a489069424163b5f8afe4c7e",
+      "address": "0xf88aa13327385931e56410f97f8cd631f95216e4",
       "transactionHash": "0xf11b2f4d4a6eb1fec0dc5e252ab766b77e99d0925ad6c0d679ba6054982aab79"
     }
   },

--- a/lib/abis/NullSettlement.json
+++ b/lib/abis/NullSettlement.json
@@ -7279,7 +7279,7 @@
   },
   "networks": {
     "3": {
-      "address": "0x9f88c5cc76148d41a5db8d0a7e581481efc9667b"
+      "address": "0x03c3567e250bf81f8ac480697fc4ca868a03d6e2"
     }
   },
   "schemaVersion": "2.0.1",

--- a/lib/abis/NullSettlementChallenge.json
+++ b/lib/abis/NullSettlementChallenge.json
@@ -35778,7 +35778,7 @@
   },
   "networks": {
     "3": {
-      "address": "0x139732f0e688a32be934ca4e28a2b57c95e9edc5"
+      "address": "0x45822d643fe53fdbb694bbe20046589e353f207a"
     }
   },
 "schemaVersion": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nahmii-sdk",
-  "version": "1.0.0-beta.23",
+  "version": "1.0.0-beta.24",
   "description": "Javascript SDK for using hubii nahmii APIs",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Update the addresses to be consistent with https://github.com/hubiinetwork/nahmii-contracts/releases/tag/v1.0-ropsten.8