### PR TITLE
Mainnet support

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,6 +12,7 @@
     },
     "rules": {
         "indent": ["error", 4],
+        "brace-style": ["error", "stroustrup", { "allowSingleLine": true }],
         "curly": ["error", "multi-or-nest", "consistent"],
         "strict": ["error", "global"]
     },

--- a/.nycrc
+++ b/.nycrc
@@ -20,6 +20,6 @@
   "per-file": false,
   "lines": 95,
   "statements": 95,
-  "functions": 90,
-  "branches": 89
+  "functions": 93,
+  "branches": 90
 }

--- a/Docs/nahmii-provider.md
+++ b/Docs/nahmii-provider.md
@@ -4,20 +4,23 @@
 
 * [nahmii-sdk](#module_nahmii-sdk)
     * [NahmiiProvider](#exp_module_nahmii-sdk--NahmiiProvider) ⏏
-        * [new NahmiiProvider(nahmiiBaseUrl, apiAppId, apiAppSecret)](#new_module_nahmii-sdk--NahmiiProvider_new)
-        * [.isUpdating](#module_nahmii-sdk--NahmiiProvider+isUpdating) ⇒ <code>boolean</code>
-        * [.startUpdate()](#module_nahmii-sdk--NahmiiProvider+startUpdate)
-        * [.stopUpdate()](#module_nahmii-sdk--NahmiiProvider+stopUpdate)
-        * [.getApiAccessToken()](#module_nahmii-sdk--NahmiiProvider+getApiAccessToken) ⇒ <code>Promise</code>
-        * [.getSupportedTokens()](#module_nahmii-sdk--NahmiiProvider+getSupportedTokens) ⇒ <code>Promise</code>
-        * [.getTokenInfo(symbolOrAddress, byAddress)](#module_nahmii-sdk--NahmiiProvider+getTokenInfo) ⇒ <code>Promise.&lt;Object&gt;</code>
-        * [.getNahmiiBalances(address)](#module_nahmii-sdk--NahmiiProvider+getNahmiiBalances) ⇒ <code>Promise</code>
-        * [.getPendingPayments()](#module_nahmii-sdk--NahmiiProvider+getPendingPayments) ⇒ <code>Promise</code>
-        * [.registerPayment(payment)](#module_nahmii-sdk--NahmiiProvider+registerPayment) ⇒ <code>Promise</code>
-        * [.effectuatePayment(receipt)](#module_nahmii-sdk--NahmiiProvider+effectuatePayment) ⇒ <code>Promise</code>
-        * [.getAllReceipts()](#module_nahmii-sdk--NahmiiProvider+getAllReceipts) ⇒ <code>Promise</code>
-        * [.getWalletReceipts(address, fromNonce, limit, asc)](#module_nahmii-sdk--NahmiiProvider+getWalletReceipts) ⇒ <code>Promise</code>
-        * [.getTransactionConfirmation(transactionHash, [timeout])](#module_nahmii-sdk--NahmiiProvider+getTransactionConfirmation) ⇒ <code>Promise.&lt;Object&gt;</code>
+        * [new NahmiiProvider(nahmiiBaseUrl, apiAppId, apiAppSecret, nodeUrl, network)](#new_module_nahmii-sdk--NahmiiProvider_new)
+        * _instance_
+            * [.isUpdating](#module_nahmii-sdk--NahmiiProvider+isUpdating) ⇒ <code>boolean</code>
+            * [.startUpdate()](#module_nahmii-sdk--NahmiiProvider+startUpdate)
+            * [.stopUpdate()](#module_nahmii-sdk--NahmiiProvider+stopUpdate)
+            * [.getApiAccessToken()](#module_nahmii-sdk--NahmiiProvider+getApiAccessToken) ⇒ <code>Promise</code>
+            * [.getSupportedTokens()](#module_nahmii-sdk--NahmiiProvider+getSupportedTokens) ⇒ <code>Promise</code>
+            * [.getTokenInfo(symbolOrAddress, byAddress)](#module_nahmii-sdk--NahmiiProvider+getTokenInfo) ⇒ <code>Promise.&lt;Object&gt;</code>
+            * [.getNahmiiBalances(address)](#module_nahmii-sdk--NahmiiProvider+getNahmiiBalances) ⇒ <code>Promise</code>
+            * [.getPendingPayments()](#module_nahmii-sdk--NahmiiProvider+getPendingPayments) ⇒ <code>Promise</code>
+            * [.registerPayment(payment)](#module_nahmii-sdk--NahmiiProvider+registerPayment) ⇒ <code>Promise</code>
+            * [.effectuatePayment(receipt)](#module_nahmii-sdk--NahmiiProvider+effectuatePayment) ⇒ <code>Promise</code>
+            * [.getAllReceipts()](#module_nahmii-sdk--NahmiiProvider+getAllReceipts) ⇒ <code>Promise</code>
+            * [.getWalletReceipts(address, fromNonce, limit, asc)](#module_nahmii-sdk--NahmiiProvider+getWalletReceipts) ⇒ <code>Promise</code>
+            * [.getTransactionConfirmation(transactionHash, [timeout])](#module_nahmii-sdk--NahmiiProvider+getTransactionConfirmation) ⇒ <code>Promise.&lt;Object&gt;</code>
+        * _static_
+            * [.from(nahmiiBaseUrl, apiAppId, apiAppSecret)](#module_nahmii-sdk--NahmiiProvider.from) ⇒ <code>Promise.&lt;NahmiiProvider&gt;</code>
 
 <a name="exp_module_nahmii-sdk--NahmiiProvider"></a>
 
@@ -28,8 +31,10 @@ A class providing low-level access to the _hubii nahmii_ APIs.
 **Kind**: Exported class  
 <a name="new_module_nahmii-sdk--NahmiiProvider_new"></a>
 
-#### new NahmiiProvider(nahmiiBaseUrl, apiAppId, apiAppSecret)
+#### new NahmiiProvider(nahmiiBaseUrl, apiAppId, apiAppSecret, nodeUrl, network)
 Construct a new NahmiiProvider.
+Instead of using this constructor directly it is recommended that you use
+the NahmiiProvider.from() factory function.
 
 
 | Param | Type | Description |
@@ -37,7 +42,15 @@ Construct a new NahmiiProvider.
 | nahmiiBaseUrl | <code>string</code> | The base URL (domain name) for the nahmii API |
 | apiAppId | <code>string</code> | nahmii API app-ID |
 | apiAppSecret | <code>string</code> | nahmii API app-secret |
+| nodeUrl | <code>string</code> | url to an ethereum node to connect to |
+| network | <code>string</code> \| <code>number</code> | a known ethereum network name or ID |
 
+**Example**  
+```js
+const {NahmiiProvider} = require('nahmii-sdk');
+
+const provider = await NahmiiProvider.from('https://api.nahmii.io', app_id, app_secret);
+```
 <a name="module_nahmii-sdk--NahmiiProvider+isUpdating"></a>
 
 #### nahmiiProvider.isUpdating ⇒ <code>boolean</code>
@@ -178,3 +191,17 @@ Rejects if a transaction is mined, but fails to execute, for example in an out o
 const {hash} = await wallet.depositEth('1.1', {gasLimit: 200000});
 const transactionReceipt = await getTransactionConfirmation(hash);
 ```
+<a name="module_nahmii-sdk--NahmiiProvider.from"></a>
+
+#### NahmiiProvider.from(nahmiiBaseUrl, apiAppId, apiAppSecret) ⇒ <code>Promise.&lt;NahmiiProvider&gt;</code>
+Factory method for creating a new NahmiiProvider automatically configured
+from the specified nahmii cluster.
+
+**Kind**: static method of [<code>NahmiiProvider</code>](#exp_module_nahmii-sdk--NahmiiProvider)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| nahmiiBaseUrl | <code>string</code> | The base URL (domain name) for the nahmii API |
+| apiAppId | <code>string</code> | nahmii API app-ID |
+| apiAppSecret | <code>string</code> | nahmii API app-secret |
+

--- a/lib/cluster-information.js
+++ b/lib/cluster-information.js
@@ -4,7 +4,7 @@ const request = require('superagent');
 
 class ClusterInformation {
     static async get(baseURL) {
-        return request.get(baseURL)
+        return request.get(`https://${baseURL}`)
             .then(res => res.body)
             .catch(err => {
                 throw new Error('Unable to retrieve cluster information: ' + err);

--- a/lib/cluster-information.js
+++ b/lib/cluster-information.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const request = require('superagent');
+
+class ClusterInformation {
+    static async get(baseURL) {
+        return request.get(baseURL)
+            .then(res => res.body)
+            .catch(err => {
+                throw new Error('Unable to retrieve cluster information: ' + err);
+            });
+    }
+}
+
+module.exports = ClusterInformation;

--- a/lib/cluster-information.spec.js
+++ b/lib/cluster-information.spec.js
@@ -1,0 +1,77 @@
+'use strict';
+
+const chai = require('chai');
+const sinonChai = require('sinon-chai');
+const expect = chai.expect;
+chai.use(sinonChai);
+const nock = require('nock');
+
+const ClusterInformation = require('./cluster-information');
+
+const baseUrl = 'http://hubii-api';
+const expectedNode = 'http://ethereum-node-url';
+const expectedNetwork = 'name-of-ethereum-network';
+
+describe('Cluster Information', () => {
+    describe('given a valid base URL', () => {
+        before(() => {
+            nock.disableNetConnect();
+        });
+
+        beforeEach(() => {
+            nock(baseUrl)
+                .get('/')
+                .reply(200, {
+                    ethereum: {
+                        node: expectedNode,
+                        net: expectedNetwork
+                    }
+                });
+        });
+
+        afterEach(() => {
+            nock.cleanAll();
+        });
+
+        after(() => {
+            nock.enableNetConnect();
+        });
+
+        it('resolves to information from meta service', async () => {
+            expect(await ClusterInformation.get(baseUrl)).to.eql({
+                ethereum: {
+                    node: expectedNode,
+                    net: expectedNetwork
+                }
+            });
+        });
+    });
+
+    describe('given a base URL resulting in a 404', () => {
+        before(() => {
+            nock.disableNetConnect();
+        });
+
+        beforeEach(() => {
+            nock(baseUrl)
+                .get('/')
+                .reply(404);
+        });
+
+        afterEach(() => {
+            nock.cleanAll();
+        });
+
+        after(() => {
+            nock.enableNetConnect();
+        });
+
+        it('rejects with error', (done) => {
+            ClusterInformation.get(baseUrl).catch(e => {
+                expect(e).to.be.an.instanceOf(Error);
+                expect(e.message).to.match(/unable.*cluster.*information/i);
+                done();
+            });
+        });
+    });
+});

--- a/lib/cluster-information.spec.js
+++ b/lib/cluster-information.spec.js
@@ -8,18 +8,23 @@ const nock = require('nock');
 
 const ClusterInformation = require('./cluster-information');
 
-const baseUrl = 'http://hubii-api';
+const baseUrl = 'hubii-api';
+const expectedUrl = `https://${baseUrl}`;
 const expectedNode = 'http://ethereum-node-url';
 const expectedNetwork = 'name-of-ethereum-network';
 
 describe('Cluster Information', () => {
-    describe('given a valid base URL', () => {
-        before(() => {
-            nock.disableNetConnect();
-        });
+    before(() => {
+        nock.disableNetConnect();
+    });
 
+    after(() => {
+        nock.enableNetConnect();
+    });
+
+    describe('given a valid base URL', () => {
         beforeEach(() => {
-            nock(baseUrl)
+            nock(expectedUrl)
                 .get('/')
                 .reply(200, {
                     ethereum: {
@@ -33,10 +38,6 @@ describe('Cluster Information', () => {
             nock.cleanAll();
         });
 
-        after(() => {
-            nock.enableNetConnect();
-        });
-
         it('resolves to information from meta service', async () => {
             expect(await ClusterInformation.get(baseUrl)).to.eql({
                 ethereum: {
@@ -48,22 +49,14 @@ describe('Cluster Information', () => {
     });
 
     describe('given a base URL resulting in a 404', () => {
-        before(() => {
-            nock.disableNetConnect();
-        });
-
         beforeEach(() => {
-            nock(baseUrl)
+            nock(expectedUrl)
                 .get('/')
                 .reply(404);
         });
 
         afterEach(() => {
             nock.cleanAll();
-        });
-
-        after(() => {
-            nock.enableNetConnect();
         });
 
         it('rejects with error', (done) => {

--- a/lib/driip-settlement.js
+++ b/lib/driip-settlement.js
@@ -46,7 +46,8 @@ class DriipSettlement {
         const challengeContract = _driipSettlementChallengeContract.get(this);
         try {
             return await challengeContract.proposalNonce(address, ct, id);
-        } catch (err) {
+        }
+        catch (err) {
             return null;
         }
     }
@@ -64,7 +65,8 @@ class DriipSettlement {
         const challengeContract = _driipSettlementChallengeContract.get(this);
         try {
             return await challengeContract.proposalExpirationTime(address, ct, id);
-        } catch (err) {
+        }
+        catch (err) {
             return null;
         }
     }
@@ -82,7 +84,8 @@ class DriipSettlement {
         const challengeContract = _driipSettlementChallengeContract.get(this);
         try {
             return await challengeContract.hasProposalExpired(address, ct, id);
-        } catch (err) {
+        }
+        catch (err) {
             return null;
         }
     }
@@ -100,7 +103,8 @@ class DriipSettlement {
         const challengeContract = _driipSettlementChallengeContract.get(this);
         try {
             return await challengeContract.proposalStageAmount(address, ct, id);
-        } catch (err) {
+        }
+        catch (err) {
             return null;
         }
     }
@@ -120,7 +124,8 @@ class DriipSettlement {
         try {
             const statusIndex = await challengeContract.proposalStatus(address, ct, id);
             return challengeStatuses[statusIndex];
-        } catch (err) {
+        }
+        catch (err) {
             return null;
         }
     }
@@ -137,7 +142,8 @@ class DriipSettlement {
             const driipSettlementContract = _driipSettlementContract.get(this);
             const settlement = await driipSettlementContract.settlementByNonce(nonce);
             return settlement;
-        } catch (error) {
+        }
+        catch (error) {
             return null;
         }
     }

--- a/lib/nahmii-provider.js
+++ b/lib/nahmii-provider.js
@@ -54,9 +54,9 @@ class NahmiiProvider extends ethers.providers.JsonRpcProvider {
     /**
      * Factory method for creating a new NahmiiProvider automatically configured
      * from the specified nahmii cluster.
-     * @param nahmiiBaseUrl
-     * @param apiAppId
-     * @param apiAppSecret
+     * @param {string} nahmiiBaseUrl - The base URL (domain name) for the nahmii API
+     * @param {string} apiAppId - nahmii API app-ID
+     * @param {string} apiAppSecret - nahmii API app-secret
      * @returns {Promise<NahmiiProvider>}
      */
     static async from(nahmiiBaseUrl, apiAppId, apiAppSecret) {

--- a/lib/nahmii-provider.js
+++ b/lib/nahmii-provider.js
@@ -9,6 +9,7 @@ const ethers = require('ethers');
 const {prefix0x} = require('./utils');
 const {createApiToken} = require('./identity-model');
 const NahmiiRequest = require('./nahmii-request');
+const ClusterInformation = require('./cluster-information');
 
 // Private properties
 const _baseUrl = new WeakMap();
@@ -23,17 +24,24 @@ const _nahmii = new WeakMap();
  * @class NahmiiProvider
  * A class providing low-level access to the _hubii nahmii_ APIs.
  * @alias module:nahmii-sdk
+ * @example
+ * const {NahmiiProvider} = require('nahmii-sdk');
+ *
+ * const provider = await NahmiiProvider.from('https://api.nahmii.io', app_id, app_secret);
  */
 class NahmiiProvider extends ethers.providers.JsonRpcProvider {
     /**
      * Construct a new NahmiiProvider.
+     * Instead of using this constructor directly it is recommended that you use
+     * the NahmiiProvider.from() factory function.
      * @param {string} nahmiiBaseUrl - The base URL (domain name) for the nahmii API
      * @param {string} apiAppId - nahmii API app-ID
      * @param {string} apiAppSecret - nahmii API app-secret
+     * @param {string} nodeUrl - url to an ethereum node to connect to
+     * @param {string|number} network - a known ethereum network name or ID
      */
-    constructor(nahmiiBaseUrl, apiAppId, apiAppSecret) {
-        // TODO: make node and network auto-configured from API server
-        super('http://geth-ropsten.dev.hubii.net', 'ropsten');
+    constructor(nahmiiBaseUrl, apiAppId, apiAppSecret, nodeUrl, network) {
+        super(nodeUrl, network);
 
         _baseUrl.set(this, nahmiiBaseUrl);
         _appId.set(this, apiAppId);
@@ -41,6 +49,19 @@ class NahmiiProvider extends ethers.providers.JsonRpcProvider {
         _nahmii.set(this, new NahmiiRequest(nahmiiBaseUrl, () => {
             return this.getApiAccessToken();
         }));
+    }
+
+    /**
+     * Factory method for creating a new NahmiiProvider automatically configured
+     * from the specified nahmii cluster.
+     * @param nahmiiBaseUrl
+     * @param apiAppId
+     * @param apiAppSecret
+     * @returns {Promise<NahmiiProvider>}
+     */
+    static async from(nahmiiBaseUrl, apiAppId, apiAppSecret) {
+        const {ethereum} = await ClusterInformation.get(nahmiiBaseUrl);
+        return new NahmiiProvider(nahmiiBaseUrl, apiAppId, apiAppSecret, ethereum.node, ethereum.net);
     }
 
     get operatorAddress() {

--- a/lib/nahmii-provider.spec.js
+++ b/lib/nahmii-provider.spec.js
@@ -17,11 +17,13 @@ const stubbedNahmiiRequest = {
     get: sinon.stub(),
     post: sinon.stub()
 };
+const stubbedClusterInformation = {};
 
 function proxyquireProvider() {
     return proxyquire('./nahmii-provider', {
         './identity-model': stubbedIdentityModel,
-        './nahmii-request': stubbedNahmiiRequestCtr
+        './nahmii-request': stubbedNahmiiRequestCtr,
+        './cluster-information': stubbedClusterInformation
     });
 }
 
@@ -34,29 +36,59 @@ const network = 'testnet';
 const walletAddr = '0000000000000000000000000000000000000001';
 
 describe('Nahmii Provider', () => {
+    let provider;
+
     afterEach(() => {
         stubbedIdentityModel.createApiToken.reset();
     });
 
-    context('a NahmiiProvider with valid configuration', () => {
-        let provider;
-
+    context('a new NahmiiProvider with valid configuration', () => {
         beforeEach(() => {
             stubbedNahmiiRequestCtr
                 .withArgs(baseUrl)
                 .returns(stubbedNahmiiRequest);
-            const NahmiiProvider = proxyquireProvider();
-            provider = new NahmiiProvider(baseUrl, appId, appSecret, node, network);
-
             stubbedIdentityModel.createApiToken
                 .withArgs(baseUrl, appId, appSecret)
                 .resolves(expectedJWT);
+            const NahmiiProvider = proxyquireProvider();
+            provider = new NahmiiProvider(baseUrl, appId, appSecret, node, network);
         });
 
         afterEach(() => {
             provider.stopUpdate();
         });
 
+        validateExpectedBehaviorOfProvider();
+    });
+
+    context('a NahmiiProvider from cluster information', () => {
+        beforeEach(async () => {
+            stubbedNahmiiRequestCtr
+                .withArgs(baseUrl)
+                .returns(stubbedNahmiiRequest);
+            stubbedIdentityModel.createApiToken
+                .withArgs(baseUrl, appId, appSecret)
+                .resolves(expectedJWT);
+            stubbedClusterInformation.get = sinon.stub();
+            stubbedClusterInformation.get.withArgs(baseUrl)
+                .resolves({
+                    ethereum: {
+                        node: node,
+                        net: network
+                    }
+                });
+            const NahmiiProvider = proxyquireProvider();
+            provider = await NahmiiProvider.from(baseUrl, appId, appSecret);
+        });
+
+        afterEach(() => {
+            provider.stopUpdate();
+        });
+
+        validateExpectedBehaviorOfProvider();
+    });
+
+    function validateExpectedBehaviorOfProvider() {
         it('can retrieve the API access token', async () => {
             expect(await provider.getApiAccessToken()).to.eql(expectedJWT);
         });
@@ -218,7 +250,11 @@ describe('Nahmii Provider', () => {
             const limit = 1;
             const asc = true;
             stubbedNahmiiRequest.get
-                .withArgs(`/trading/wallets/${walletAddr}/receipts`, {fromNonce, limit, direction: 'asc'})
+                .withArgs(`/trading/wallets/${walletAddr}/receipts`, {
+                    fromNonce,
+                    limit,
+                    direction: 'asc'
+                })
                 .resolves(expectedReceipts);
             const result = await provider.getWalletReceipts(walletAddr, fromNonce, limit, asc);
             expect(result).to.equal(expectedReceipts);
@@ -234,7 +270,8 @@ describe('Nahmii Provider', () => {
 
         [
             [402, 'Insufficient funds!'],
-            [403, 'Not authorized!']
+            [403, 'Not authorized!'],
+            [500, 'Error']
         ].forEach(([statusCode, expectedMessage]) => {
             it('sends back error messages with sensible messages when API fails to register payment', (done) => {
                 const expectedPayment = {};
@@ -260,9 +297,10 @@ describe('Nahmii Provider', () => {
             return provider.effectuatePayment(expectedReceipt);
         });
 
-        it('can watch a tx hash and resolve when it\'s mined and executed sucesfully', async () => {
+        it('can watch a tx hash and resolve when it\'s mined and executed successfully', async () => {
             const txReceipt = {hash: 'magic tx hash', status: 1};
             const txHash = '0x1bb332f5b3c2c6b56e43284145c1cb7454606d89bd9b82bd8821e3edfe8d35ad';
+            // TODO: Fix this. Dont stub the code under test!
             sinon.stub(provider, 'getTransactionReceipt')
                 .withArgs(txHash)
                 .resolves(txReceipt);
@@ -273,6 +311,8 @@ describe('Nahmii Provider', () => {
         it('can watch a tx hash and reject when it\'s mined but failed to execute', (done) => {
             const txReceipt = {hash: 'magic tx hash 2', status: 0};
             const txHash = '0x1bb332f5b3c2c6b56e43284145c1cb7454606d89bd9b82bd8821e3edfe8d35ad';
+
+            // TODO: Fix this. Dont stub the code under test!
             sinon.stub(provider, 'getTransactionReceipt')
                 .withArgs(txHash)
                 .resolves(txReceipt);
@@ -287,7 +327,8 @@ describe('Nahmii Provider', () => {
 
         [
             [403, 'Not authorized!'],
-            [404, 'Payment not found']
+            [404, 'Payment not found'],
+            [500, 'Error']
         ].forEach(([statusCode, expectedMessage]) => {
             it('sends back error messages with sensible messages when API fails to effectuate payment', (done) => {
                 const expectedReceipt = {};
@@ -304,5 +345,5 @@ describe('Nahmii Provider', () => {
                     });
             });
         });
-    });
+    }
 });

--- a/lib/null-settlement.js
+++ b/lib/null-settlement.js
@@ -44,7 +44,8 @@ class NullSettlement {
         const challengeContract = _nullSettlementChallengeContract.get(this);
         try {
             return await challengeContract.isLockedWallet(address);
-        } catch (err) {
+        }
+        catch (err) {
             return null;
         }
     }
@@ -62,7 +63,8 @@ class NullSettlement {
         const challengeContract = _nullSettlementChallengeContract.get(this);
         try {
             return await challengeContract.hasProposalExpired(address, ct, id);
-        } catch (err) {
+        }
+        catch (err) {
             return null;
         }
     }
@@ -80,7 +82,8 @@ class NullSettlement {
         const challengeContract = _nullSettlementChallengeContract.get(this);
         try {
             return await challengeContract.proposalNonce(address, ct, id);
-        } catch (err) {
+        }
+        catch (err) {
             return null;
         }
     }
@@ -98,7 +101,8 @@ class NullSettlement {
         const challengeContract = _nullSettlementChallengeContract.get(this);
         try {
             return await challengeContract.proposalExpirationTime(address, ct, id);
-        } catch (err) {
+        }
+        catch (err) {
             return null;
         }
     }
@@ -116,7 +120,8 @@ class NullSettlement {
         const challengeContract = _nullSettlementChallengeContract.get(this);
         try {
             return await challengeContract.proposalStageAmount(address, ct, id);
-        } catch (err) {
+        }
+        catch (err) {
             return null;
         }
     }
@@ -136,7 +141,8 @@ class NullSettlement {
         try {
             const statusIndex = await challengeContract.proposalStatus(address, ct, id);
             return challengeStatuses[statusIndex];
-        } catch (err) {
+        }
+        catch (err) {
             return null;
         }
     }
@@ -155,7 +161,8 @@ class NullSettlement {
             const nullSettlementContract = _nullSettlementContract.get(this);
             const maxNullNonce = await nullSettlementContract.walletCurrencyMaxNullNonce(address, ct, id);
             return maxNullNonce;
-        } catch (error) {
+        }
+        catch (error) {
             return null;
         }
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -47,7 +47,8 @@ function hashObject(obj, propertyNameGlobs, prevHashValue) {
         let value;
         if (Array.isArray(path)) {
             value = hashObject(obj, path);
-        } else {
+        }
+        else {
             value = getNestedProperty(obj, path);
             if (value === undefined)
                 throw new Error(`Cannot hash object: Expected property "${path}" does not exist on object.`);
@@ -104,7 +105,8 @@ function expandPropertyNameGlobs(object, globPatterns) {
         let indexOfGlob = pattern.indexOf('*');
         if (indexOfGlob === -1) {
             result.push(pattern);
-        } else {
+        }
+        else {
             const {arrayProp, arrayPropName} = getArrayProperty(object, pattern, indexOfGlob);
 
             arrayProp.forEach((v, i) => {
@@ -242,7 +244,8 @@ function isSignedBy(message, signature, address) {
     try {
         const ethMessage = ethHash(message);
         return caseInsensitiveCompare(recoverAddress(ethMessage, signature), prefix0x(address));
-    } catch (e) {
+    }
+    catch (e) {
         return false;
     }
 }

--- a/lib/utils.spec.js
+++ b/lib/utils.spec.js
@@ -208,7 +208,8 @@ describe('#hashObject()', () => {
             let error;
             try {
                 utils.hashObject(obj, hashProperties);
-            } catch (err) {
+            }
+            catch (err) {
                 error = err;
             }
             expect(error).to.exist;

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -142,7 +142,8 @@ class Wallet extends ethers.Signer {
         const clientFund = _clientFund.get(this);
         try {
             return await tokenContract.approve(clientFund.address, amountBN, options);
-        } catch (e) {
+        }
+        catch (e) {
             throw new Error(`Failed to approve token deposit: ${e}`);
         }
     }
@@ -169,7 +170,8 @@ class Wallet extends ethers.Signer {
         
         try {
             return await clientFund.receiveTokens('', amountBN, tokenContract.address, 0, 'ERC20', options);
-        } catch(e) {
+        }
+        catch(e) {
             throw new Error(`Failed to complete token deposit: ${e}`);
         }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nahmii-sdk",
-  "version": "1.0.0-beta.27",
+  "version": "1.0.0-beta.28",
   "description": "Javascript SDK for using hubii nahmii APIs",
   "main": "index.js",
   "scripts": {
@@ -13,9 +13,9 @@
     "build:docs:monetary-amount": "jsdoc2md lib/monetary-amount.js > Docs/monetary-amount.md",
     "build:docs:utils": "jsdoc2md lib/utils.js > Docs/utils.md",
     "test": "nyc mocha lib/**/*.spec.js --exit",
-    "test:watch": "nyc mocha lib/**/*.spec.js --exit --watch",
+    "test:watch": "npm run test -- --watch",
     "lint": "eslint --ignore-path .gitignore .",
-    "lint:fix": "eslint --ignore-path .gitignore --fix ."
+    "lint:fix": "npm run lint -- --fix"
   },
   "pre-commit": [
     "lint",


### PR DESCRIPTION
BREAKING CHANGE to NahmiiProvider.

- Constructor changes signature: new parameters
- Use the async "from()" factory to create it automatically from cluster.
- Remove hardcoding of ropsten URL in provider.

Prepares the SDK so its possible to use on multiple networks/clusters without maintaining multiple versions of the SDK. #33