### PR TITLE
Enhancements to receipts and event provider

### DIFF
--- a/Docs/nahmii-event-provider.md
+++ b/Docs/nahmii-event-provider.md
@@ -7,6 +7,7 @@
         * [new NahmiiEventProvider(nahmiiDomainOrProvider)](#new_module_nahmii-sdk--NahmiiEventProvider_new)
         * _instance_
             * [.onNewReceipt(listener)](#module_nahmii-sdk--NahmiiEventProvider+onNewReceipt) ⇒ <code>NahmiiEventProvider</code>
+            * [.dispose()](#module_nahmii-sdk--NahmiiEventProvider+dispose)
         * _static_
             * [.from(nahmiiDomainOrProvider)](#module_nahmii-sdk--NahmiiEventProvider.from) ⇒ <code>Promise.&lt;NahmiiEventProvider&gt;</code>
 
@@ -46,7 +47,7 @@ nahmiiEvents.onNewReceipt(receipt => {
 const {NahmiiProvider, NahmiiEventProvider}= require('nahmii-sdk');
 
 const provider = await NahmiiProvider.from('api.nahmii.io', my_app_id, my_app_secret);
-const nahmiiEvents = NahmiiEventProvider.from(provider);
+const nahmiiEvents = await NahmiiEventProvider.from(provider);
 
 nahmiiEvents.onNewReceipt(receipt => {
     if (!receipt.isSigned())
@@ -71,6 +72,14 @@ chained.
 | --- |
 | listener | 
 
+<a name="module_nahmii-sdk--NahmiiEventProvider+dispose"></a>
+
+#### nahmiiEventProvider.dispose()
+Call this to stop listening for events from the nahmii cluster. The
+instance of the NahmiiEventProvider can not be used after it has been
+disposed.
+
+**Kind**: instance method of [<code>NahmiiEventProvider</code>](#exp_module_nahmii-sdk--NahmiiEventProvider)  
 <a name="module_nahmii-sdk--NahmiiEventProvider.from"></a>
 
 #### NahmiiEventProvider.from(nahmiiDomainOrProvider) ⇒ <code>Promise.&lt;NahmiiEventProvider&gt;</code>

--- a/Docs/receipt.md
+++ b/Docs/receipt.md
@@ -6,6 +6,12 @@
     * [Receipt](#exp_module_nahmii-sdk--Receipt) ⏏
         * [new Receipt(payment, [walletOrProvider])](#new_module_nahmii-sdk--Receipt_new)
         * _instance_
+            * [.payment](#module_nahmii-sdk--Receipt+payment) ⇒ <code>Payment</code>
+            * [.blockNumber](#module_nahmii-sdk--Receipt+blockNumber) ⇒ <code>any</code>
+            * ~~[.nonce](#module_nahmii-sdk--Receipt+nonce) ⇒ <code>any</code>~~
+            * [.sender](#module_nahmii-sdk--Receipt+sender) ⇒ <code>Address</code>
+            * [.recipient](#module_nahmii-sdk--Receipt+recipient) ⇒ <code>Address</code>
+            * [.operatorId](#module_nahmii-sdk--Receipt+operatorId) ⇒ <code>Number</code>
             * [.sign()](#module_nahmii-sdk--Receipt+sign)
             * [.isSigned()](#module_nahmii-sdk--Receipt+isSigned) ⇒ <code>Boolean</code>
             * [.effectuate()](#module_nahmii-sdk--Receipt+effectuate) ⇒ <code>Promise</code>
@@ -34,6 +40,44 @@ Receipt constructor
 | payment | <code>Payment</code> |  | A payment instance |
 | [walletOrProvider] | <code>Wallet</code> \| <code>NahmiiProvider</code> | <code></code> | Optional wallet or provider instance |
 
+<a name="module_nahmii-sdk--Receipt+payment"></a>
+
+#### receipt.payment ⇒ <code>Payment</code>
+Retrieve the payment this Receipt is based on.
+
+**Kind**: instance property of [<code>Receipt</code>](#exp_module_nahmii-sdk--Receipt)  
+<a name="module_nahmii-sdk--Receipt+blockNumber"></a>
+
+#### receipt.blockNumber ⇒ <code>any</code>
+Reference to the on-chain state the payments was effectuated after.
+
+**Kind**: instance property of [<code>Receipt</code>](#exp_module_nahmii-sdk--Receipt)  
+<a name="module_nahmii-sdk--Receipt+nonce"></a>
+
+#### ~~receipt.nonce ⇒ <code>any</code>~~
+***Deprecated***
+
+Global nonce - dont use this for anything, will be removed!
+
+**Kind**: instance property of [<code>Receipt</code>](#exp_module_nahmii-sdk--Receipt)  
+<a name="module_nahmii-sdk--Receipt+sender"></a>
+
+#### receipt.sender ⇒ <code>Address</code>
+The address of the sender
+
+**Kind**: instance property of [<code>Receipt</code>](#exp_module_nahmii-sdk--Receipt)  
+<a name="module_nahmii-sdk--Receipt+recipient"></a>
+
+#### receipt.recipient ⇒ <code>Address</code>
+The address of the recipient
+
+**Kind**: instance property of [<code>Receipt</code>](#exp_module_nahmii-sdk--Receipt)  
+<a name="module_nahmii-sdk--Receipt+operatorId"></a>
+
+#### receipt.operatorId ⇒ <code>Number</code>
+The ID of the operator that effectuated this payment.
+
+**Kind**: instance property of [<code>Receipt</code>](#exp_module_nahmii-sdk--Receipt)  
 <a name="module_nahmii-sdk--Receipt+sign"></a>
 
 #### receipt.sign()

--- a/lib/event-provider/index.js
+++ b/lib/event-provider/index.js
@@ -133,7 +133,7 @@ function subscribeToEvents() {
     });
 
     socket.on('new_receipt', receiptJSON => {
-        const receipt = Receipt.from(receiptJSON);
+        const receipt = Receipt.from(receiptJSON, _provider.get(this));
         _eventEmitter.get(this).emit(EventNames.newReceipt, receipt);
     });
 }

--- a/lib/event-provider/index.js
+++ b/lib/event-provider/index.js
@@ -38,7 +38,7 @@ const EventNames = Object.freeze({
  * const {NahmiiProvider, NahmiiEventProvider}= require('nahmii-sdk');
  *
  * const provider = await NahmiiProvider.from('api.nahmii.io', my_app_id, my_app_secret);
- * const nahmiiEvents = NahmiiEventProvider.from(provider);
+ * const nahmiiEvents = await NahmiiEventProvider.from(provider);
  *
  * nahmiiEvents.onNewReceipt(receipt => {
  *     if (!receipt.isSigned())
@@ -107,6 +107,11 @@ class NahmiiEventProvider {
         return this;
     }
 
+    /**
+     * Call this to stop listening for events from the nahmii cluster. The
+     * instance of the NahmiiEventProvider can not be used after it has been
+     * disposed.
+     */
     dispose() {
         const emitter = _eventEmitter.get(this);
         const socket = _socket.get(this);

--- a/lib/event-provider/index.js
+++ b/lib/event-provider/index.js
@@ -106,6 +106,20 @@ class NahmiiEventProvider {
         });
         return this;
     }
+
+    dispose() {
+        const emitter = _eventEmitter.get(this);
+        const socket = _socket.get(this);
+
+        _eventEmitter.set(this, null);
+        _socket.set(this, null);
+        _provider.set(this, null);
+
+        socket.disconnect();
+        socket.removeAllListeners('new_receipt');
+
+        emitter.removeAllListeners(EventNames.newReceipt);
+    }
 }
 
 /**

--- a/lib/event-provider/index.spec.js
+++ b/lib/event-provider/index.spec.js
@@ -34,7 +34,16 @@ function proxyquireProvider() {
 }
 
 describe('Nahmii Event Provider', () => {
-    let provider, fakeSocket;
+    let provider, fakeSocket, receiptJSON;
+
+    beforeEach(() => {
+        receiptJSON = {
+            amount: '0',
+            currency: {ct: '0x0000000000000000000000000000000000000000', id: 0},
+            sender: {wallet: ''},
+            recipient: {wallet: ''}
+        };
+    });
 
     afterEach(() => {
         stubbedSocketIOClient.connect.reset();
@@ -92,6 +101,15 @@ describe('Nahmii Event Provider', () => {
         });
 
         validateExpectedBehavior();
+
+        it('emits a "new receipt" event for a receipt that can be validated', (done) => {
+            provider.onNewReceipt(r => {
+                expect(r).to.be.instanceOf(Receipt);
+                expect(() => r.isSigned()).to.not.throw();
+                done();
+            });
+            fakeSocket.emit('new_receipt', receiptJSON);
+        });
     });
 
     context('a NahmiiEventProvider from invalid data', () => {
@@ -104,12 +122,6 @@ describe('Nahmii Event Provider', () => {
     });
 
     function validateExpectedBehavior() {
-        const receiptJSON = {
-            amount: '0',
-            currency: {ct: '0x0000000000000000000000000000000000000000', id: 0},
-            sender: {wallet: ''},
-            recipient: {wallet: ''}
-        };
 
         it('connects to the event API', () => {
             expect(stubbedSocketIOClient.connect).to.have.been.calledWith(

--- a/lib/event-provider/index.spec.js
+++ b/lib/event-provider/index.spec.js
@@ -121,8 +121,34 @@ describe('Nahmii Event Provider', () => {
         });
     });
 
-    function validateExpectedBehavior() {
+    context('a disposed NahmiiEventProvider', () => {
+        const onNewReceipt = sinon.stub();
 
+        beforeEach(async () => {
+            fakeSocket = new EventEmitter();
+            fakeSocket.disconnect = sinon.stub();
+            stubbedSocketIOClient.connect.returns(fakeSocket);
+            const NahmiiEventProvider = proxyquireProvider();
+            provider = await NahmiiEventProvider.from(new FakeNahmiiProvider());
+            provider.onNewReceipt(onNewReceipt);
+            provider.dispose();
+        });
+
+        afterEach(() => {
+            onNewReceipt.reset();
+        });
+
+        it('disconnects from server', () => {
+            expect(fakeSocket.disconnect).to.have.been.calledOnce;
+        });
+
+        it('does not emit a "new receipt" event when server issues a new receipt', () => {
+            fakeSocket.emit('new_receipt', receiptJSON);
+            expect(onNewReceipt).to.not.have.been.called;
+        });
+    });
+
+    function validateExpectedBehavior() {
         it('connects to the event API', () => {
             expect(stubbedSocketIOClient.connect).to.have.been.calledWith(
                 `https://${nahmiiDomain}/receipts`, {path: '/events/socket.io'}

--- a/lib/payment.js
+++ b/lib/payment.js
@@ -64,6 +64,8 @@ class Payment {
         _wallet.set(this, wallet);
         _provider.set(this, provider);
         _amount.set(this, amount);
+
+        // TODO: ensure sender/recipient addresses are of EthereumAddress type.
         _sender.set(this, sender);
         _recipient.set(this, recipient);
     }

--- a/lib/receipt.js
+++ b/lib/receipt.js
@@ -95,6 +95,34 @@ class Receipt {
         return _payment.get(this);
     }
 
+    get blockNumber() {
+        return _blockNumber.get(this);
+    }
+
+    get nonce() {
+        return _nonce.get(this);
+    }
+
+    get sender() {
+        return this.payment.sender;
+    }
+
+    get senderNonce() {
+        return _senderNonce.get(this);
+    }
+
+    get recipient() {
+        return this.payment.recipient;
+    }
+
+    get recipientNonce() {
+        return _recipientNonce.get(this);
+    }
+
+    get operatorId() {
+        return _operatorId.get(this);
+    }
+
     /**
      * Will hash and sign the receipt with the wallet passed into the constructor
      */

--- a/lib/receipt.js
+++ b/lib/receipt.js
@@ -91,18 +91,35 @@ class Receipt {
         _payment.set(this, payment);
     }
 
+    /**
+     * Retrieve the payment this Receipt is based on.
+     * @returns {Payment}
+     */
     get payment() {
         return _payment.get(this);
     }
 
+    /**
+     * Reference to the on-chain state the payments was effectuated after.
+     * @returns {any}
+     */
     get blockNumber() {
         return _blockNumber.get(this);
     }
 
+    /**
+     * Global nonce - dont use this for anything, will be removed!
+     * @deprecated
+     * @returns {any}
+     */
     get nonce() {
         return _nonce.get(this);
     }
 
+    /**
+     * The address of the sender
+     * @returns {Address}
+     */
     get sender() {
         return this.payment.sender;
     }
@@ -111,6 +128,10 @@ class Receipt {
         return _senderNonce.get(this);
     }
 
+    /**
+     * The address of the recipient
+     * @returns {Address}
+     */
     get recipient() {
         return this.payment.recipient;
     }
@@ -119,6 +140,10 @@ class Receipt {
         return _recipientNonce.get(this);
     }
 
+    /**
+     * The ID of the operator that effectuated this payment.
+     * @returns {Number}
+     */
     get operatorId() {
         return _operatorId.get(this);
     }

--- a/lib/receipt.spec.js
+++ b/lib/receipt.spec.js
@@ -50,7 +50,7 @@ const stubbedProvider = {
 describe('Receipt', () => {
     let signedPayload, unsignedPayload, receipt;
 
-    const hashFeesTotal = (totalFigures) => {
+    function hashFeesTotal(totalFigures) {
         let feesTotalHash = 0;
         for (let i = 0; i < totalFigures.length; i++) {
             feesTotalHash = hash(
@@ -62,9 +62,9 @@ describe('Receipt', () => {
             );
         }
         return feesTotalHash;
-    };
+    }
 
-    const hashPaymentAsOperator = payment => {
+    function hashPaymentAsOperator(payment) {
         const walletSignatureHash = hash(
             {type: 'uint8', value: payment.seals.wallet.signature.v},
             payment.seals.wallet.signature.r,
@@ -101,17 +101,15 @@ describe('Receipt', () => {
             payment.transfers.total
         );
         return hash(walletSignatureHash, nonceHash, senderHash, recipientHash, transfersHash);
-    };
+    }
 
-    const signPaymentAsWallet = async json => {
+    async function signPaymentAsWallet(json) {
         const senderWallet = new Wallet(senderKey);
         const payment = Payment.from(json, senderWallet);
         await payment.sign();
         const paymentJSON = payment.toJSON();
-        const walletSeal = paymentJSON.seals.wallet;
-
-        json.seals.wallet = walletSeal;
-    };
+        json.seals.wallet = paymentJSON.seals.wallet;
+    }
 
     beforeEach(async () => {
         unsignedPayload = {
@@ -228,20 +226,20 @@ describe('Receipt', () => {
             it('can not be de-serialized', () => {
                 expect(() => Receipt.from({}, wallet)).to.throw();
             });
+        });
 
-            context('a de-serialized incomplete Receipt', () => {
-                [
-                    payload => delete payload.sender.fees.single,
-                    payload => delete payload.sender.balances.current,
-                    payload => delete payload.nonce
-                ].forEach(modifier => {
-                    context('when ' + modifier.toString(), () => {
-                        it('can not be signed', () => {
-                            let modifiedPayload = {...unsignedPayload};
-                            modifier(modifiedPayload);
-                            let incompleteReceipt = Receipt.from(modifiedPayload, wallet);
-                            expect(incompleteReceipt.sign()).to.be.rejected;
-                        });
+        context('a de-serialized incomplete Receipt', () => {
+            [
+                payload => delete payload.sender.fees.single,
+                payload => delete payload.sender.balances.current,
+                payload => delete payload.nonce
+            ].forEach(modifier => {
+                context('when ' + modifier.toString(), () => {
+                    it('can not be signed', () => {
+                        let modifiedPayload = {...unsignedPayload};
+                        modifier(modifiedPayload);
+                        let incompleteReceipt = Receipt.from(modifiedPayload, wallet);
+                        expect(incompleteReceipt.sign()).to.be.rejected;
                     });
                 });
             });
@@ -271,9 +269,7 @@ describe('Receipt', () => {
                 expect(receipt.isSigned()).to.eql(true);
             });
 
-            it('has a valid payment', () => {
-                expect(receipt.payment.isSigned()).to.be.true;
-            });
+            validateAllReceiptProperties({expectedNonce: 1});
         });
 
         context('a de-serialized signed Receipt that has no recipient fees', () => {
@@ -303,9 +299,7 @@ describe('Receipt', () => {
                 expect(receipt.isSigned()).to.eql(true);
             });
 
-            it('has a valid payment', () => {
-                expect(receipt.payment.isSigned()).to.be.true;
-            });
+            validateAllReceiptProperties({expectedNonce: 1});
         });
 
         context('a de-serialized signed Receipt', () => {
@@ -332,9 +326,7 @@ describe('Receipt', () => {
                 expect(receipt.toJSON()).to.eql(signedPayload);
             });
 
-            it('has a valid payment', () => {
-                expect(receipt.payment.isSigned()).to.be.true;
-            });
+            validateAllReceiptProperties({expectedNonce: 1});
         });
 
         context('a de-serialized signed Receipt that has been tampered with (nonce)', () => {
@@ -359,9 +351,7 @@ describe('Receipt', () => {
                 expect(receipt.isSigned()).to.be.false;
             });
 
-            it('has a valid payment', () => {
-                expect(receipt.payment.isSigned()).to.be.true;
-            });
+            validateAllReceiptProperties({expectedNonce: 9999});
         });
 
         context('a de-serialized signed Receipt that has been tampered with (sender)', () => {
@@ -420,20 +410,20 @@ describe('Receipt', () => {
             it('can not be de-serialized', () => {
                 expect(() => Receipt.from({}, stubbedProvider)).to.throw();
             });
+        });
 
-            context('a de-serialized incomplete Receipt', () => {
-                [
-                    payload => delete payload.sender.fees.single,
-                    payload => delete payload.sender.balances.current,
-                    payload => delete payload.nonce
-                ].forEach(modifier => {
-                    context('when ' + modifier.toString(), () => {
-                        it('can not be signed', () => {
-                            let modifiedPayload = {...unsignedPayload};
-                            modifier(modifiedPayload);
-                            let incompleteReceipt = Receipt.from(modifiedPayload, stubbedProvider);
-                            expect(incompleteReceipt.sign()).to.be.rejected;
-                        });
+        context('a de-serialized incomplete Receipt', () => {
+            [
+                payload => delete payload.sender.fees.single,
+                payload => delete payload.sender.balances.current,
+                payload => delete payload.nonce
+            ].forEach(modifier => {
+                context('when ' + modifier.toString(), () => {
+                    it('can not be signed', () => {
+                        let modifiedPayload = {...unsignedPayload};
+                        modifier(modifiedPayload);
+                        let incompleteReceipt = Receipt.from(modifiedPayload, stubbedProvider);
+                        expect(incompleteReceipt.sign()).to.be.rejected;
                     });
                 });
             });
@@ -465,9 +455,7 @@ describe('Receipt', () => {
                 });
             });
 
-            it('has a valid payment', () => {
-                expect(receipt.payment.isSigned()).to.be.true;
-            });
+            validateAllReceiptProperties({expectedNonce: 1});
         });
 
         context('a de-serialized unsigned Receipt that has no fees', () => {
@@ -500,9 +488,7 @@ describe('Receipt', () => {
                 });
             });
 
-            it('has a valid payment', () => {
-                expect(receipt.payment.isSigned()).to.be.true;
-            });
+            validateAllReceiptProperties({expectedNonce: 1});
         });
 
         context('a de-serialized signed Receipt', () => {
@@ -531,9 +517,7 @@ describe('Receipt', () => {
                 });
             });
 
-            it('has a valid payment', () => {
-                expect(receipt.payment.isSigned()).to.be.true;
-            });
+            validateAllReceiptProperties({expectedNonce: 1});
         });
 
         context('a de-serialized signed Receipt that has been tampered with (nonce)', () => {
@@ -558,9 +542,7 @@ describe('Receipt', () => {
                 expect(receipt.isSigned()).to.be.false;
             });
 
-            it('has a valid payment', () => {
-                expect(receipt.payment.isSigned()).to.be.true;
-            });
+            validateAllReceiptProperties({expectedNonce: 9999});
         });
 
         context('a de-serialized signed Receipt that has been tampered with (sender)', () => {
@@ -624,6 +606,23 @@ describe('Receipt', () => {
             });
         });
 
+        context('a de-serialized incomplete Receipt', () => {
+            [
+                payload => delete payload.sender.fees.single,
+                payload => delete payload.sender.balances.current,
+                payload => delete payload.nonce
+            ].forEach(modifier => {
+                context('when ' + modifier.toString(), () => {
+                    it('can not be signed', () => {
+                        let modifiedPayload = {...unsignedPayload};
+                        modifier(modifiedPayload);
+                        let incompleteReceipt = Receipt.from(modifiedPayload);
+                        expect(incompleteReceipt.sign()).to.be.rejected;
+                    });
+                });
+            });
+        });
+
         context('a de-serialized unsigned Receipt', () => {
             beforeEach(() => {
                 receipt = Receipt.from(unsignedPayload);
@@ -653,9 +652,7 @@ describe('Receipt', () => {
                 });
             });
 
-            it('has a valid payment', () => {
-                expect(receipt.payment.isSigned()).to.be.true;
-            });
+            validateAllReceiptProperties({expectedNonce: 1});
         });
 
         context('a de-serialized unsigned Receipt that has no fees', () => {
@@ -691,9 +688,7 @@ describe('Receipt', () => {
                 });
             });
 
-            it('has a valid payment', () => {
-                expect(receipt.payment.isSigned()).to.be.true;
-            });
+            validateAllReceiptProperties({expectedNonce: 1});
         });
 
         context('a de-serialized signed Receipt', () => {
@@ -725,9 +720,7 @@ describe('Receipt', () => {
                 });
             });
 
-            it('has a valid payment', () => {
-                expect(receipt.payment.isSigned()).to.be.true;
-            });
+            validateAllReceiptProperties({expectedNonce: 1});
         });
 
         context('a de-serialized signed Receipt that has been tampered with (nonce)', () => {
@@ -755,9 +748,7 @@ describe('Receipt', () => {
                 expect(() => receipt.isSigned()).to.throw(Error, /validate signature.*provider.*wallet/);
             });
 
-            it('has a valid payment', () => {
-                expect(receipt.payment.isSigned()).to.be.true;
-            });
+            validateAllReceiptProperties({expectedNonce: 9999});
         });
 
         context('a de-serialized signed Receipt that has been tampered with (sender)', () => {
@@ -790,4 +781,39 @@ describe('Receipt', () => {
             });
         });
     });
+
+    function validateAllReceiptProperties(expectedValues) {
+
+        it('has a valid payment', () => {
+            expect(receipt.payment.isSigned()).to.be.true;
+        });
+
+        it('has a nonce', () => {
+            expect(receipt.nonce).to.eql(expectedValues.expectedNonce);
+        });
+
+        it('has a block number', () => {
+            expect(receipt.blockNumber).to.eql(unsignedPayload.blockNumber);
+        });
+
+        it('has an operator ID', () => {
+            expect(receipt.operatorId).to.eql(unsignedPayload.operatorId);
+        });
+
+        it('has a sender nonce', () => {
+            expect(receipt.senderNonce).to.eql(unsignedPayload.sender.nonce);
+        });
+
+        it('has a recipient nonce', () => {
+            expect(receipt.recipientNonce).to.eql(unsignedPayload.recipient.nonce);
+        });
+
+        it('has a sender', function() {
+            expect(receipt.sender).to.eql(unsignedPayload.sender.wallet);
+        });
+
+        it('has a recipient', () => {
+            expect(receipt.recipient).to.eql(unsignedPayload.recipient.wallet);
+        });
+    }
 });

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test:watch": "npm run test -- --watch",
     "lint": "eslint --ignore-path .gitignore .",
     "lint:fix": "npm run lint -- --fix",
-    "postinstall": "if [[ $npm_config_production == 'true' || $npm_config_only == prod* ]] ; then exit 0 ; else npx npm-install-peers ; fi"
+    "postinstall": "bash -c \"if [[ $npm_config_production == 'true' || $npm_config_only == prod* ]] ; then exit 0 ; else npx npm-install-peers ; fi\""
   },
   "pre-commit": [
     "lint",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nahmii-sdk",
-  "version": "1.0.0-beta.42",
+  "version": "1.0.0-beta.43",
   "description": "Javascript SDK for using hubii nahmii APIs",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
   },
   "dependencies": {
     "ethereumjs-util": "^5.2.0",
-    "ethers": "~4.0.0",
     "keythereum": "^1.0.4",
     "lodash.get": "^4.4.2",
     "nahmii-ethereum-address": "^2.0.0",
@@ -70,5 +69,8 @@
     "superagent": "^3.8.3",
     "web3-utils": "1.0.0-beta.37",
     "yargs": "^12.0.1"
+  },
+  "peerDependencies": {
+    "ethers": "~4.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test:watch": "npm run test -- --watch",
     "lint": "eslint --ignore-path .gitignore .",
     "lint:fix": "npm run lint -- --fix",
-    "postinstall": "bash -c \"if [[ $npm_config_production == 'true' || $npm_config_only == prod* ]] ; then exit 0 ; else npx npm-install-peers ; fi\""
+    "postinstall": "bash -c \"if [[ '$npm_config_production' == 'true' || '$npm_config_only' == prod* ]] ; then exit 0 ; else npx npm-install-peers ; fi\""
   },
   "pre-commit": [
     "lint",

--- a/package.json
+++ b/package.json
@@ -17,10 +17,11 @@
     "build:docs:settlement": "jsdoc2md lib/settlement/settlement.js > Docs/settlement.md",
     "build:docs:driip-settlement": "jsdoc2md lib/settlement/driip-settlement.js > Docs/driip-settlement.md",
     "build:docs:null-settlement": "jsdoc2md lib/settlement/null-settlement.js > Docs/null-settlement.md",
-    "test": "nyc mocha 'lib/**/*.spec.js' --exit",
+    "test": "NODE_PATH=$npm_package_peerInstallOptions_prefix/node_modules nyc mocha 'lib/**/*.spec.js' --exit",
     "test:watch": "npm run test -- --watch",
     "lint": "eslint --ignore-path .gitignore .",
-    "lint:fix": "npm run lint -- --fix"
+    "lint:fix": "npm run lint -- --fix",
+    "postinstall": "if [[ $npm_config_production == 'true' || $npm_config_only == prod* ]] ; then exit 0 ; else npx npm-install-peers ; fi"
   },
   "pre-commit": [
     "lint",
@@ -53,6 +54,7 @@
     "jsdoc-to-markdown": "^4.0.1",
     "mocha": "^5.2.0",
     "nock": "^9.6.1",
+    "npm-install-peers": "^1.2.1",
     "nyc": "^12.0.2",
     "pre-commit": "^1.2.2",
     "proxyquire": "^2.0.1",
@@ -72,5 +74,8 @@
   },
   "peerDependencies": {
     "ethers": "~4.0.0"
+  },
+  "peerInstallOptions": {
+    "prefix": "./peer_modules"
   }
 }


### PR DESCRIPTION
- ethers is now a peer dependency
- auto installs peers in separate folder (unless production deployment)
- Added NahmiiEventProvider#dispose()
- Fix missing provider in receipts from NahmiiEventProvider#onNewReceipt()
- Added some property accessors on the Receipt class
- Documentation updates