### PR TITLE
unlock ethers dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nahmii-sdk",
-  "version": "1.0.0-beta.41",
+  "version": "1.0.0-beta.42",
   "description": "Javascript SDK for using hubii nahmii APIs",
   "main": "index.js",
   "scripts": {
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "ethereumjs-util": "^5.2.0",
-    "ethers": "4.0.18",
+    "ethers": "~4.0.0",
     "keythereum": "^1.0.4",
     "lodash.get": "^4.4.2",
     "nahmii-ethereum-address": "^2.0.0",


### PR DESCRIPTION
Loosen up the version requirement for ethers so "instanceof" checks have a higher likelyhood of working as expected.