### PR TITLE
Make wallet or provider an optional parameter for Receipts and Payments

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -18,8 +18,8 @@
   ],
   "check-coverage": true,
   "per-file": false,
-  "lines": 94,
-  "statements": 94,
+  "lines": 95,
+  "statements": 95,
   "functions": 90,
-  "branches": 88
+  "branches": 89
 }

--- a/lib/balance-tracker-contract.spec.js
+++ b/lib/balance-tracker-contract.spec.js
@@ -1,0 +1,69 @@
+'use strict';
+
+const chai = require('chai');
+const sinonChai = require('sinon-chai');
+const expect = chai.expect;
+chai.use(sinonChai);
+
+const proxyquire = require('proxyquire').noPreserveCache().noCallThru();
+
+const fakeBalanceTrackerDeployment = {
+    networks: {
+        '123456789': {
+            address: 'some address'
+        }
+    },
+    abi: []
+};
+
+class Contract {
+    constructor(addr, abi, signerOrProvider) {
+        this.addr = addr;
+        this.abi = abi;
+        this.signerOrProvider = signerOrProvider;
+    }
+}
+
+const fakeEthers = {
+    Contract
+};
+
+const BalanceTrackerContract = proxyquire('./balance-tracker-contract', {
+    'ethers': fakeEthers,
+    './abis/BalanceTracker': fakeBalanceTrackerDeployment
+});
+
+const fakeProvider = {
+    network: {
+        chainId: '123456789'
+    }
+};
+const fakeWallet = {
+    provider: fakeProvider
+};
+
+describe('BalanceTrackerContract', () => {
+
+    [
+        ['wallet', fakeWallet],
+        ['provider', fakeProvider]
+    ].forEach(([description, walletOrProvider]) => {
+        context('with ' + description, () => {
+            let contract;
+
+            beforeEach(() => {
+                contract = new BalanceTrackerContract(walletOrProvider);
+            });
+
+            it('is an instance of Contract', () => {
+                expect(contract).to.be.an.instanceOf(Contract);
+            });
+
+            it('uses correct contract address in construction', () => {
+                expect(contract.addr).to.eql(fakeBalanceTrackerDeployment.networks['123456789'].address);
+                expect(contract.abi).to.eql(fakeBalanceTrackerDeployment.abi);
+                expect(contract.signerOrProvider).to.equal(walletOrProvider);
+            });
+        });
+    });
+});

--- a/lib/client-fund-contract.spec.js
+++ b/lib/client-fund-contract.spec.js
@@ -1,0 +1,69 @@
+'use strict';
+
+const chai = require('chai');
+const sinonChai = require('sinon-chai');
+const expect = chai.expect;
+chai.use(sinonChai);
+
+const proxyquire = require('proxyquire').noPreserveCache().noCallThru();
+
+const fakeClientFundDeployment = {
+    networks: {
+        '123456789': {
+            address: 'some address'
+        }
+    },
+    abi: []
+};
+
+class Contract {
+    constructor(addr, abi, signerOrProvider) {
+        this.addr = addr;
+        this.abi = abi;
+        this.signerOrProvider = signerOrProvider;
+    }
+}
+
+const fakeEthers = {
+    Contract
+};
+
+const ClientFundContract = proxyquire('./client-fund-contract', {
+    'ethers': fakeEthers,
+    './abis/ClientFund': fakeClientFundDeployment
+});
+
+const fakeProvider = {
+    network: {
+        chainId: '123456789'
+    }
+};
+const fakeWallet = {
+    provider: fakeProvider
+};
+
+describe('ClientFundContract', () => {
+
+    [
+        ['wallet', fakeWallet],
+        ['provider', fakeProvider]
+    ].forEach(([description, walletOrProvider]) => {
+        context('with ' + description, () => {
+            let contract;
+
+            beforeEach(() => {
+                contract = new ClientFundContract(walletOrProvider);
+            });
+
+            it('is an instance of Contract', () => {
+                expect(contract).to.be.an.instanceOf(Contract);
+            });
+
+            it('uses correct contract address in construction', () => {
+                expect(contract.addr).to.eql(fakeClientFundDeployment.networks['123456789'].address);
+                expect(contract.abi).to.eql(fakeClientFundDeployment.abi);
+                expect(contract.signerOrProvider).to.equal(walletOrProvider);
+            });
+        });
+    });
+});

