### PR TITLE
Improve out-of-the-box compatibility with webpack projects

### DIFF
--- a/lib/driip-settlement-challenge-contract.js
+++ b/lib/driip-settlement-challenge-contract.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const ethers = require('ethers');
-const driipSettlementChallengeDeployment = require('./abis/DriipSettlementChallenge');
+const driipSettlementChallengeDeployment = require('./abis/DriipSettlementChallenge.json');
 
 class DriipSettlementChallengeContract extends ethers.Contract {
     constructor(walletOrProvider) {

--- a/lib/driip-settlement-contract.js
+++ b/lib/driip-settlement-contract.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const ethers = require('ethers');
-const driipSettlementDeployment = require('./abis/DriipSettlement');
+const driipSettlementDeployment = require('./abis/DriipSettlement.json');
 
 class DriipSettlementContract extends ethers.Contract {
     constructor(walletOrProvider) {

--- a/lib/null-settlement-challenge-contract.js
+++ b/lib/null-settlement-challenge-contract.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const ethers = require('ethers');
-const nullSettlementChallengeDeployment = require('./abis/NullSettlementChallenge');
+const nullSettlementChallengeDeployment = require('./abis/NullSettlementChallenge.json');
 
 class NullSettlementChallengeContract extends ethers.Contract {
     constructor(walletOrProvider) {

--- a/lib/null-settlement-contract.js
+++ b/lib/null-settlement-contract.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const ethers = require('ethers');
-const nullSettlementDeployment = require('./abis/NullSettlement');
+const nullSettlementDeployment = require('./abis/NullSettlement.json');
 
 class NullSettlementContract extends ethers.Contract {
     constructor(walletOrProvider) {

--- a/lib/wallet/balance-tracker-contract.js
+++ b/lib/wallet/balance-tracker-contract.js
@@ -6,7 +6,7 @@ class BalanceTrackerContract extends ethers.Contract {
     constructor(walletOrProvider) {
         const provider = walletOrProvider.provider || walletOrProvider;
         const networkName = provider.network.name;
-        const balanceTrackerDeployment = require(`./abis/${networkName}/BalanceTracker`);
+        const balanceTrackerDeployment = require(`./abis/${networkName}/BalanceTracker.json`);
         const chainId = provider.network.chainId;
         const balanceTrackerAddress = balanceTrackerDeployment.networks[chainId].address;
 

--- a/lib/wallet/client-fund-contract.js
+++ b/lib/wallet/client-fund-contract.js
@@ -6,7 +6,7 @@ class ClientFundContract extends ethers.Contract {
     constructor(walletOrProvider) {
         const provider = walletOrProvider.provider || walletOrProvider;
         const networkName = provider.network.name;
-        const clientFundDeployment = require(`./abis/${networkName}/ClientFund`);
+        const clientFundDeployment = require(`./abis/${networkName}/ClientFund.json`);
         const chainId = provider.network.chainId;
         const clientFundAddress = clientFundDeployment.networks[chainId].address;
 

--- a/lib/wallet/erc20-contract.js
+++ b/lib/wallet/erc20-contract.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const ethers = require('ethers');
-const erc20Abi = require('./abis/erc20');
+const erc20Abi = require('./abis/erc20.json');
 
 class Erc20Contract extends ethers.Contract {
     constructor(contractAddress, walletOrProvider) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nahmii-sdk",
-  "version": "1.0.0-beta.30",
+  "version": "1.0.0-beta.31",
   "description": "Javascript SDK for using hubii nahmii APIs",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The popular code bundler [webpack](https://github.com/webpack/webpack) works a little differently to nodejs when parsing `require` statements. It expects that apart from when importing .js files, the file extension should be explicitly defined.

Explicitly defining .json in our ABI imports would improve the out-of-the-box compatibility with many web projects.