--- a/lib/driip-settlement.spec.js
+++ b/lib/driip-settlement.spec.js
@@ -87,7 +87,7 @@ describe('Driip settlement operations', () => {
     [true, null].forEach(t => {
         it(`can start payment challenge period for eth when #hasProposalExpired returns ${t}`, async () => {
             const currency = address0;
-            const receipt = Receipt.from({}, {
+            const receipt = Receipt.from({
                 amount: '100',
                 currency: {ct: currency, id: 0},
                 sender: {wallet: ''},
@@ -107,7 +107,7 @@ describe('Driip settlement operations', () => {
     it('can not start payment challenge period when current challenge proposal has not expired yet', (done) => {
         const amount = '1.23';
         const currency = address0;
-        const receipt = Receipt.from({}, {
+        const receipt = Receipt.from({
             amount: '100',
             currency: {ct: currency, id: 0},
             sender: {wallet: ''},
@@ -123,7 +123,7 @@ describe('Driip settlement operations', () => {
     it('can not start payment challenge period when the receipt nonce is less or equal to the latest proposal\'s', (done) => {
         const amount = '1.23';
         const currency = address0;
-        const receipt = Receipt.from({}, {
+        const receipt = Receipt.from({
             nonce: 2,
             amount: '100',
             currency: {ct: currency, id: 0},
@@ -139,7 +139,7 @@ describe('Driip settlement operations', () => {
 
     testTokens.forEach(t => {
         it(`can start payment challenge period for token ${t.symbol}`, async () => {
-            const receipt = Receipt.from({}, {
+            const receipt = Receipt.from({
                 amount: '100',
                 currency: {ct: testTokens[1].currency, id: 0},
                 sender: {wallet: ''},
@@ -157,7 +157,7 @@ describe('Driip settlement operations', () => {
     });
 
     it('can settle payment driip', async () => {
-        const receipt = Receipt.from({}, {
+        const receipt = Receipt.from({
             amount: '100',
             currency: {ct: address0, id: 0},
             sender: {wallet: ''},
@@ -173,7 +173,7 @@ describe('Driip settlement operations', () => {
     });
 
     it('can not settle payment driip when proposal has not expired yet', (done) => {
-        const receipt = Receipt.from({}, {
+        const receipt = Receipt.from({
             amount: '100',
             currency: {ct: address0, id: 0},
             sender: {wallet: ''},
@@ -191,7 +191,7 @@ describe('Driip settlement operations', () => {
     });
 
     it('can not settle payment driip when proposal is disqualified', (done) => {
-        const receipt = Receipt.from({}, {
+        const receipt = Receipt.from({
             amount: '100',
             currency: {ct: address0, id: 0},
             sender: {wallet: ''},
@@ -209,7 +209,7 @@ describe('Driip settlement operations', () => {
     });
 
     it('can not replay a payment driip settlement', (done) => {
-        const receipt = Receipt.from({}, {
+        const receipt = Receipt.from({
             nonce: 1,
             amount: '100',
             currency: {ct: address0, id: 0},

--- a/lib/payment.js
+++ b/lib/payment.js
@@ -7,6 +7,7 @@
 const ethers = require('ethers');
 const MonetaryAmount = require('./monetary-amount');
 const {fromRpcSig, hashObject, hash, isSignedBy} = require('./utils');
+const Wallet = require('./wallet');
 
 const _amount = new WeakMap();
 const _sender = new WeakMap();
@@ -25,18 +26,21 @@ const PAYMENT_REQUEST_HASH_PARTS = [
 /**
  * @class Payment
  * A class for creating a _hubii nahmii_ payment.
+ * To be able to sign a new payment, you must supply a valid Wallet instance.
+ * To be able to do operations that interacts with the server you need to
+ * supply a valid Wallet or NahmiiProvider instance.
  * @alias module:nahmii-sdk
  * @example
  * const nahmii = require('nahmii-sdk');
- * const provider = new nahmii.NahmiiProvider(nahmii_base_url, nahmii_app_id, nahmii_app_secret);
+ * const wallet = new nahmii.Wallet(...);
  *
  * // Creates a new Payment, providing essential inputs such as the amount,
  * // the currency, the sender, and the recipient.
  * const monetaryAmount = new nahmii.MonetaryAmount(amount, erc20_token_address);
- * const payment = new nahmii.Payment(provider, monetaryAmount, wallet_address, recipient_address);
+ * const payment = new nahmii.Payment(monetaryAmount, wallet_address, recipient_address, wallet);
  *
- * // Signs the payment with the private key belonging to your wallet_address.
- * payment.sign(private_key);
+ * // Signs the payment with the private key belonging to your wallet.
+ * payment.sign();
  *
  * // Sends the signed payment to the API for registration and execution and
  * // logs the API response to the console.
@@ -45,19 +49,20 @@ const PAYMENT_REQUEST_HASH_PARTS = [
 class Payment {
     /**
      * Constructor
-     * @param {Wallet} wallet - A Wallet instance, must be the sender of this payment
      * @param {MonetaryAmount} amount - Amount in a currency
      * @param {Address} sender - Senders address
      * @param {Address} recipient - Recipient address
+     * @param {Wallet|NahmiiProvider} [walletOrProvider] - An optional Wallet or NahmiiProvider instance
      */
-    constructor(wallet, amount, sender, recipient) {
+    constructor(amount, sender, recipient, walletOrProvider) {
         if (!(amount instanceof MonetaryAmount))
             throw new TypeError('amount is not an instance of MonetaryAmount');
 
-        if (wallet) {
-            _wallet.set(this, wallet);
-            _provider.set(this, wallet.provider);
-        }
+        const wallet = walletOrProvider instanceof Wallet ? walletOrProvider : null;
+        const provider = wallet ? wallet.provider: walletOrProvider;
+
+        _wallet.set(this, wallet);
+        _provider.set(this, provider);
         _amount.set(this, amount);
         _sender.set(this, sender);
         _recipient.set(this, recipient);
@@ -91,9 +96,13 @@ class Payment {
      * Will hash and sign the payment with the wallet passed into the constructor
      */
     async sign() {
+        const wallet = _wallet.get(this);
+        if (!wallet)
+            throw new Error('No wallet is available for signing!');
+
         const h = hashPayment(this.toJSON());
         const hArr = ethers.utils.arrayify(h);
-        const sigFlat = await _wallet.get(this).signMessage(hArr);
+        const sigFlat = await wallet.signMessage(hArr);
         const sigExpanded = fromRpcSig(sigFlat);
 
         _hash.set(this, h);
@@ -126,8 +135,12 @@ class Payment {
      * Registers the payment with the server to be effectuated
      * @returns {Promise} A promise that resolves to the registered payment as JSON
      */
-    register() {
-        return _provider.get(this).registerPayment(this.toJSON());
+    async register() {
+        const provider = _provider.get(this);
+        if (!provider)
+            throw new Error('No provider is available for API access!');
+
+        return provider.registerPayment(this.toJSON());
     }
 
     /**
@@ -157,13 +170,13 @@ class Payment {
 
     /**
      * Factory/de-serializing method
-     * @param {Wallet} wallet - The wallet sending the payment
      * @param json - A JSON object that can be de-serialized to a Payment instance
+     * @param {Wallet|NahmiiProvider} [walletOrProvider] - The wallet used for signing the payment
      * @returns {Payment}
      */
-    static from(wallet, json) {
+    static from(json, walletOrProvider = null) {
         const amount = MonetaryAmount.from(json);
-        const p = new Payment(wallet, amount, json.sender.wallet, json.recipient.wallet);
+        const p = new Payment(amount, json.sender.wallet, json.recipient.wallet, walletOrProvider);
         if (json.seals && json.seals.wallet) {
             _hash.set(p, json.seals.wallet.hash);
             _signature.set(p, json.seals.wallet.signature);

--- a/lib/payment.spec.js
+++ b/lib/payment.spec.js
@@ -7,29 +7,26 @@ const proxyquire = require('proxyquire').noPreserveCache().noCallThru();
 const expect = chai.expect;
 chai.use(sinonChai);
 
-const Payment = require('./payment');
 const MonetaryAmount = require('./monetary-amount');
 
 const {privateToAddress} = require('ethereumjs-util');
 const {hash, prefix0x} = require('./utils');
 
-const stubbedClientFundContract = {
-    depositTokens: sinon.stub(),
-    address: 'client fund address'
-};
+const Wallet = proxyquire('./wallet', {
+    './client-fund-contract': function() {
+        return {};
+    },
+    './balance-tracker-contract': function() {
+        return {};
+    },
+    './erc20-contract': function() {
+        return {};
+    }
+});
 
-function proxyquireWallet() {
-    return proxyquire('./wallet', {
-        './client-fund-contract': function() {
-            return stubbedClientFundContract;
-        },
-        './balance-tracker-contract': function() {
-            return {};
-        }
-    });
-}
-
-const Wallet = proxyquireWallet();
+const Payment = proxyquire('./payment', {
+    './wallet': Wallet
+});
 
 const stubbedProvider = {
     registerPayment: sinon.stub()
@@ -69,7 +66,7 @@ describe('Payment', () => {
     const recipient = '0x0000000000000000000000000000000000000003';
     const privateKey = '3a1076bf45ab87712ad64ccb3b10217737f7faacbf2872e88fdd9a537d8fe266';
     const sender = prefix0x(privateToAddress(new Buffer(privateKey, 'hex')).toString('hex'));
-    let unsignedPayload, signedPayload, wallet;
+    let unsignedPayload, signedPayload;
 
     const hashPaymentAsWallet = payload => {
         const amountCurrencyHash = hash(
@@ -113,42 +110,401 @@ describe('Payment', () => {
         };
     });
 
-    context('a new Payment', () => {
-        let payment;
+    afterEach(() => {
+        stubbedProvider.registerPayment.reset();
+    });
+
+    context('given a wallet', () => {
+        let wallet;
 
         beforeEach(() => {
             wallet = new Wallet(privateKey, stubbedProvider);
-            payment = new Payment(wallet, new MonetaryAmount(amount, currency.ct, currency.id), sender, recipient);
         });
 
-        it('can be serialized to an object literal', () => {
-            expect(payment.toJSON()).to.eql(unsignedPayload);
+        context('a new Payment', () => {
+            let payment;
+
+            beforeEach(() => {
+                payment = new Payment(new MonetaryAmount(amount, currency.ct, currency.id), sender, recipient, wallet);
+            });
+
+            it('can be serialized to an object literal', () => {
+                expect(payment.toJSON()).to.eql(unsignedPayload);
+            });
+
+            it('can be signed', async () => {
+                await payment.sign();
+                expect(payment.toJSON()).to.eql(signedPayload);
+            });
+
+            it('can be registered with the API', () => {
+                payment.register();
+                expect(stubbedProvider.registerPayment).to.have.been.calledWith(payment.toJSON());
+            });
+
+            it('has the supplied amount', () => {
+                expect(payment.amount).to.be.equalMoney(new MonetaryAmount(amount, currency.ct, currency.id));
+            });
+
+            it('has the supplied sender', () => {
+                expect(payment.sender).to.eql(sender);
+            });
+
+            it('has the supplied recipient', () => {
+                expect(payment.recipient).to.eql(recipient);
+            });
+
+            it('does not have a valid signature', () => {
+                expect(payment.isSigned()).to.be.false;
+            });
         });
 
-        it('can be signed', async () => {
-            await payment.sign();
-            expect(payment.toJSON()).to.eql(signedPayload);
+        context('a signed Payment', () => {
+            let payment;
+
+            beforeEach(async () => {
+                payment = new Payment(new MonetaryAmount(amount, currency.ct, currency.id), sender, recipient, wallet);
+                await payment.sign();
+            });
+
+            it('can be serialized to an object literal', () => {
+                expect(payment.toJSON()).to.eql(signedPayload);
+            });
+
+            it('can be registered with the API', () => {
+                payment.register();
+                expect(stubbedProvider.registerPayment).to.have.been.calledWith(signedPayload);
+            });
+
+            it('has the supplied amount', () => {
+                expect(payment.amount).to.be.equalMoney(new MonetaryAmount(amount, currency.ct, currency.id));
+            });
+
+            it('has the supplied sender', () => {
+                expect(payment.sender).to.eql(sender);
+            });
+
+            it('has the supplied recipient', () => {
+                expect(payment.recipient).to.eql(recipient);
+            });
+
+            it('has a valid signature', () => {
+                expect(payment.isSigned()).to.be.true;
+            });
         });
 
-        it('can be registered with the API', () => {
-            payment.register();
-            expect(stubbedProvider.registerPayment).to.have.been.calledWith(payment.toJSON());
+        context('a de-serialized unsigned Payment', () => {
+            let payment;
+
+            beforeEach(() => {
+                payment = Payment.from(unsignedPayload, wallet);
+            });
+
+            it('can be serialized to a new object literal', () => {
+                expect(payment.toJSON()).to.eql(unsignedPayload);
+            });
+
+            it('can be signed', async () => {
+                await payment.sign();
+                expect(payment.toJSON()).to.eql(signedPayload);
+            });
+
+            it('can be registered with the API', () => {
+                payment.register();
+                expect(stubbedProvider.registerPayment).to.have.been.calledWith(unsignedPayload);
+            });
+
+            it('has the supplied amount', () => {
+                expect(payment.amount).to.be.equalMoney(new MonetaryAmount(amount, currency.ct, currency.id));
+            });
+
+            it('has the supplied sender', () => {
+                expect(payment.sender).to.eql(sender);
+            });
+
+            it('has the supplied recipient', () => {
+                expect(payment.recipient).to.eql(recipient);
+            });
+
+            it('does not have a valid signature', () => {
+                expect(payment.isSigned()).to.be.false;
+            });
         });
 
-        it('has the supplied amount', () => {
-            expect(payment.amount).to.be.equalMoney(new MonetaryAmount(amount, currency.ct, currency.id));
+        context('a de-serialized signed Payment', () => {
+            let payment;
+
+            beforeEach(() => {
+                payment = Payment.from(signedPayload, wallet);
+            });
+
+            it('can be serialized to a new object literal', () => {
+                expect(payment.toJSON()).to.eql(signedPayload);
+            });
+
+            it('can be registered with the API', () => {
+                payment.register();
+                expect(stubbedProvider.registerPayment).to.have.been.calledWith(signedPayload);
+            });
+
+            it('has the supplied amount', () => {
+                expect(payment.amount).to.eql(new MonetaryAmount(amount, currency.ct, currency.id));
+            });
+
+            it('has the supplied sender', () => {
+                expect(payment.sender).to.eql(sender);
+            });
+
+            it('has the supplied recipient', () => {
+                expect(payment.recipient).to.eql(recipient);
+            });
+
+            it('has a valid signature', () => {
+                expect(payment.isSigned()).to.be.true;
+            });
+        });
+    });
+
+    context('given a provider', () => {
+        context('a new Payment', () => {
+            let payment;
+
+            beforeEach(() => {
+                payment = new Payment(new MonetaryAmount(amount, currency.ct, currency.id), sender, recipient, stubbedProvider);
+            });
+
+            it('can be serialized to an object literal', () => {
+                expect(payment.toJSON()).to.eql(unsignedPayload);
+            });
+
+            it('can not be signed', (done) => {
+                payment.sign().catch(e => {
+                    expect(e).to.be.an.instanceOf(Error);
+                    expect(e.message).to.match(/no wallet/i);
+                    done();
+                });
+            });
+
+            it('can be registered with the API', () => {
+                payment.register();
+                expect(stubbedProvider.registerPayment).to.have.been.calledWith(payment.toJSON());
+            });
+
+            it('has the supplied amount', () => {
+                expect(payment.amount).to.be.equalMoney(new MonetaryAmount(amount, currency.ct, currency.id));
+            });
+
+            it('has the supplied sender', () => {
+                expect(payment.sender).to.eql(sender);
+            });
+
+            it('has the supplied recipient', () => {
+                expect(payment.recipient).to.eql(recipient);
+            });
+
+            it('does not have a valid signature', () => {
+                expect(payment.isSigned()).to.be.false;
+            });
         });
 
-        it('has the supplied sender', () => {
-            expect(payment.sender).to.eql(sender);
+        context('a de-serialized unsigned Payment', () => {
+            let payment;
+
+            beforeEach(() => {
+                payment = Payment.from(unsignedPayload, stubbedProvider);
+            });
+
+            it('can be serialized to a new object literal', () => {
+                expect(payment.toJSON()).to.eql(unsignedPayload);
+            });
+
+            it('can not be signed', (done) => {
+                payment.sign().catch(e => {
+                    expect(e).to.be.an.instanceOf(Error);
+                    expect(e.message).to.match(/no wallet/i);
+                    done();
+                });
+            });
+
+            it('can be registered with the API', () => {
+                payment.register();
+                expect(stubbedProvider.registerPayment).to.have.been.calledWith(unsignedPayload);
+            });
+
+            it('has the supplied amount', () => {
+                expect(payment.amount).to.be.equalMoney(new MonetaryAmount(amount, currency.ct, currency.id));
+            });
+
+            it('has the supplied sender', () => {
+                expect(payment.sender).to.eql(sender);
+            });
+
+            it('has the supplied recipient', () => {
+                expect(payment.recipient).to.eql(recipient);
+            });
+
+            it('does not have a valid signature', () => {
+                expect(payment.isSigned()).to.be.false;
+            });
         });
 
-        it('has the supplied recipient', () => {
-            expect(payment.recipient).to.eql(recipient);
+        context('a de-serialized signed Payment', () => {
+            let payment;
+
+            beforeEach(() => {
+                payment = Payment.from(signedPayload, stubbedProvider);
+            });
+
+            it('can be serialized to a new object literal', () => {
+                expect(payment.toJSON()).to.eql(signedPayload);
+            });
+
+            it('can be registered with the API', () => {
+                payment.register();
+                expect(stubbedProvider.registerPayment).to.have.been.calledWith(signedPayload);
+            });
+
+            it('has the supplied amount', () => {
+                expect(payment.amount).to.eql(new MonetaryAmount(amount, currency.ct, currency.id));
+            });
+
+            it('has the supplied sender', () => {
+                expect(payment.sender).to.eql(sender);
+            });
+
+            it('has the supplied recipient', () => {
+                expect(payment.recipient).to.eql(recipient);
+            });
+
+            it('has a valid signature', () => {
+                expect(payment.isSigned()).to.be.true;
+            });
+        });
+    });
+
+    context('given neither a wallet nor a provider', () => {
+        context('a new Payment', () => {
+            let payment;
+
+            beforeEach(() => {
+                payment = new Payment(new MonetaryAmount(amount, currency.ct, currency.id), sender, recipient);
+            });
+
+            it('can be serialized to an object literal', () => {
+                expect(payment.toJSON()).to.eql(unsignedPayload);
+            });
+
+            it('can not be signed', (done) => {
+                payment.sign().catch(e => {
+                    expect(e).to.be.an.instanceOf(Error);
+                    expect(e.message).to.match(/no wallet/i);
+                    done();
+                });
+            });
+
+            it('can not be registered with the API', (done) => {
+                payment.register().catch(e => {
+                    expect(e).to.be.an.instanceOf(Error);
+                    expect(e.message).to.match(/no provider/i);
+                    done();
+                });
+            });
+
+            it('has the supplied amount', () => {
+                expect(payment.amount).to.be.equalMoney(new MonetaryAmount(amount, currency.ct, currency.id));
+            });
+
+            it('has the supplied sender', () => {
+                expect(payment.sender).to.eql(sender);
+            });
+
+            it('has the supplied recipient', () => {
+                expect(payment.recipient).to.eql(recipient);
+            });
+
+            it('does not have a valid signature', () => {
+                expect(payment.isSigned()).to.be.false;
+            });
         });
 
-        it('does not have a valid signature', () => {
-            expect(payment.isSigned()).to.be.false;
+        context('a de-serialized unsigned Payment', () => {
+            let payment;
+
+            beforeEach(() => {
+                payment = Payment.from(unsignedPayload);
+            });
+
+            it('can be serialized to a new object literal', () => {
+                expect(payment.toJSON()).to.eql(unsignedPayload);
+            });
+
+            it('can not be signed', (done) => {
+                payment.sign().catch(e => {
+                    expect(e).to.be.an.instanceOf(Error);
+                    expect(e.message).to.match(/no wallet/i);
+                    done();
+                });
+            });
+
+            it('can not be registered with the API', (done) => {
+                payment.register().catch(e => {
+                    expect(e).to.be.an.instanceOf(Error);
+                    expect(e.message).to.match(/no provider/i);
+                    done();
+                });
+            });
+
+            it('has the supplied amount', () => {
+                expect(payment.amount).to.be.equalMoney(new MonetaryAmount(amount, currency.ct, currency.id));
+            });
+
+            it('has the supplied sender', () => {
+                expect(payment.sender).to.eql(sender);
+            });
+
+            it('has the supplied recipient', () => {
+                expect(payment.recipient).to.eql(recipient);
+            });
+
+            it('does not have a valid signature', () => {
+                expect(payment.isSigned()).to.be.false;
+            });
+        });
+
+        context('a de-serialized signed Payment', () => {
+            let payment;
+
+            beforeEach(() => {
+                payment = Payment.from(signedPayload);
+            });
+
+            it('can be serialized to a new object literal', () => {
+                expect(payment.toJSON()).to.eql(signedPayload);
+            });
+
+            it('can not be registered with the API', (done) => {
+                payment.register().catch(e => {
+                    expect(e).to.be.an.instanceOf(Error);
+                    expect(e.message).to.match(/no provider/i);
+                    done();
+                });
+            });
+
+            it('has the supplied amount', () => {
+                expect(payment.amount).to.eql(new MonetaryAmount(amount, currency.ct, currency.id));
+            });
+
+            it('has the supplied sender', () => {
+                expect(payment.sender).to.eql(sender);
+            });
+
+            it('has the supplied recipient', () => {
+                expect(payment.recipient).to.eql(recipient);
+            });
+
+            it('has a valid signature', () => {
+                expect(payment.isSigned()).to.be.true;
+            });
         });
     });
 
@@ -158,138 +514,13 @@ describe('Payment', () => {
         });
     });
 
-    context('a signed Payment', () => {
-        let payment;
-
-        beforeEach(async () => {
-            wallet = new Wallet(privateKey, stubbedProvider);
-            payment = new Payment(wallet, new MonetaryAmount(amount, currency.ct, currency.id), sender, recipient);
-            await payment.sign();
-        });
-
-        it('can be serialized to an object literal', () => {
-            expect(payment.toJSON()).to.eql(signedPayload);
-        });
-
-        it('can be registered with the API', () => {
-            payment.register();
-            expect(stubbedProvider.registerPayment).to.have.been.calledWith(signedPayload);
-        });
-
-        it('has the supplied amount', () => {
-            expect(payment.amount).to.be.equalMoney(new MonetaryAmount(amount, currency.ct, currency.id));
-        });
-
-        it('has the supplied sender', () => {
-            expect(payment.sender).to.eql(sender);
-        });
-
-        it('has the supplied recipient', () => {
-            expect(payment.recipient).to.eql(recipient);
-        });
-
-        it('has a valid signature', () => {
-            expect(payment.isSigned()).to.be.true;
-        });
-    });
-
-    context('a serialized Payment', () => {
-        let serializedPayment;
-        beforeEach(() => {
-            serializedPayment = {...unsignedPayload};
-            wallet = new Wallet(privateKey, stubbedProvider);
-        });
-
-        it('can be de-serialized when passing a wallet', () => {
-            const payment = Payment.from(wallet, serializedPayment);
-            expect(payment.toJSON()).to.eql(serializedPayment);
-        });
-
-        it('can be de-serialized without passing a wallet', () => {
-            const payment = Payment.from(null, serializedPayment);
-            expect(payment.toJSON()).to.eql(serializedPayment);
-        });
-    });
-
-    context('a de-serialized unsigned Payment', () => {
-        let payment;
-
-        beforeEach(() => {
-            wallet = new Wallet(privateKey, stubbedProvider);
-            payment = Payment.from(wallet, unsignedPayload);
-        });
-
-        it('can be serialized to a new object literal', () => {
-            expect(payment.toJSON()).to.eql(unsignedPayload);
-        });
-
-        it('can be signed', async () => {
-            await payment.sign();
-            expect(payment.toJSON()).to.eql(signedPayload);
-        });
-
-        it('can be registered with the API', () => {
-            payment.register();
-            expect(stubbedProvider.registerPayment).to.have.been.calledWith(unsignedPayload);
-        });
-
-        it('has the supplied amount', () => {
-            expect(payment.amount).to.be.equalMoney(new MonetaryAmount(amount, currency.ct, currency.id));
-        });
-
-        it('has the supplied sender', () => {
-            expect(payment.sender).to.eql(sender);
-        });
-
-        it('has the supplied recipient', () => {
-            expect(payment.recipient).to.eql(recipient);
-        });
-
-        it('does not have a valid signature', () => {
-            expect(payment.isSigned()).to.be.false;
-        });
-    });
-
-    context('a de-serialized signed Payment', () => {
-        let payment;
-
-        beforeEach(() => {
-            payment = Payment.from(stubbedWallet, signedPayload);
-        });
-
-        it('can be serialized to a new object literal', () => {
-            expect(payment.toJSON()).to.eql(signedPayload);
-        });
-
-        it('can be registered with the API', () => {
-            payment.register();
-            expect(stubbedProvider.registerPayment).to.have.been.calledWith(signedPayload);
-        });
-
-        it('has the supplied amount', () => {
-            expect(payment.amount).to.eql(new MonetaryAmount(amount, currency.ct, currency.id));
-        });
-
-        it('has the supplied sender', () => {
-            expect(payment.sender).to.eql(sender);
-        });
-
-        it('has the supplied recipient', () => {
-            expect(payment.recipient).to.eql(recipient);
-        });
-
-        it('has a valid signature', () => {
-            expect(payment.isSigned()).to.be.true;
-        });
-    });
-
     context('a de-serialized signed Payment that has been tampered with (amount)', () => {
         let payment, modifiedPayload;
 
         beforeEach(() => {
             modifiedPayload = {...signedPayload};
             modifiedPayload.amount = '999999';
-            payment = Payment.from(stubbedWallet, modifiedPayload);
+            payment = Payment.from(modifiedPayload, stubbedWallet);
         });
 
         it('has the modified amount', () => {
@@ -307,7 +538,7 @@ describe('Payment', () => {
         beforeEach(() => {
             modifiedPayload = {...signedPayload};
             modifiedPayload.sender.wallet = '0x0000000000000000000000000000000000000099';
-            payment = Payment.from(stubbedWallet, modifiedPayload);
+            payment = Payment.from(modifiedPayload, stubbedWallet);
         });
 
         it('has the modified sender', () => {
@@ -325,7 +556,7 @@ describe('Payment', () => {
         beforeEach(() => {
             modifiedPayload = {...signedPayload};
             modifiedPayload.seals.wallet.signature = '0xffff9e389115e663107162f9049da8ed06670a53dd6b3bb77165940b6a55eba3156f788625446d6e553dd448608445f122803556c015559b32cf66d781e7d85b18';
-            payment = Payment.from(stubbedWallet, modifiedPayload);
+            payment = Payment.from(modifiedPayload, stubbedWallet);
         });
 
         it('does not have a valid signature', () => {

--- a/lib/receipt.js
+++ b/lib/receipt.js
@@ -8,6 +8,7 @@ const ethers = require('ethers');
 const {hashObject, fromRpcSig, hash, isSignedBy} = require('./utils');
 const Payment = require('./payment');
 const MonetaryAmount = require('./monetary-amount');
+const Wallet = require('./wallet');
 
 const _provider = new WeakMap();
 const _wallet = new WeakMap();
@@ -45,20 +46,20 @@ const PAYMENT_RECEIPT_HASH_PARTS = [
         ['sender.fees.single.amount',
             'sender.fees.single.currency.ct',
             'sender.fees.single.currency.id'],
-        ['sender.fees.total.[]', 
-            'originId', 
-            'figure.amount', 
-            'figure.currency.ct', 
+        ['sender.fees.total.[]',
+            'originId',
+            'figure.amount',
+            'figure.currency.ct',
             'figure.currency.id']
     ],
     [
         ['recipient.nonce'],
         ['recipient.balances.current',
             'recipient.balances.previous'],
-        ['recipient.fees.total.[]', 
-            'originId', 
-            'figure.amount', 
-            'figure.currency.ct', 
+        ['recipient.fees.total.[]',
+            'originId',
+            'figure.amount',
+            'figure.currency.ct',
             'figure.currency.id']
     ],
     [
@@ -70,14 +71,23 @@ const PAYMENT_RECEIPT_HASH_PARTS = [
 /**
  * @class Receipt
  * A class for modelling a _hubii nahmii_ payment receipt.
+ * To be able to sign a receipt, you must supply a valid Wallet instance.
+ * To be able to do operations that interacts with the server you need to
+ * supply a valid Wallet or NahmiiProvider instance.
  * @alias module:nahmii-sdk
  */
 class Receipt {
-    constructor(wallet, payment) {
-        if (wallet) {
-            _wallet.set(this, wallet);
-            _provider.set(this, wallet.provider);
-        }
+    /**
+     * Receipt constructor
+     * @param {Payment} payment - A payment instance
+     * @param {Wallet|NahmiiProvider} [walletOrProvider] - Optional wallet or provider instance
+     */
+    constructor(payment, walletOrProvider = null) {
+        const wallet = walletOrProvider instanceof Wallet ? walletOrProvider : null;
+        const provider = wallet ? wallet.provider : walletOrProvider;
+
+        _wallet.set(this, wallet);
+        _provider.set(this, provider);
         _payment.set(this, payment);
     }
 
@@ -89,9 +99,13 @@ class Receipt {
      * Will hash and sign the receipt with the wallet passed into the constructor
      */
     async sign() {
+        const wallet = _wallet.get(this);
+        if (!wallet)
+            throw new Error('No wallet is available for signing!');
+
         const h = hashReceipt(this.toJSON());
         const hArr = ethers.utils.arrayify(h);
-        const sigFlat = await _wallet.get(this).signMessage(hArr);
+        const sigFlat = await wallet.signMessage(hArr);
         const sigExpanded = fromRpcSig(sigFlat);
 
         _hash.set(this, h);
@@ -104,6 +118,10 @@ class Receipt {
      * @returns {Boolean}
      */
     isSigned() {
+        let provider = _provider.get(this);
+        if (!provider)
+            throw new Error('Unable to validate signature without provider or wallet');
+
         const payment = _payment.get(this);
         if (!payment)
             return false;
@@ -120,7 +138,7 @@ class Receipt {
         if (h !== serializedReceipt.seals.operator.hash)
             return false;
 
-        const operatorAddress = _provider.get(this).operatorAddress;
+        const operatorAddress = provider.operatorAddress;
 
         return isSignedBy(
             serializedReceipt.seals.operator.hash,
@@ -133,8 +151,11 @@ class Receipt {
      * Registers the receipt with the server to be effectuated
      * @returns {Promise} A promise that resolves to the registered receipt as JSON
      */
-    effectuate() {
+    async effectuate() {
         const provider = _provider.get(this);
+        if (!provider)
+            throw new Error('No provider is available for API access!');
+
         return provider.effectuatePayment(this.toJSON());
     }
 
@@ -163,10 +184,11 @@ class Receipt {
         if (senderSingleFee)
             result.sender.fees.single = senderSingleFee.toJSON();
         const senderTotalFees = _senderTotalFees.get(this);
-        if (senderTotalFees && senderTotalFees.length)
-        {result.sender.fees.total = senderTotalFees.map(f => {
-            return {originId: f.originId, figure: f.figure.toJSON()};
-        });}
+        if (senderTotalFees && senderTotalFees.length) {
+            result.sender.fees.total = senderTotalFees.map(f => {
+                return {originId: f.originId, figure: f.figure.toJSON()};
+            });
+        }
 
         result.recipient.nonce = _recipientNonce.get(this);
         result.recipient.balances = {
@@ -199,13 +221,13 @@ class Receipt {
 
     /**
      * Factory/de-serializing method
-     * @param {Wallet} wallet - An instance of a Wallet
      * @param json - A JSON object that can be de-serialized to a Receipt instance
+     * @param {Wallet|NahmiiProvider} [walletOrProvider] - Optional wallet or provider instance
      * @returns {Receipt}
      */
-    static from(wallet, json) {
-        const p = Payment.from(wallet, json);
-        const r = new Receipt(wallet, p);
+    static from(json, walletOrProvider = null) {
+        const p = Payment.from(json, walletOrProvider);
+        const r = new Receipt(p, walletOrProvider);
 
         _nonce.set(r, json.nonce);
         _blockNumber.set(r, json.blockNumber);
@@ -221,7 +243,10 @@ class Receipt {
                 _senderSingleFee.set(r, MonetaryAmount.from(json.sender.fees.single));
                 if (json.sender.fees.total) {
                     const totalFees = json.sender.fees.total.map(f => {
-                        return {originId: f.originId, figure: MonetaryAmount.from(f.figure)};
+                        return {
+                            originId: f.originId,
+                            figure: MonetaryAmount.from(f.figure)
+                        };
                     });
                     _senderTotalFees.set(r, totalFees);
                 }
@@ -236,7 +261,10 @@ class Receipt {
             }
             if (json.recipient.fees) {
                 const totalFees = json.recipient.fees.total.map(f => {
-                    return {originId: f.originId, figure: MonetaryAmount.from(f.figure)};
+                    return {
+                        originId: f.originId,
+                        figure: MonetaryAmount.from(f.figure)
+                    };
                 });
                 _recipientTotalFees.set(r, totalFees);
             }

--- a/lib/receipt.spec.js
+++ b/lib/receipt.spec.js
@@ -9,50 +9,46 @@ const expect = chai.expect;
 chai.use(sinonChai);
 chai.use(chaiAsPromised);
 
-const Receipt = require('./receipt');
-
 const {privateToAddress} = require('ethereumjs-util');
 const {hash, prefix0x} = require('./utils');
-const Payment = require('./payment');
 
 const amount = '1000';
-const currency = {ct:'0x0000000000000000000000000000000000000001', id: '0'};
+const currency = {ct: '0x0000000000000000000000000000000000000001', id: '0'};
 const recipient = '0x0000000000000000000000000000000000000003';
 const senderKey = '3a1076bf45ab87712ad64ccb3b10217737f7faacbf2872e88fdd9a537d8fe266';
 const sender = prefix0x(privateToAddress(new Buffer(senderKey, 'hex')).toString('hex'));
 const operatorKey = '252c772d9e9d570c726473927c52f23227cc674b6567935287d3f4a76a57d352';
 const operatorAddress = prefix0x(privateToAddress(new Buffer(operatorKey, 'hex')).toString('hex'));
 
-const stubbedClientFundContract = {
-    depositTokens: sinon.stub(),
-    address: 'client fund address'
-};
+const Wallet = proxyquire('./wallet', {
+    './client-fund-contract': function() {
+        return {};
+    },
+    './balance-tracker-contract': function() {
+        return {};
+    },
+    './erc20-contract': function() {
+        return {};
+    }
+});
 
-function proxyquireWallet() {
-    return proxyquire('./wallet', {
-        './client-fund-contract': function() {
-            return stubbedClientFundContract;
-        },
-        './balance-tracker-contract': function() {
-            return {};
-        }
-    });
-}
+const Payment = proxyquire('./payment', {
+    './wallet': Wallet
+});
 
-const Wallet = proxyquireWallet();
+const Receipt = proxyquire('./receipt', {
+    './wallet': Wallet,
+    './payment': Payment
+});
 
 const stubbedProvider = {
     operatorAddress,
     effectuatePayment: sinon.stub()
 };
 
-const stubbedWallet = {
-    provider: stubbedProvider
-};
-
 
 describe('Receipt', () => {
-    let signedPayload, unsignedPayload, receipt, wallet;
+    let signedPayload, unsignedPayload, receipt;
 
     const hashFeesTotal = (totalFigures) => {
         let feesTotalHash = 0;
@@ -81,7 +77,7 @@ describe('Receipt', () => {
         const senderHash = hash(
             hash(payment.sender.nonce),
             hash(
-                payment.sender.balances.current, 
+                payment.sender.balances.current,
                 payment.sender.balances.previous
             ),
             hash(
@@ -109,7 +105,7 @@ describe('Receipt', () => {
 
     const signPaymentAsWallet = async json => {
         const senderWallet = new Wallet(senderKey);
-        const payment = Payment.from(senderWallet, json);
+        const payment = Payment.from(json, senderWallet);
         await payment.sign();
         const paymentJSON = payment.toJSON();
         const walletSeal = paymentJSON.seals.wallet;
@@ -198,198 +194,600 @@ describe('Receipt', () => {
         stubbedProvider.effectuatePayment.reset();
     });
 
-    context('a new Receipt', () => {
+    context('given a wallet', () => {
+        let wallet;
+
         beforeEach(() => {
-            receipt = new Receipt(stubbedWallet);
+            wallet = new Wallet(operatorKey, stubbedProvider);
         });
 
-        it('can be serialized to a new object literal', () => {
-            expect(receipt.toJSON()).to.eql({});
+        context('a new Receipt', () => {
+            beforeEach(() => {
+                receipt = new Receipt(undefined, wallet);
+            });
+
+            it('can be serialized to a new object literal', () => {
+                expect(receipt.toJSON()).to.eql({});
+            });
+
+            it('can be registered with the API', () => {
+                receipt.effectuate();
+                expect(stubbedProvider.effectuatePayment).to.have.been.calledWith(receipt.toJSON());
+            });
+
+            it('does not have a valid signature', () => {
+                expect(receipt.isSigned()).to.be.false;
+            });
+
+            it('does not have a payment', () => {
+                expect(receipt.payment).to.be.undefined;
+            });
         });
 
-        it('can be registered with the API', () => {
-            receipt.effectuate();
-            expect(stubbedProvider.effectuatePayment).to.have.been.calledWith(receipt.toJSON());
-        });
+        context('a serialized incomplete Receipt', () => {
+            it('can not be de-serialized', () => {
+                expect(() => Receipt.from({}, wallet)).to.throw();
+            });
 
-        it('does not have a valid signature', () => {
-            expect(receipt.isSigned()).to.be.false;
-        });
-
-        it('does not have a payment', () => {
-            expect(receipt.payment).to.be.undefined;
-        });
-    });
-
-    context('a serialized incomplete Receipt', () => {
-        it('can not be de-serialized', () => {
-            expect(() => Receipt.from(stubbedWallet, {})).to.throw();
-        });
-
-        context('a de-serialized incomplete Receipt', () => {
-            [
-                payload => delete payload.sender.fees.single,
-                payload => delete payload.sender.balances.current,
-                payload => delete payload.nonce
-            ].forEach(modifier => {
-                context('when ' + modifier.toString(), () => {
-                    it('can not be signed', () => {
-                        let modifiedPayload = {...unsignedPayload};
-                        modifier(modifiedPayload);
-                        let incompleteReceipt = Receipt.from(stubbedWallet, modifiedPayload);
-                        expect(incompleteReceipt.sign()).to.be.rejected;
+            context('a de-serialized incomplete Receipt', () => {
+                [
+                    payload => delete payload.sender.fees.single,
+                    payload => delete payload.sender.balances.current,
+                    payload => delete payload.nonce
+                ].forEach(modifier => {
+                    context('when ' + modifier.toString(), () => {
+                        it('can not be signed', () => {
+                            let modifiedPayload = {...unsignedPayload};
+                            modifier(modifiedPayload);
+                            let incompleteReceipt = Receipt.from(modifiedPayload, wallet);
+                            expect(incompleteReceipt.sign()).to.be.rejected;
+                        });
                     });
                 });
             });
         });
+
+        context('a de-serialized unsigned Receipt', () => {
+            beforeEach(() => {
+                receipt = Receipt.from(unsignedPayload, wallet);
+            });
+
+            it('can be serialized to a new object literal', () => {
+                expect(receipt.toJSON()).to.eql(unsignedPayload);
+            });
+
+            it('can be registered with the API', () => {
+                receipt.effectuate();
+                expect(stubbedProvider.effectuatePayment).to.have.been.calledWith(receipt.toJSON());
+            });
+
+            it('does not have a valid signature', () => {
+                expect(receipt.isSigned()).to.be.false;
+            });
+
+            it('can be signed', async () => {
+                await receipt.sign();
+                expect(receipt.toJSON()).to.eql(signedPayload);
+                expect(receipt.isSigned()).to.eql(true);
+            });
+
+            it('has a valid payment', () => {
+                expect(receipt.payment.isSigned()).to.be.true;
+            });
+        });
+
+        context('a de-serialized signed Receipt that has no recipient fees', () => {
+            let modifiedPayload;
+
+            beforeEach(() => {
+                modifiedPayload = {...signedPayload};
+                modifiedPayload.recipient.fees = {total: []};
+                receipt = Receipt.from(modifiedPayload, wallet);
+            });
+
+            it('can be serialized to a new object literal with empty fees property', () => {
+                expect(receipt.toJSON().recipient.fees).to.eql({total: []});
+            });
+
+            it('can be registered with the API', () => {
+                receipt.effectuate();
+                expect(stubbedProvider.effectuatePayment).to.have.been.calledWith(receipt.toJSON());
+            });
+
+            it('does not have a valid signature', () => {
+                expect(receipt.isSigned()).to.be.false;
+            });
+
+            it('can be signed', async () => {
+                await receipt.sign();
+                expect(receipt.isSigned()).to.eql(true);
+            });
+
+            it('has a valid payment', () => {
+                expect(receipt.payment.isSigned()).to.be.true;
+            });
+        });
+
+        context('a de-serialized signed Receipt', () => {
+            beforeEach(() => {
+                wallet = new Wallet(operatorKey, stubbedProvider);
+                receipt = Receipt.from(signedPayload, wallet);
+            });
+
+            it('can be serialized to a new object literal', () => {
+                expect(receipt.toJSON()).to.eql(signedPayload);
+            });
+
+            it('can be registered with the API', () => {
+                receipt.effectuate();
+                expect(stubbedProvider.effectuatePayment).to.have.been.calledWith(receipt.toJSON());
+            });
+
+            it('has a valid signature', () => {
+                expect(receipt.isSigned()).to.be.true;
+            });
+
+            it('can be signed', () => {
+                receipt.sign(operatorKey);
+                expect(receipt.toJSON()).to.eql(signedPayload);
+            });
+
+            it('has a valid payment', () => {
+                expect(receipt.payment.isSigned()).to.be.true;
+            });
+        });
+
+        context('a de-serialized signed Receipt that has been tampered with (nonce)', () => {
+            let modifiedPayload;
+
+            beforeEach(() => {
+                modifiedPayload = {...signedPayload};
+                modifiedPayload.nonce = 9999;
+                receipt = Receipt.from(modifiedPayload, wallet);
+            });
+
+            it('can be registered with the API', () => {
+                receipt.effectuate();
+                expect(stubbedProvider.effectuatePayment).to.have.been.calledWith(receipt.toJSON());
+            });
+
+            it('has the modified nonce', () => {
+                expect(receipt.toJSON().nonce).to.eql(modifiedPayload.nonce);
+            });
+
+            it('does not have a valid signature', () => {
+                expect(receipt.isSigned()).to.be.false;
+            });
+
+            it('has a valid payment', () => {
+                expect(receipt.payment.isSigned()).to.be.true;
+            });
+        });
+
+        context('a de-serialized signed Receipt that has been tampered with (sender)', () => {
+            let modifiedPayload;
+
+            beforeEach(() => {
+                modifiedPayload = {...signedPayload};
+                modifiedPayload.sender.wallet = '0';
+                receipt = Receipt.from(modifiedPayload, wallet);
+            });
+
+            it('can be registered with the API', () => {
+                receipt.effectuate();
+                expect(stubbedProvider.effectuatePayment).to.have.been.calledWith(receipt.toJSON());
+            });
+
+            it('has the modified sender', () => {
+                expect(receipt.toJSON().sender.wallet).to.eql(modifiedPayload.sender.wallet);
+            });
+
+            it('does not have a valid signature', () => {
+                expect(receipt.isSigned()).to.be.false;
+            });
+
+            it('has an invalid payment', () => {
+                expect(receipt.payment.isSigned()).to.be.false;
+            });
+        });
     });
 
-    context('a serialized Receipt', () => {
-        let serializedReceipt;
-        beforeEach(() => {
-            wallet = new Wallet(operatorKey, stubbedProvider);
-            serializedReceipt = { ...unsignedPayload };
+    context('given a provider', () => {
+        context('a new Receipt', () => {
+            beforeEach(() => {
+                receipt = new Receipt(undefined, stubbedProvider);
+            });
+
+            it('can be serialized to a new object literal', () => {
+                expect(receipt.toJSON()).to.eql({});
+            });
+
+            it('can be registered with the API', () => {
+                receipt.effectuate();
+                expect(stubbedProvider.effectuatePayment).to.have.been.calledWith(receipt.toJSON());
+            });
+
+            it('does not have a valid signature', () => {
+                expect(receipt.isSigned()).to.be.false;
+            });
+
+            it('does not have a payment', () => {
+                expect(receipt.payment).to.be.undefined;
+            });
         });
 
-        it('can be de-serialized when passing a wallet', () => {
-            const receipt = Receipt.from(wallet, serializedReceipt);
-            expect(receipt.toJSON()).to.eql(serializedReceipt);
+        context('a serialized incomplete Receipt', () => {
+            it('can not be de-serialized', () => {
+                expect(() => Receipt.from({}, stubbedProvider)).to.throw();
+            });
+
+            context('a de-serialized incomplete Receipt', () => {
+                [
+                    payload => delete payload.sender.fees.single,
+                    payload => delete payload.sender.balances.current,
+                    payload => delete payload.nonce
+                ].forEach(modifier => {
+                    context('when ' + modifier.toString(), () => {
+                        it('can not be signed', () => {
+                            let modifiedPayload = {...unsignedPayload};
+                            modifier(modifiedPayload);
+                            let incompleteReceipt = Receipt.from(modifiedPayload, stubbedProvider);
+                            expect(incompleteReceipt.sign()).to.be.rejected;
+                        });
+                    });
+                });
+            });
         });
 
-        it('can be de-serialized without passing a wallet', () => {
-            const receipt = Receipt.from(null, serializedReceipt);
-            expect(receipt.toJSON()).to.eql(serializedReceipt);
+        context('a de-serialized unsigned Receipt', () => {
+            beforeEach(() => {
+                receipt = Receipt.from(unsignedPayload, stubbedProvider);
+            });
+
+            it('can be serialized to a new object literal', () => {
+                expect(receipt.toJSON()).to.eql(unsignedPayload);
+            });
+
+            it('can be registered with the API', () => {
+                receipt.effectuate();
+                expect(stubbedProvider.effectuatePayment).to.have.been.calledWith(receipt.toJSON());
+            });
+
+            it('does not have a valid signature', () => {
+                expect(receipt.isSigned()).to.be.false;
+            });
+
+            it('can not be signed', (done) => {
+                receipt.sign().catch(e => {
+                    expect(e).to.be.an.instanceOf(Error);
+                    expect(e.message).to.match(/no wallet/i);
+                    done();
+                });
+            });
+
+            it('has a valid payment', () => {
+                expect(receipt.payment.isSigned()).to.be.true;
+            });
+        });
+
+        context('a de-serialized unsigned Receipt that has no fees', () => {
+            let modifiedPayload;
+
+            beforeEach(() => {
+                modifiedPayload = {...unsignedPayload};
+                modifiedPayload.recipient.fees = {total: []};
+                receipt = Receipt.from(modifiedPayload, stubbedProvider);
+            });
+
+            it('can be serialized to a new object literal with empty fees property', () => {
+                expect(receipt.toJSON().recipient.fees).to.eql({total: []});
+            });
+
+            it('can be registered with the API', () => {
+                receipt.effectuate();
+                expect(stubbedProvider.effectuatePayment).to.have.been.calledWith(receipt.toJSON());
+            });
+
+            it('does not have a valid signature', () => {
+                expect(receipt.isSigned()).to.be.false;
+            });
+
+            it('can not be signed', (done) => {
+                receipt.sign().catch(e => {
+                    expect(e).to.be.an.instanceOf(Error);
+                    expect(e.message).to.match(/no wallet/i);
+                    done();
+                });
+            });
+
+            it('has a valid payment', () => {
+                expect(receipt.payment.isSigned()).to.be.true;
+            });
+        });
+
+        context('a de-serialized signed Receipt', () => {
+            beforeEach(() => {
+                receipt = Receipt.from(signedPayload, stubbedProvider);
+            });
+
+            it('can be serialized to a new object literal', () => {
+                expect(receipt.toJSON()).to.eql(signedPayload);
+            });
+
+            it('can be registered with the API', () => {
+                receipt.effectuate();
+                expect(stubbedProvider.effectuatePayment).to.have.been.calledWith(receipt.toJSON());
+            });
+
+            it('has a valid signature', () => {
+                expect(receipt.isSigned()).to.be.true;
+            });
+
+            it('can not be signed', (done) => {
+                receipt.sign().catch(e => {
+                    expect(e).to.be.an.instanceOf(Error);
+                    expect(e.message).to.match(/no wallet/i);
+                    done();
+                });
+            });
+
+            it('has a valid payment', () => {
+                expect(receipt.payment.isSigned()).to.be.true;
+            });
+        });
+
+        context('a de-serialized signed Receipt that has been tampered with (nonce)', () => {
+            let modifiedPayload;
+
+            beforeEach(() => {
+                modifiedPayload = {...signedPayload};
+                modifiedPayload.nonce = 9999;
+                receipt = Receipt.from(modifiedPayload, stubbedProvider);
+            });
+
+            it('can be registered with the API', () => {
+                receipt.effectuate();
+                expect(stubbedProvider.effectuatePayment).to.have.been.calledWith(receipt.toJSON());
+            });
+
+            it('has the modified nonce', () => {
+                expect(receipt.toJSON().nonce).to.eql(modifiedPayload.nonce);
+            });
+
+            it('does not have a valid signature', () => {
+                expect(receipt.isSigned()).to.be.false;
+            });
+
+            it('has a valid payment', () => {
+                expect(receipt.payment.isSigned()).to.be.true;
+            });
+        });
+
+        context('a de-serialized signed Receipt that has been tampered with (sender)', () => {
+            let modifiedPayload;
+
+            beforeEach(() => {
+                modifiedPayload = {...signedPayload};
+                modifiedPayload.sender.wallet = '0';
+                receipt = Receipt.from(modifiedPayload, stubbedProvider);
+            });
+
+            it('can be registered with the API', () => {
+                receipt.effectuate();
+                expect(stubbedProvider.effectuatePayment).to.have.been.calledWith(receipt.toJSON());
+            });
+
+            it('has the modified sender', () => {
+                expect(receipt.toJSON().sender.wallet).to.eql(modifiedPayload.sender.wallet);
+            });
+
+            it('does not have a valid signature', () => {
+                expect(receipt.isSigned()).to.be.false;
+            });
+
+            it('has an invalid payment', () => {
+                expect(receipt.payment.isSigned()).to.be.false;
+            });
         });
     });
 
-    context('a de-serialized unsigned Receipt', () => {
-        beforeEach(() => {
-            wallet = new Wallet(operatorKey, stubbedProvider);
-            receipt = Receipt.from(wallet, unsignedPayload);
+    context('given neither a wallet nor a provider', () => {
+        context('a new Receipt', () => {
+            beforeEach(() => {
+                receipt = new Receipt();
+            });
+
+            it('can be serialized to a new object literal', () => {
+                expect(receipt.toJSON()).to.eql({});
+            });
+
+            it('can not be registered with the API', (done) => {
+                receipt.effectuate().catch(e => {
+                    expect(e).to.be.an.instanceOf(Error);
+                    expect(e.message).to.match(/no provider/i);
+                    done();
+                });
+            });
+
+            it('can not validate signature', () => {
+                expect(() => receipt.isSigned()).to.throw(Error, /validate signature.*provider.*wallet/);
+            });
+
+            it('does not have a payment', () => {
+                expect(receipt.payment).to.be.undefined;
+            });
         });
 
-        it('can be serialized to a new object literal', () => {
-            expect(receipt.toJSON()).to.eql(unsignedPayload);
+        context('a serialized incomplete Receipt', () => {
+            it('can not be de-serialized', () => {
+                expect(() => Receipt.from({})).to.throw();
+            });
         });
 
-        it('can be registered with the API', () => {
-            receipt.effectuate();
-            expect(stubbedProvider.effectuatePayment).to.have.been.calledWith(receipt.toJSON());
+        context('a de-serialized unsigned Receipt', () => {
+            beforeEach(() => {
+                receipt = Receipt.from(unsignedPayload);
+            });
+
+            it('can be serialized to a new object literal', () => {
+                expect(receipt.toJSON()).to.eql(unsignedPayload);
+            });
+
+            it('can not be registered with the API', (done) => {
+                receipt.effectuate().catch(e => {
+                    expect(e).to.be.an.instanceOf(Error);
+                    expect(e.message).to.match(/no provider/i);
+                    done();
+                });
+            });
+
+            it('can not validate signature', () => {
+                expect(() => receipt.isSigned()).to.throw(Error, /validate signature.*provider.*wallet/);
+            });
+
+            it('can not be signed', (done) => {
+                receipt.sign().catch(e => {
+                    expect(e).to.be.an.instanceOf(Error);
+                    expect(e.message).to.match(/no wallet/i);
+                    done();
+                });
+            });
+
+            it('has a valid payment', () => {
+                expect(receipt.payment.isSigned()).to.be.true;
+            });
         });
 
-        it('does not have a valid signature', () => {
-            expect(receipt.isSigned()).to.be.false;
+        context('a de-serialized unsigned Receipt that has no fees', () => {
+            let modifiedPayload;
+
+            beforeEach(() => {
+                modifiedPayload = {...unsignedPayload};
+                modifiedPayload.recipient.fees = {total: []};
+                receipt = Receipt.from(modifiedPayload);
+            });
+
+            it('can be serialized to a new object literal with empty fees property', () => {
+                expect(receipt.toJSON().recipient.fees).to.eql({total: []});
+            });
+
+            it('can not be registered with the API', (done) => {
+                receipt.effectuate().catch(e => {
+                    expect(e).to.be.an.instanceOf(Error);
+                    expect(e.message).to.match(/no provider/i);
+                    done();
+                });
+            });
+
+            it('can not validate signature', () => {
+                expect(() => receipt.isSigned()).to.throw(Error, /validate signature.*provider.*wallet/);
+            });
+
+            it('can not be signed', (done) => {
+                receipt.sign().catch(e => {
+                    expect(e).to.be.an.instanceOf(Error);
+                    expect(e.message).to.match(/no wallet/i);
+                    done();
+                });
+            });
+
+            it('has a valid payment', () => {
+                expect(receipt.payment.isSigned()).to.be.true;
+            });
         });
 
-        it('can be signed', async () => {
-            await receipt.sign();
-            expect(receipt.toJSON()).to.eql(signedPayload);
-            expect(receipt.isSigned()).to.eql(true);
+        context('a de-serialized signed Receipt', () => {
+            beforeEach(() => {
+                receipt = Receipt.from(signedPayload);
+            });
+
+            it('can be serialized to a new object literal', () => {
+                expect(receipt.toJSON()).to.eql(signedPayload);
+            });
+
+            it('can not be registered with the API', (done) => {
+                receipt.effectuate().catch(e => {
+                    expect(e).to.be.an.instanceOf(Error);
+                    expect(e.message).to.match(/no provider/i);
+                    done();
+                });
+            });
+
+            it('can not validate signature', () => {
+                expect(() => receipt.isSigned()).to.throw(Error, /validate signature.*provider.*wallet/);
+            });
+
+            it('can not be signed', (done) => {
+                receipt.sign().catch(e => {
+                    expect(e).to.be.an.instanceOf(Error);
+                    expect(e.message).to.match(/no wallet/i);
+                    done();
+                });
+            });
+
+            it('has a valid payment', () => {
+                expect(receipt.payment.isSigned()).to.be.true;
+            });
         });
 
-        it('has a valid payment', () => {
-            expect(receipt.payment.isSigned()).to.be.true;
-        });
-    });
+        context('a de-serialized signed Receipt that has been tampered with (nonce)', () => {
+            let modifiedPayload;
 
-    context('a de-serialized signed Receipt', () => {
-        beforeEach(() => {
-            wallet = new Wallet(operatorKey, stubbedProvider);
-            receipt = Receipt.from(wallet, signedPayload);
-        });
+            beforeEach(() => {
+                modifiedPayload = {...signedPayload};
+                modifiedPayload.nonce = 9999;
+                receipt = Receipt.from(modifiedPayload);
+            });
 
-        it('can be serialized to a new object literal', () => {
-            expect(receipt.toJSON()).to.eql(signedPayload);
-        });
+            it('can not be registered with the API', (done) => {
+                receipt.effectuate().catch(e => {
+                    expect(e).to.be.an.instanceOf(Error);
+                    expect(e.message).to.match(/no provider/i);
+                    done();
+                });
+            });
 
-        it('can be registered with the API', () => {
-            receipt.effectuate();
-            expect(stubbedProvider.effectuatePayment).to.have.been.calledWith(receipt.toJSON());
-        });
+            it('has the modified nonce', () => {
+                expect(receipt.toJSON().nonce).to.eql(modifiedPayload.nonce);
+            });
 
-        it('has a valid signature', () => {
-            expect(receipt.isSigned()).to.be.true;
-        });
+            it('can not validate signature', () => {
+                expect(() => receipt.isSigned()).to.throw(Error, /validate signature.*provider.*wallet/);
+            });
 
-        it('can be signed', () => {
-            receipt.sign(operatorKey);
-            expect(receipt.toJSON()).to.eql(signedPayload);
-        });
-
-        it('has a valid payment', () => {
-            expect(receipt.payment.isSigned()).to.be.true;
-        });
-    });
-
-    context('a de-serialized signed Receipt that has been tampered with (nonce)', () => {
-        let modifiedPayload;
-
-        beforeEach(() => {
-            modifiedPayload = {...signedPayload};
-            modifiedPayload.nonce = 9999;
-            receipt = Receipt.from(stubbedWallet, modifiedPayload);
+            it('has a valid payment', () => {
+                expect(receipt.payment.isSigned()).to.be.true;
+            });
         });
 
-        it('can be registered with the API', () => {
-            receipt.effectuate();
-            expect(stubbedProvider.effectuatePayment).to.have.been.calledWith(receipt.toJSON());
-        });
+        context('a de-serialized signed Receipt that has been tampered with (sender)', () => {
+            let modifiedPayload;
 
-        it('has the modified nonce', () => {
-            expect(receipt.toJSON().nonce).to.eql(modifiedPayload.nonce);
-        });
+            beforeEach(() => {
+                modifiedPayload = {...signedPayload};
+                modifiedPayload.sender.wallet = '0';
+                receipt = Receipt.from(modifiedPayload);
+            });
 
-        it('does not have a valid signature', () => {
-            expect(receipt.isSigned()).to.be.false;
-        });
+            it('can not be registered with the API', (done) => {
+                receipt.effectuate().catch(e => {
+                    expect(e).to.be.an.instanceOf(Error);
+                    expect(e.message).to.match(/no provider/i);
+                    done();
+                });
+            });
 
-        it('has a valid payment', () => {
-            expect(receipt.payment.isSigned()).to.be.true;
-        });
-    });
+            it('has the modified sender', () => {
+                expect(receipt.toJSON().sender.wallet).to.eql(modifiedPayload.sender.wallet);
+            });
 
-    context('a de-serialized Receipt that has no fees', () => {
-        let modifiedPayload;
+            it('can not validate signature', () => {
+                expect(() => receipt.isSigned()).to.throw(Error, /validate signature.*provider.*wallet/);
+            });
 
-        beforeEach(() => {
-            modifiedPayload = {...signedPayload};
-            modifiedPayload.recipient.fees = {total: []};
-            receipt = Receipt.from(stubbedProvider, modifiedPayload);
-        });
-
-        it('has empty fees property', () => {
-            expect(receipt.toJSON().recipient.fees).to.eql({total: []});
-        });
-
-        it('has a valid payment', () => {
-            expect(receipt.payment.isSigned()).to.be.true;
-        });
-    });
-
-    context('a de-serialized signed Receipt that has been tampered with (sender)', () => {
-        let modifiedPayload;
-
-        beforeEach(() => {
-            modifiedPayload = {...signedPayload};
-            modifiedPayload.sender.wallet = '0';
-            receipt = Receipt.from(stubbedWallet, modifiedPayload);
-        });
-
-        it('can be registered with the API', () => {
-            receipt.effectuate();
-            expect(stubbedProvider.effectuatePayment).to.have.been.calledWith(receipt.toJSON());
-        });
-
-        it('has the modified sender', () => {
-            expect(receipt.toJSON().sender.wallet).to.eql(modifiedPayload.sender.wallet);
-        });
-
-        it('does not have a valid signature', () => {
-            expect(receipt.isSigned()).to.be.false;
-        });
-
-        it('has an invalid payment', () => {
-            expect(receipt.payment.isSigned()).to.be.false;
+            it('has an invalid payment', () => {
+                expect(receipt.payment.isSigned()).to.be.false;
+            });
         });
     });
 });

--- a/lib/settlement.js
+++ b/lib/settlement.js
@@ -50,9 +50,9 @@ class Settlement {
         let allowedChallenges = [];
         try {
             allowedChallenges = await this.checkStartChallenge(stageMonetaryAmount, latestReceipt, walletAddress);
-            if (!allowedChallenges.length) 
+            if (!allowedChallenges.length)
                 return requiredChallenges;
-            
+
         } catch (error) {} //eslint-disable-line
 
         if (allowedChallenges.length === 1) {
@@ -72,31 +72,32 @@ class Settlement {
             }
         }
 
-        if (caseInsensitiveCompare(latestReceipt.sender.wallet, walletAddress)) 
+        if (caseInsensitiveCompare(latestReceipt.sender.wallet, walletAddress))
             latestDriipBalance = ethers.utils.bigNumberify(latestReceipt.sender.balances.current);
-        
-        if (caseInsensitiveCompare(latestReceipt.recipient.wallet, walletAddress)) 
+
+        if (caseInsensitiveCompare(latestReceipt.recipient.wallet, walletAddress))
             latestDriipBalance = ethers.utils.bigNumberify(latestReceipt.recipient.balances.current);
 
         if (ethers.utils.bigNumberify(stageAmount).gt(latestDriipBalance)) {
             driipSettlementStageAmount = latestDriipBalance;
             nullSettlementStageAmount = stageAmount.sub(latestDriipBalance);
             requiredChallenges = [{
-                type: 'payment-driip', 
+                type: 'payment-driip',
                 receipt: latestReceipt,
                 stageMonetaryAmount: new MonetaryAmount(driipSettlementStageAmount, currency.ct, currency.id)
             }, {
                 type: 'null',
                 stageMonetaryAmount: new MonetaryAmount(nullSettlementStageAmount, currency.ct, currency.id)
             }];
-        } else {
+        }
+        else {
             requiredChallenges = [{
-                type: 'payment-driip', 
+                type: 'payment-driip',
                 receipt: latestReceipt,
                 stageMonetaryAmount
             }];
         }
-        
+
         return requiredChallenges;
     }
 
@@ -114,7 +115,7 @@ class Settlement {
 
         let allowedChallenges = [];
         try {
-            await driipSettlement.checkStartChallengeFromPayment(Receipt.from(provider, latestReceipt), walletAddress);
+            await driipSettlement.checkStartChallengeFromPayment(Receipt.from(latestReceipt, provider), walletAddress);
             allowedChallenges.push('payment-driip');
         } catch (error) {} //eslint-disable-line
         try {
@@ -136,18 +137,18 @@ class Settlement {
         const provider = _provider.get(this);
         const driipSettlement = _driipSettlement.get(this);
         const nullSettlement = _nullSettlement.get(this);
-        
+
         const setteableChallenges = [];
         try {
             const nonce = await driipSettlement.getCurrentProposalNonce(address, ct, id);
             const stageAmount = await driipSettlement.getCurrentProposalStageAmount(address, ct, id);
             const challengedReceipt = (await provider.getWalletReceipts(address, nonce.toNumber(), 1))[0];
-            
-            await driipSettlement.checkSettleDriipAsPayment(Receipt.from(provider, challengedReceipt), address);
+
+            await driipSettlement.checkSettleDriipAsPayment(Receipt.from(challengedReceipt, provider), address);
 
             setteableChallenges.push({
-                type: 'payment-driip', 
-                receipt: challengedReceipt, 
+                type: 'payment-driip',
+                receipt: challengedReceipt,
                 intendedStageAmount: new MonetaryAmount(stageAmount, ct, id)
             });
         } catch (error) {} //eslint-disable-line
@@ -177,7 +178,7 @@ class Settlement {
 
         const driipExpirationTime = await driipSettlement.getCurrentProposalExpirationTime(address, ct, id);
         const nullExpirationTime = await nullSettlement.getCurrentProposalExpirationTime(address, ct, id);
-        
+
         const ongoingChallenges = [];
         let currentTime = new Date().getTime();
         if (driipExpirationTime) {
@@ -216,9 +217,9 @@ class Settlement {
      */
     async getMaxChallengesTimeout(address, ct, id) {
         const ongoingChallenges = await this.getOngoingChallenges(address, ct, id);
-        if (!ongoingChallenges.length) 
+        if (!ongoingChallenges.length)
             return null;
-        
+
         return ongoingChallenges.sort((a, b) => {
             return b.expirationTime - a.expirationTime;
         })[0].expirationTime;
@@ -254,11 +255,11 @@ class Settlement {
         for (let requiredChallenge of requiredChallenges) {
             const {type, receipt, stageMonetaryAmount} = requiredChallenge;
             let tx;
-            if (type === 'null') 
+            if (type === 'null')
                 tx = await nullSettlement.startChallenge(wallet, stageMonetaryAmount, options);
-            
-            if (type === 'payment-driip') 
-                tx = await driipSettlement.startChallengeFromPayment(Receipt.from(wallet, receipt), stageMonetaryAmount, wallet, options);
+
+            if (type === 'payment-driip')
+                tx = await driipSettlement.startChallengeFromPayment(Receipt.from(receipt, wallet), stageMonetaryAmount, wallet, options);
 
             txs.push({tx, type, intendedStageAmount: stageMonetaryAmount});
         }
@@ -282,12 +283,12 @@ class Settlement {
         for (let settleableChallenge of settleableChallenges) {
             const {type, receipt, intendedStageAmount} = settleableChallenge;
             let tx;
-            if (type === 'null') 
+            if (type === 'null')
                 tx = await nullSettlement.settleNull(wallet, ct, id, options);
-            
-            if (type === 'payment-driip') 
-                tx = await driipSettlement.settleDriipAsPayment(Receipt.from(wallet, receipt), wallet, options);
-            
+
+            if (type === 'payment-driip')
+                tx = await driipSettlement.settleDriipAsPayment(Receipt.from(receipt, wallet), wallet, options);
+
             txs.push({tx, type, intendedStageAmount});
         }
 

--- a/lib/settlement.spec.js
+++ b/lib/settlement.spec.js
@@ -201,12 +201,12 @@ describe('Settlement', () => {
         ].forEach(t => {
             it(t.describe, async () => {
                 const allowedChallenges = [];
-                if (!t.notAllowNewDriipChallenge) 
+                if (!t.notAllowNewDriipChallenge)
                     allowedChallenges.push('payment-driip');
-                
-                if (!t.notAllowNewNullChallenge) 
+
+                if (!t.notAllowNewNullChallenge)
                     allowedChallenges.push('null');
-                
+
 
                 // settlement.checkStartChallenge = sinon.stub();
                 sinon.stub(settlement, 'checkStartChallenge')
@@ -215,7 +215,7 @@ describe('Settlement', () => {
 
                 const stageAmount = ethers.utils.bigNumberify(t.stageAmount);
                 const stageMonetaryAmount = new MonetaryAmount(stageAmount, currency.ct, currency.id);
-        
+
                 const requiredChallenges = await settlement.getRequiredChallengesForIntendedStageAmount(stageMonetaryAmount, t.receipt, t.walletAddress);
                 const actualRequiredChallenges = JSON.parse(JSON.stringify(requiredChallenges));
                 const expectedRequiredChallenges = JSON.parse(JSON.stringify(t.expect));
@@ -226,31 +226,31 @@ describe('Settlement', () => {
     describe('#checkStartChallenge', () => {
         [
             {
-                null: {allow: true}, 
+                null: {allow: true},
                 driip: {allow: true},
                 receipt: mockReceipt,
                 allow: ['payment-driip', 'null']
             },
             {
-                null: {allow: false}, 
+                null: {allow: false},
                 driip: {allow: true},
                 receipt: mockReceipt,
                 allow: ['payment-driip']
             },
             {
-                null: {allow: true}, 
+                null: {allow: true},
                 driip: {allow: false},
                 receipt: mockReceipt,
                 allow: ['null']
             },
             {
-                null: {allow: false}, 
+                null: {allow: false},
                 driip: {allow: false},
                 receipt: mockReceipt,
                 allow: []
             },
             {
-                null: {allow: true}, 
+                null: {allow: true},
                 driip: {allow: false},
                 receipt: mockReceipt,
                 allow: ['null']
@@ -259,18 +259,18 @@ describe('Settlement', () => {
             it(`should not allow new challenge when allowed driip challenge: ${t.driip.allow}, null challenge: ${t.null.allow}, provided receipt: ${t.receipt? true: false}`, async () => {
                 const stageMonetaryAmount = new MonetaryAmount('100', currency.ct, currency.id);
                 const checkDriip = stubbedDriipSettlement.checkStartChallengeFromPayment
-                    .withArgs(Receipt.from(stubbedProvider, t.receipt), wallet.address);
+                    .withArgs(Receipt.from(t.receipt, stubbedProvider), wallet.address);
                 const checkNull = stubbedNullSettlement.checkStartChallenge
                     .withArgs(stageMonetaryAmount, wallet.address);
 
-                if (t.driip.allow) 
+                if (t.driip.allow)
                     checkDriip.resolves(true);
-                else 
+                else
                     checkDriip.rejects(true);
-                
-                if (t.null.allow) 
+
+                if (t.null.allow)
                     checkNull.resolves(true);
-                else 
+                else
                     checkNull.rejects(true);
 
                 const allowed = await settlement.checkStartChallenge(stageMonetaryAmount, t.receipt, wallet.address);
@@ -288,14 +288,14 @@ describe('Settlement', () => {
                 .withArgs(mockReceipt.sender.wallet, currency.ct, currency.id)
                 .resolves(stageAmount);
             stubbedDriipSettlement.checkSettleDriipAsPayment
-                .withArgs(Receipt.from(stubbedProvider, mockReceipt), mockReceipt.sender.wallet)
+                .withArgs(Receipt.from(mockReceipt, stubbedProvider), mockReceipt.sender.wallet)
                 .resolves(true);
             stubbedNullSettlement.checkSettleNull
                 .rejects(new Error());
             stubbedProvider.getWalletReceipts
                 .withArgs(mockReceipt.sender.wallet, mockReceipt.nonce, 1)
                 .resolves([mockReceipt]);
-            
+
             const settleableChallenges = await settlement.getSettleableChallenges(mockReceipt.sender.wallet, currency.ct, currency.id);
             expect(settleableChallenges.length).to.equal(1);
             expect(settleableChallenges[0].type).to.equal('payment-driip');
@@ -308,7 +308,7 @@ describe('Settlement', () => {
                 .withArgs(mockReceipt.sender.wallet, mockReceipt.nonce, 1)
                 .resolves([mockReceipt]);
             stubbedDriipSettlement.checkSettleDriipAsPayment
-                .withArgs(Receipt.from(stubbedProvider, mockReceipt), mockReceipt.sender.wallet)
+                .withArgs(Receipt.from(mockReceipt, stubbedProvider), mockReceipt.sender.wallet)
                 .rejects(new Error());
             stubbedNullSettlement.getCurrentProposalStageAmount
                 .withArgs(mockReceipt.sender.wallet, currency.ct, currency.id)
@@ -316,7 +316,7 @@ describe('Settlement', () => {
             stubbedNullSettlement.checkSettleNull
                 .withArgs(mockReceipt.sender.wallet, currency.ct, currency.id)
                 .resolves(true);
-            
+
             const settleableChallenges = await settlement.getSettleableChallenges(mockReceipt.sender.wallet, currency.ct, currency.id);
             expect(settleableChallenges.length).to.equal(1);
             expect(settleableChallenges[0].type).to.equal('null');
@@ -335,7 +335,7 @@ describe('Settlement', () => {
                 .withArgs(mockReceipt.sender.wallet, currency.ct, currency.id)
                 .resolves(ethers.utils.bigNumberify(mockReceipt.nonce));
             stubbedDriipSettlement.checkSettleDriipAsPayment
-                .withArgs(Receipt.from(stubbedProvider, mockReceipt), mockReceipt.sender.wallet)
+                .withArgs(Receipt.from(mockReceipt, stubbedProvider), mockReceipt.sender.wallet)
                 .resolves(true);
             stubbedNullSettlement.getCurrentProposalStageAmount
                 .withArgs(mockReceipt.sender.wallet, currency.ct, currency.id)
@@ -343,7 +343,7 @@ describe('Settlement', () => {
             stubbedNullSettlement.checkSettleNull
                 .withArgs(mockReceipt.sender.wallet, currency.ct, currency.id)
                 .resolves(true);
-            
+
             const settleableChallenges = await settlement.getSettleableChallenges(mockReceipt.sender.wallet, currency.ct, currency.id);
             expect(JSON.parse(JSON.stringify(settleableChallenges))).to.deep.equal([
                 {
@@ -460,9 +460,9 @@ describe('Settlement', () => {
                     }
                 ]);
             stubbedDriipSettlement.startChallengeFromPayment
-                .withArgs(Receipt.from(wallet, mockReceipt), stageAmount, wallet)
+                .withArgs(Receipt.from(mockReceipt, wallet), stageAmount, wallet)
                 .resolves(expectedTx);
-            
+
             const txs = await settlement.startChallenge(stageAmount, wallet);
             expect(JSON.parse(JSON.stringify(txs))).to.deep.equal([{tx: expectedTx, type: 'payment-driip', intendedStageAmount: stageAmount.toJSON()}]);
         });
@@ -483,7 +483,7 @@ describe('Settlement', () => {
             stubbedNullSettlement.startChallenge
                 .withArgs(wallet, stageAmount)
                 .resolves(expectedTx);
-            
+
             const txs = await settlement.startChallenge(stageAmount, wallet);
             expect(JSON.parse(JSON.stringify(txs))).to.deep.equal([{tx: expectedTx, type: 'null', intendedStageAmount: stageAmount.toJSON()}]);
         });
@@ -510,9 +510,9 @@ describe('Settlement', () => {
                 .withArgs(wallet, stageAmount)
                 .resolves(expectedTx);
             stubbedDriipSettlement.startChallengeFromPayment
-                .withArgs(Receipt.from(wallet, mockReceipt), stageAmount, wallet)
+                .withArgs(Receipt.from(mockReceipt, wallet), stageAmount, wallet)
                 .resolves(expectedTx);
-            
+
             const txs = await settlement.startChallenge(stageAmount, wallet);
             expect(JSON.parse(JSON.stringify(txs))).to.deep.equal([
                 {tx: expectedTx, type: 'null', intendedStageAmount: stageAmount.toJSON()},
@@ -523,7 +523,7 @@ describe('Settlement', () => {
             const stageAmount = new MonetaryAmount(mockReceipt.amount, currency.ct, currency.id);
             settlement.getRequiredChallengesForIntendedStageAmount
                 .resolves([]);
-            
+
             const txs = await settlement.startChallenge(stageAmount, wallet);
             expect(txs).to.deep.equal([]);
         });
@@ -548,9 +548,9 @@ describe('Settlement', () => {
                     }
                 ]);
             stubbedDriipSettlement.settleDriipAsPayment
-                .withArgs(Receipt.from(wallet, mockReceipt), wallet)
+                .withArgs(Receipt.from(mockReceipt, wallet), wallet)
                 .resolves(expectedTx);
-            
+
             const txs = await settlement.settle(currency.ct, currency.id, wallet);
             expect(JSON.parse(JSON.stringify(txs))).to.deep.equal([{tx: expectedTx, type: 'payment-driip', intendedStageAmount: stageAmount.toJSON()}]);
         });
@@ -568,7 +568,7 @@ describe('Settlement', () => {
             stubbedNullSettlement.settleNull
                 .withArgs(wallet, currency.ct, currency.id)
                 .resolves(expectedTx);
-            
+
             const txs = await settlement.settle(currency.ct, currency.id, wallet);
             expect(JSON.parse(JSON.stringify(txs))).to.deep.equal([{tx: expectedTx, type: 'null', intendedStageAmount: stageAmount.toJSON()}]);
         });
@@ -590,12 +590,12 @@ describe('Settlement', () => {
                     }
                 ]);
             stubbedDriipSettlement.settleDriipAsPayment
-                .withArgs(Receipt.from(wallet, mockReceipt), wallet)
+                .withArgs(Receipt.from(mockReceipt, wallet), wallet)
                 .resolves(expectedTx);
             stubbedNullSettlement.settleNull
                 .withArgs(wallet, currency.ct, currency.id)
                 .resolves(expectedTx);
-            
+
             const txs = await settlement.settle(currency.ct, currency.id, wallet);
             expect(JSON.parse(JSON.stringify(txs))).to.deep.equal([
                 {tx: expectedTx, type: 'payment-driip', intendedStageAmount: stageAmountOne.toJSON()},
@@ -606,7 +606,7 @@ describe('Settlement', () => {
             settlement.getSettleableChallenges
                 .withArgs(wallet.address, currency.ct, currency.id)
                 .resolves([]);
-            
+
             const txs = await settlement.settle(currency.ct, currency.id, wallet);
             expect(txs).to.deep.equal([]);
         });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nahmii-sdk",
-  "version": "1.0.0-beta.24",
+  "version": "1.0.0-beta.25",
   "description": "Javascript SDK for using hubii nahmii APIs",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nahmii-sdk",
-  "version": "1.0.0-beta.25",
+  "version": "1.0.0-beta.26",
   "description": "Javascript SDK for using hubii nahmii APIs",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
BREAKING CHANGE for Receipt and Payment classes!

- Constructor and factory function (#from()) has changed signatures
- Takes either a wallet, provider or null
- Capabilities of object adjust accordingly
- Throws or rejects with explicit errors for operations outside of instance capabilities