### PR TITLE
Update payment schema

### DIFF
--- a/Docs/receipt.md
+++ b/Docs/receipt.md
@@ -8,7 +8,6 @@
         * _instance_
             * [.payment](#module_nahmii-sdk--Receipt+payment) ⇒ <code>Payment</code>
             * [.blockNumber](#module_nahmii-sdk--Receipt+blockNumber) ⇒ <code>any</code>
-            * ~~[.nonce](#module_nahmii-sdk--Receipt+nonce) ⇒ <code>any</code>~~
             * [.sender](#module_nahmii-sdk--Receipt+sender) ⇒ <code>Address</code>
             * [.recipient](#module_nahmii-sdk--Receipt+recipient) ⇒ <code>Address</code>
             * [.operatorId](#module_nahmii-sdk--Receipt+operatorId) ⇒ <code>Number</code>
@@ -50,14 +49,6 @@ Retrieve the payment this Receipt is based on.
 
 #### receipt.blockNumber ⇒ <code>any</code>
 Reference to the on-chain state the payments was effectuated after.
-
-**Kind**: instance property of [<code>Receipt</code>](#exp_module_nahmii-sdk--Receipt)  
-<a name="module_nahmii-sdk--Receipt+nonce"></a>
-
-#### ~~receipt.nonce ⇒ <code>any</code>~~
-***Deprecated***
-
-Global nonce - dont use this for anything, will be removed!
 
 **Kind**: instance property of [<code>Receipt</code>](#exp_module_nahmii-sdk--Receipt)  
 <a name="module_nahmii-sdk--Receipt+sender"></a>

--- a/lib/event-provider/index.spec.js
+++ b/lib/event-provider/index.spec.js
@@ -40,8 +40,9 @@ describe('Nahmii Event Provider', () => {
         receiptJSON = {
             amount: '0',
             currency: {ct: '0x0000000000000000000000000000000000000000', id: 0},
-            sender: {wallet: ''},
-            recipient: {wallet: ''}
+            sender: {wallet: '', data: 'data'},
+            recipient: {wallet: ''},
+            operator: {id: 0, data: 'data'}
         };
     });
 

--- a/lib/payment.js
+++ b/lib/payment.js
@@ -11,6 +11,7 @@ const Wallet = require('./wallet');
 
 const _amount = new WeakMap();
 const _sender = new WeakMap();
+const _senderData = new WeakMap();
 const _recipient = new WeakMap();
 const _hash = new WeakMap();
 const _signature = new WeakMap();
@@ -19,7 +20,7 @@ const _provider = new WeakMap();
 
 const PAYMENT_REQUEST_HASH_PARTS = [
     ['amount', 'currency.ct', 'currency.id'],
-    ['sender.wallet'],
+    ['sender.wallet', 'sender.data'],
     ['recipient.wallet']
 ];
 
@@ -84,6 +85,14 @@ class Payment {
      */
     get sender() {
         return _sender.get(this);
+    }
+
+    /**
+     * The sender data string of the payment
+     * @returns {String}
+     */
+    get senderData() {
+        return _senderData.get(this);
     }
 
     /**
@@ -154,7 +163,8 @@ class Payment {
 
         const result = Object.assign({}, amount, {
             sender: {
-                wallet: _sender.get(this)
+                wallet: _sender.get(this),
+                data: _senderData.get(this)
             },
             recipient: {
                 wallet: _recipient.get(this)
@@ -180,6 +190,7 @@ class Payment {
         // TODO: implement proper data validation before instantiation of new Payment
         const amount = MonetaryAmount.from(json);
         const p = new Payment(amount, json.sender.wallet, json.recipient.wallet, walletOrProvider);
+        _senderData.set(p, json.sender.data);
         if (json.seals && json.seals.wallet) {
             _hash.set(p, json.seals.wallet.hash);
             _signature.set(p, json.seals.wallet.signature);

--- a/lib/payment.js
+++ b/lib/payment.js
@@ -88,14 +88,6 @@ class Payment {
     }
 
     /**
-     * The sender data string of the payment
-     * @returns {String}
-     */
-    get senderData() {
-        return _senderData.get(this);
-    }
-
-    /**
      * The recipient of the payment
      * @returns {Address}
      */
@@ -190,7 +182,7 @@ class Payment {
         // TODO: implement proper data validation before instantiation of new Payment
         const amount = MonetaryAmount.from(json);
         const p = new Payment(amount, json.sender.wallet, json.recipient.wallet, walletOrProvider);
-        _senderData.set(p, json.sender.data);
+        _senderData.set(p, json.sender.data || '');
         if (json.seals && json.seals.wallet) {
             _hash.set(p, json.seals.wallet.hash);
             _signature.set(p, json.seals.wallet.signature);

--- a/lib/payment.js
+++ b/lib/payment.js
@@ -156,7 +156,7 @@ class Payment {
         const result = Object.assign({}, amount, {
             sender: {
                 wallet: _sender.get(this),
-                data: _senderData.get(this)
+                data: _senderData.get(this) || ''
             },
             recipient: {
                 wallet: _recipient.get(this)
@@ -182,7 +182,7 @@ class Payment {
         // TODO: implement proper data validation before instantiation of new Payment
         const amount = MonetaryAmount.from(json);
         const p = new Payment(amount, json.sender.wallet, json.recipient.wallet, walletOrProvider);
-        _senderData.set(p, json.sender.data || '');
+        _senderData.set(p, json.sender.data);
         if (json.seals && json.seals.wallet) {
             _hash.set(p, json.seals.wallet.hash);
             _signature.set(p, json.seals.wallet.signature);

--- a/lib/payment.spec.js
+++ b/lib/payment.spec.js
@@ -75,7 +75,8 @@ describe('Payment', () => {
             payload.currency.id
         );
         const senderHash = hash(
-            payload.sender.wallet
+            payload.sender.wallet,
+            payload.sender.data,
         );
         const recipientHash = hash(
             payload.recipient.wallet
@@ -89,7 +90,8 @@ describe('Payment', () => {
             amount,
             currency,
             sender: {
-                wallet: sender
+                wallet: sender,
+                data: 'data'
             },
             recipient: {
                 wallet: recipient
@@ -101,9 +103,9 @@ describe('Payment', () => {
                 wallet: {
                     hash: hashPaymentAsWallet(unsignedPayload),
                     signature: {
-                        r: '0xb7421b9b8eabd78a4e669130cd4df49d03c2aeb2cb453cb2cc92c95d7db97091',
-                        s: '0x3241c2f39fc4c64452c866c611671bc87b2c0b90ebadfcb67fd20ea774812b72',
-                        v: 28
+                        r: '0x72e01a17545dfdd2cd5c7f34d7459f71579aad968cec0026fe34d1ae59168346',
+                        s: '0x767ac6c2d6e02bd092689c202e2f4935ca5779ac6e5c183f0e0d7095e01b1702',
+                        v: 27
                     }
                 }
             }
@@ -125,7 +127,7 @@ describe('Payment', () => {
             let payment;
 
             beforeEach(() => {
-                payment = new Payment(MonetaryAmount.from(amount, currency.ct, currency.id), sender, recipient, wallet);
+                payment = Payment.from(unsignedPayload, wallet);
             });
 
             it('can be serialized to an object literal', () => {
@@ -163,7 +165,7 @@ describe('Payment', () => {
             let payment;
 
             beforeEach(async () => {
-                payment = new Payment(MonetaryAmount.from(amount, currency.ct, currency.id), sender, recipient, wallet);
+                payment = Payment.from(unsignedPayload, wallet);
                 await payment.sign();
             });
 
@@ -270,7 +272,7 @@ describe('Payment', () => {
             let payment;
 
             beforeEach(() => {
-                payment = new Payment(MonetaryAmount.from(amount, currency.ct, currency.id), sender, recipient, stubbedProvider);
+                payment = Payment.from(unsignedPayload, stubbedProvider);
             });
 
             it('can be serialized to an object literal', () => {
@@ -387,7 +389,7 @@ describe('Payment', () => {
             let payment;
 
             beforeEach(() => {
-                payment = new Payment(MonetaryAmount.from(amount, currency.ct, currency.id), sender, recipient);
+                payment = Payment.from(unsignedPayload);
             });
 
             it('can be serialized to an object literal', () => {

--- a/lib/payment.spec.js
+++ b/lib/payment.spec.js
@@ -516,6 +516,19 @@ describe('Payment', () => {
         });
     });
 
+    context('a de-serialized unsigned Payment that has a null sender data', () => {
+        let payment;
+
+        beforeEach(() => {
+            const modifiedPayload = {...unsignedPayload, sender: {wallet: sender}};
+            payment = Payment.from(modifiedPayload, stubbedWallet);
+        });
+        
+        it('has empty string for the sender data', () => {
+            expect(payment.toJSON().sender.data).to.equal('');
+        });
+    });
+
     context('a de-serialized signed Payment that has been tampered with (amount)', () => {
         let payment, modifiedPayload;
 

--- a/lib/receipt.js
+++ b/lib/receipt.js
@@ -15,7 +15,6 @@ const _wallet = new WeakMap();
 const _payment = new WeakMap();
 const _hash = new WeakMap();
 const _signature = new WeakMap();
-const _nonce = new WeakMap();
 const _blockNumber = new WeakMap();
 const _operatorId = new WeakMap();
 const _operatorData = new WeakMap();
@@ -109,15 +108,6 @@ class Receipt {
     }
 
     /**
-     * Global nonce - dont use this for anything, will be removed!
-     * @deprecated
-     * @returns {any}
-     */
-    get nonce() {
-        return _nonce.get(this);
-    }
-
-    /**
      * The address of the sender
      * @returns {Address}
      */
@@ -147,14 +137,6 @@ class Receipt {
      */
     get operatorId() {
         return _operatorId.get(this);
-    }
-
-    /**
-     * The data string of the operator that effectuated this payment.
-     * @returns {Number}
-     */
-    get operatorData() {
-        return _operatorData.get(this);
     }
 
     /**
@@ -293,10 +275,9 @@ class Receipt {
         const p = Payment.from(json, walletOrProvider);
         const r = new Receipt(p, walletOrProvider);
 
-        _nonce.set(r, json.nonce);
         _blockNumber.set(r, json.blockNumber);
         _operatorId.set(r, json.operator.id);
-        _operatorData.set(r, json.operator.data);
+        _operatorData.set(r, json.operator.data || '');
 
         if (json.sender) {
             _senderNonce.set(r, json.sender.nonce);

--- a/lib/receipt.js
+++ b/lib/receipt.js
@@ -217,7 +217,7 @@ class Receipt {
         result.blockNumber = _blockNumber.get(this);
         result.operator = {
             id: _operatorId.get(this),
-            data: _operatorData.get(this)
+            data: _operatorData.get(this) || ''
         };
         result.sender.nonce = _senderNonce.get(this);
         result.sender.balances = {
@@ -277,7 +277,7 @@ class Receipt {
 
         _blockNumber.set(r, json.blockNumber);
         _operatorId.set(r, json.operator.id);
-        _operatorData.set(r, json.operator.data || '');
+        _operatorData.set(r, json.operator.data);
 
         if (json.sender) {
             _senderNonce.set(r, json.sender.nonce);

--- a/lib/receipt.js
+++ b/lib/receipt.js
@@ -18,6 +18,7 @@ const _signature = new WeakMap();
 const _nonce = new WeakMap();
 const _blockNumber = new WeakMap();
 const _operatorId = new WeakMap();
+const _operatorData = new WeakMap();
 const _senderNonce = new WeakMap();
 const _recipientNonce = new WeakMap();
 const _senderCurrentBalance = new WeakMap();
@@ -35,9 +36,6 @@ const PAYMENT_RECEIPT_HASH_PARTS = [
         'seals.wallet.signature.v',
         'seals.wallet.signature.r',
         'seals.wallet.signature.s'
-    ],
-    [
-        'nonce'
     ],
     [
         ['sender.nonce'],
@@ -65,6 +63,9 @@ const PAYMENT_RECEIPT_HASH_PARTS = [
     [
         'transfers.single',
         'transfers.total'
+    ],
+    [
+        'operator.data'
     ]
 ];
 
@@ -149,6 +150,14 @@ class Receipt {
     }
 
     /**
+     * The data string of the operator that effectuated this payment.
+     * @returns {Number}
+     */
+    get operatorData() {
+        return _operatorData.get(this);
+    }
+
+    /**
      * Will hash and sign the receipt with the wallet passed into the constructor
      */
     async sign() {
@@ -223,9 +232,11 @@ class Receipt {
 
         const result = payment.toJSON();
 
-        result.nonce = _nonce.get(this);
         result.blockNumber = _blockNumber.get(this);
-        result.operatorId = _operatorId.get(this);
+        result.operator = {
+            id: _operatorId.get(this),
+            data: _operatorData.get(this)
+        };
         result.sender.nonce = _senderNonce.get(this);
         result.sender.balances = {
             current: _senderCurrentBalance.get(this),
@@ -284,7 +295,8 @@ class Receipt {
 
         _nonce.set(r, json.nonce);
         _blockNumber.set(r, json.blockNumber);
-        _operatorId.set(r, json.operatorId);
+        _operatorId.set(r, json.operator.id);
+        _operatorData.set(r, json.operator.data);
 
         if (json.sender) {
             _senderNonce.set(r, json.sender.nonce);

--- a/lib/receipt.spec.js
+++ b/lib/receipt.spec.js
@@ -468,6 +468,19 @@ describe('Receipt', () => {
             validateAllReceiptProperties();
         });
 
+        context('a de-serialized unsigned Receipt that has a null operator data', () => {
+            let receipt;
+    
+            beforeEach(() => {
+                const modifiedPayload = {...unsignedPayload, operator: {id: 0}};
+                receipt = Receipt.from(modifiedPayload, stubbedProvider);
+            });
+            
+            it('has empty string for the operator data', () => {
+                expect(receipt.toJSON().operator.data).to.equal('');
+            });
+        });
+
         context('a de-serialized signed Receipt', () => {
             beforeEach(() => {
                 receipt = Receipt.from(signedPayload, stubbedProvider);
@@ -718,10 +731,6 @@ describe('Receipt', () => {
 
         it('has an operator ID', () => {
             expect(receipt.operatorId).to.eql(unsignedPayload.operator.id);
-        });
-
-        it('has an operator data', () => {
-            expect(receipt.operatorData).to.eql(unsignedPayload.operator.data);
         });
 
         it('has a sender nonce', () => {

--- a/lib/receipt.spec.js
+++ b/lib/receipt.spec.js
@@ -70,9 +70,6 @@ describe('Receipt', () => {
             payment.seals.wallet.signature.r,
             payment.seals.wallet.signature.s
         );
-        const nonceHash = hash(
-            payment.nonce
-        );
 
         const senderHash = hash(
             hash(payment.sender.nonce),
@@ -100,7 +97,10 @@ describe('Receipt', () => {
             payment.transfers.single,
             payment.transfers.total
         );
-        return hash(walletSignatureHash, nonceHash, senderHash, recipientHash, transfersHash);
+        const operatorHash = hash(
+            payment.operator.data
+        );
+        return hash(walletSignatureHash, senderHash, recipientHash, transfersHash, operatorHash);
     }
 
     async function signPaymentAsWallet(json) {
@@ -116,9 +116,7 @@ describe('Receipt', () => {
             amount,
             currency,
             seals: {},
-            nonce: 1,
             blockNumber: 1,
-            operatorId: 1,
             sender: {
                 nonce: 1,
                 wallet: sender,
@@ -140,7 +138,8 @@ describe('Receipt', () => {
                             }
                         }
                     ]
-                }
+                },
+                data: 'data'
             },
             recipient: {
                 nonce: 1,
@@ -167,6 +166,10 @@ describe('Receipt', () => {
             transfers: {
                 single: '100',
                 total: '100'
+            },
+            operator: {
+                id: 0,
+                data: 'data'
             }
         };
 
@@ -179,9 +182,9 @@ describe('Receipt', () => {
                 operator: {
                     hash: hashPaymentAsOperator(unsignedPayload),
                     signature: {
-                        r: '0x19dbbbf5fd9f8cc4e39ea8b1c214d3cef3605129eb0499129a14d7c49551a686',
-                        s: '0x123c22665cda95f8acb82a425ac2e18243be4ff6c51b1403b18dd80cc9f26010',
-                        v: 28
+                        r: '0x259d290b4366a9346c88297f2e73dc7c2eb5a0e4636faea2bd5b8d9165cd7af8',
+                        s: '0x1643ae02ad76af082ac6cc5f2936b62378d505197869f86f2331c3b78e84fa3a',
+                        v: 27
                     }
                 }
             }
@@ -231,8 +234,7 @@ describe('Receipt', () => {
         context('a de-serialized incomplete Receipt', () => {
             [
                 payload => delete payload.sender.fees.single,
-                payload => delete payload.sender.balances.current,
-                payload => delete payload.nonce
+                payload => delete payload.sender.balances.current
             ].forEach(modifier => {
                 context('when ' + modifier.toString(), () => {
                     it('can not be signed', () => {
@@ -269,7 +271,7 @@ describe('Receipt', () => {
                 expect(receipt.isSigned()).to.eql(true);
             });
 
-            validateAllReceiptProperties({expectedNonce: 1});
+            validateAllReceiptProperties();
         });
 
         context('a de-serialized signed Receipt that has no recipient fees', () => {
@@ -299,7 +301,7 @@ describe('Receipt', () => {
                 expect(receipt.isSigned()).to.eql(true);
             });
 
-            validateAllReceiptProperties({expectedNonce: 1});
+            validateAllReceiptProperties();
         });
 
         context('a de-serialized signed Receipt', () => {
@@ -326,32 +328,7 @@ describe('Receipt', () => {
                 expect(receipt.toJSON()).to.eql(signedPayload);
             });
 
-            validateAllReceiptProperties({expectedNonce: 1});
-        });
-
-        context('a de-serialized signed Receipt that has been tampered with (nonce)', () => {
-            let modifiedPayload;
-
-            beforeEach(() => {
-                modifiedPayload = {...signedPayload};
-                modifiedPayload.nonce = 9999;
-                receipt = Receipt.from(modifiedPayload, wallet);
-            });
-
-            it('can be registered with the API', () => {
-                receipt.effectuate();
-                expect(stubbedProvider.effectuatePayment).to.have.been.calledWith(receipt.toJSON());
-            });
-
-            it('has the modified nonce', () => {
-                expect(receipt.toJSON().nonce).to.eql(modifiedPayload.nonce);
-            });
-
-            it('does not have a valid signature', () => {
-                expect(receipt.isSigned()).to.be.false;
-            });
-
-            validateAllReceiptProperties({expectedNonce: 9999});
+            validateAllReceiptProperties();
         });
 
         context('a de-serialized signed Receipt that has been tampered with (sender)', () => {
@@ -455,7 +432,7 @@ describe('Receipt', () => {
                 });
             });
 
-            validateAllReceiptProperties({expectedNonce: 1});
+            validateAllReceiptProperties();
         });
 
         context('a de-serialized unsigned Receipt that has no fees', () => {
@@ -488,7 +465,7 @@ describe('Receipt', () => {
                 });
             });
 
-            validateAllReceiptProperties({expectedNonce: 1});
+            validateAllReceiptProperties();
         });
 
         context('a de-serialized signed Receipt', () => {
@@ -517,32 +494,7 @@ describe('Receipt', () => {
                 });
             });
 
-            validateAllReceiptProperties({expectedNonce: 1});
-        });
-
-        context('a de-serialized signed Receipt that has been tampered with (nonce)', () => {
-            let modifiedPayload;
-
-            beforeEach(() => {
-                modifiedPayload = {...signedPayload};
-                modifiedPayload.nonce = 9999;
-                receipt = Receipt.from(modifiedPayload, stubbedProvider);
-            });
-
-            it('can be registered with the API', () => {
-                receipt.effectuate();
-                expect(stubbedProvider.effectuatePayment).to.have.been.calledWith(receipt.toJSON());
-            });
-
-            it('has the modified nonce', () => {
-                expect(receipt.toJSON().nonce).to.eql(modifiedPayload.nonce);
-            });
-
-            it('does not have a valid signature', () => {
-                expect(receipt.isSigned()).to.be.false;
-            });
-
-            validateAllReceiptProperties({expectedNonce: 9999});
+            validateAllReceiptProperties();
         });
 
         context('a de-serialized signed Receipt that has been tampered with (sender)', () => {
@@ -652,7 +604,7 @@ describe('Receipt', () => {
                 });
             });
 
-            validateAllReceiptProperties({expectedNonce: 1});
+            validateAllReceiptProperties();
         });
 
         context('a de-serialized unsigned Receipt that has no fees', () => {
@@ -688,7 +640,7 @@ describe('Receipt', () => {
                 });
             });
 
-            validateAllReceiptProperties({expectedNonce: 1});
+            validateAllReceiptProperties();
         });
 
         context('a de-serialized signed Receipt', () => {
@@ -720,35 +672,7 @@ describe('Receipt', () => {
                 });
             });
 
-            validateAllReceiptProperties({expectedNonce: 1});
-        });
-
-        context('a de-serialized signed Receipt that has been tampered with (nonce)', () => {
-            let modifiedPayload;
-
-            beforeEach(() => {
-                modifiedPayload = {...signedPayload};
-                modifiedPayload.nonce = 9999;
-                receipt = Receipt.from(modifiedPayload);
-            });
-
-            it('can not be registered with the API', (done) => {
-                receipt.effectuate().catch(e => {
-                    expect(e).to.be.an.instanceOf(Error);
-                    expect(e.message).to.match(/no provider/i);
-                    done();
-                });
-            });
-
-            it('has the modified nonce', () => {
-                expect(receipt.toJSON().nonce).to.eql(modifiedPayload.nonce);
-            });
-
-            it('can not validate signature', () => {
-                expect(() => receipt.isSigned()).to.throw(Error, /validate signature.*provider.*wallet/);
-            });
-
-            validateAllReceiptProperties({expectedNonce: 9999});
+            validateAllReceiptProperties();
         });
 
         context('a de-serialized signed Receipt that has been tampered with (sender)', () => {
@@ -782,14 +706,10 @@ describe('Receipt', () => {
         });
     });
 
-    function validateAllReceiptProperties(expectedValues) {
+    function validateAllReceiptProperties() {
 
         it('has a valid payment', () => {
             expect(receipt.payment.isSigned()).to.be.true;
-        });
-
-        it('has a nonce', () => {
-            expect(receipt.nonce).to.eql(expectedValues.expectedNonce);
         });
 
         it('has a block number', () => {
@@ -797,7 +717,11 @@ describe('Receipt', () => {
         });
 
         it('has an operator ID', () => {
-            expect(receipt.operatorId).to.eql(unsignedPayload.operatorId);
+            expect(receipt.operatorId).to.eql(unsignedPayload.operator.id);
+        });
+
+        it('has an operator data', () => {
+            expect(receipt.operatorData).to.eql(unsignedPayload.operator.data);
         });
 
         it('has a sender nonce', () => {

--- a/lib/settlement/driip-settlement.js
+++ b/lib/settlement/driip-settlement.js
@@ -318,6 +318,7 @@ class DriipSettlement {
         try {
             const {amount} = stageAmount.toJSON();
             const challengeContract = new DriipSettlementChallengeContract(wallet);
+            console.log(JSON.stringify(receipt, undefined, 2));
             return await challengeContract.startChallengeFromPayment(receipt.toJSON(), amount, options);
         }
         catch (error) {

--- a/lib/settlement/driip-settlement.js
+++ b/lib/settlement/driip-settlement.js
@@ -318,7 +318,6 @@ class DriipSettlement {
         try {
             const {amount} = stageAmount.toJSON();
             const challengeContract = new DriipSettlementChallengeContract(wallet);
-            console.log(JSON.stringify(receipt, undefined, 2));
             return await challengeContract.startChallengeFromPayment(receipt.toJSON(), amount, options);
         }
         catch (error) {

--- a/lib/settlement/driip-settlement.spec.js
+++ b/lib/settlement/driip-settlement.spec.js
@@ -74,7 +74,8 @@ describe('Driip settlement operations', () => {
             amount: '100',
             currency: {ct: address0, id: 0},
             sender: {wallet: wallet.address, nonce: 2},
-            recipient: {wallet: '0x1', nonce: 3}
+            recipient: {wallet: '0x1', nonce: 3},
+            operator: {id: 0, data: 'data'}
         });
         const DriipSettlement = proxyquireSettlementChallenge();
         driipSettlement = new DriipSettlement(stubbedProvider);
@@ -495,7 +496,8 @@ describe('Driip settlement operations', () => {
             amount: '100',
             currency: {ct: address0, id: 0},
             sender: {wallet: ''},
-            recipient: {wallet: ''}
+            recipient: {wallet: ''},
+            operator: {id: 0, data: 'data'}
         });
         const stageAmount = MonetaryAmount.from({amount: 1, currency: {ct: address0, id: address0id}});
         const {currency} = stageAmount.toJSON();

--- a/lib/settlement/settlement.js
+++ b/lib/settlement/settlement.js
@@ -325,7 +325,6 @@ class Settlement {
         const nullSettlement = _nullSettlement.get(this);
         try {
             const {type, receipt, stageMonetaryAmount} = requiredChallenge;
-            console.log('start', JSON.stringify(receipt, undefined, 2));
             if (type === 'null')
                 return await nullSettlement.startChallenge(wallet, stageMonetaryAmount, options);
 

--- a/lib/settlement/settlement.js
+++ b/lib/settlement/settlement.js
@@ -325,7 +325,7 @@ class Settlement {
         const nullSettlement = _nullSettlement.get(this);
         try {
             const {type, receipt, stageMonetaryAmount} = requiredChallenge;
-
+            console.log('start', JSON.stringify(receipt, undefined, 2));
             if (type === 'null')
                 return await nullSettlement.startChallenge(wallet, stageMonetaryAmount, options);
 

--- a/lib/settlement/settlement.js
+++ b/lib/settlement/settlement.js
@@ -303,10 +303,13 @@ class Settlement {
         const provider = _provider.get(this);
         try {
             const receipts = await provider.getWalletReceipts(address, null, 100);
-            const filteredReceipts = receipts.filter(r => caseInsensitiveCompare(r.currency.ct, ct)).sort((a, b) => b.nonce - a.nonce);
+            const filteredReceipts = receipts
+                .filter(r => caseInsensitiveCompare(r.currency.ct, ct))
+                .sort((a, b) => determineNonceFromReceipt(b, address) - determineNonceFromReceipt(a, address));
             return filteredReceipts.length ? filteredReceipts[0] : null;
         }
         catch (error) {
+            console.log(error);
             throw new NestedError(error, 'Unable to get the latest receipt for a settlement.');
         }
     }

--- a/lib/settlement/settlement.js
+++ b/lib/settlement/settlement.js
@@ -309,7 +309,6 @@ class Settlement {
             return filteredReceipts.length ? filteredReceipts[0] : null;
         }
         catch (error) {
-            console.log(error);
             throw new NestedError(error, 'Unable to get the latest receipt for a settlement.');
         }
     }

--- a/lib/settlement/settlement.spec.js
+++ b/lib/settlement/settlement.spec.js
@@ -92,7 +92,6 @@ describe('Settlement', () => {
     const {Settlement} = proxyquireSettlementModule();
     const wallet = new Wallet(privateKey, stubbedProvider);
     const mockReceipt = {
-        nonce: 1,
         amount: 100,
         currency,
         sender: {
@@ -100,7 +99,8 @@ describe('Settlement', () => {
             balances: {
                 current: 200
             },
-            nonce: 1
+            nonce: 1,
+            data: 'data'
         },
         recipient: {
             wallet: '0x2',
@@ -108,6 +108,10 @@ describe('Settlement', () => {
                 current: 200
             },
             nonce: 2
+        },
+        operator: {
+            id: 0, 
+            data: 'data'
         }
     };
 
@@ -148,7 +152,15 @@ describe('Settlement', () => {
         it('should return latest receipt sorted by nonce in desc', async () => {
             stubbedProvider.getWalletReceipts
                 .withArgs(mockReceipt.sender.wallet, null, 100)
-                .resolves([{nonce: mockReceipt.nonce - 1, currency}, mockReceipt]);
+                .resolves([
+                    {
+                        sender: {
+                            wallet: mockReceipt.sender.wallet, nonce: mockReceipt.sender.nonce - 1
+                        }, 
+                        currency
+                    }, 
+                    mockReceipt
+                ]);
 
             const latestReceipt = await settlement.getLatestReceiptForSettlement(mockReceipt.sender.wallet, currency.ct.toUpperCase());
             expect(latestReceipt).to.deep.equal(mockReceipt);
@@ -500,10 +512,10 @@ describe('Settlement', () => {
         it('should return null settlement as a settleable challenge', async () => {
             const stageAmount = ethers.utils.bigNumberify(1);
             stubbedProvider.getWalletReceipts
-                .withArgs(mockReceipt.sender.wallet, mockReceipt.nonce, 1)
+                .withArgs(mockReceipt.sender.wallet)
                 .resolves([mockReceipt]);
             stubbedDriipSettlement.getCurrentProposalNonce
-                .resolves(ethers.utils.bigNumberify(mockReceipt.nonce));
+                .resolves(ethers.utils.bigNumberify(mockReceipt.sender.nonce));
             stubbedDriipSettlement.checkSettleDriipAsPayment
                 .withArgs(Receipt.from(mockReceipt, stubbedProvider), mockReceipt.sender.wallet)
                 .resolves({valid: false, reasons: []});
@@ -534,7 +546,7 @@ describe('Settlement', () => {
                 .resolves(stageAmount);
             stubbedDriipSettlement.getCurrentProposalNonce
                 .withArgs(mockReceipt.sender.wallet, currency.ct, currency.id)
-                .resolves(ethers.utils.bigNumberify(mockReceipt.nonce));
+                .resolves(ethers.utils.bigNumberify(mockReceipt.sender.nonce));
             stubbedDriipSettlement.checkSettleDriipAsPayment
                 .withArgs(Receipt.from(mockReceipt, stubbedProvider), mockReceipt.sender.wallet)
                 .resolves({valid: true});
@@ -560,7 +572,7 @@ describe('Settlement', () => {
         });
         it('should return empty settleable challenges when there are no qualified settlements', async () => {
             stubbedDriipSettlement.getCurrentProposalNonce
-                .resolves(ethers.utils.bigNumberify(mockReceipt.nonce));
+                .resolves(ethers.utils.bigNumberify(mockReceipt.sender.nonce));
             stubbedDriipSettlement.checkSettleDriipAsPayment
                 .resolves({valid: false, reasons: []});
             stubbedNullSettlement.checkSettleNull

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nahmii-sdk",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Javascript SDK for using hubii nahmii APIs",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nahmii-sdk",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "Javascript SDK for using hubii nahmii APIs",
   "main": "index.js",
   "scripts": {
@@ -67,7 +67,7 @@
     "keythereum": "^1.0.4",
     "lodash.get": "^4.4.2",
     "nahmii-contract-abstractions": "1.2.0",
-    "nahmii-contract-abstractions-ropsten": "1.3.0",
+    "nahmii-contract-abstractions-ropsten": "1.4.0",
     "nahmii-ethereum-address": "^2.0.0",
     "node-yaml": "^3.2.0",
     "socket.io-client": "^2.2.0",


### PR DESCRIPTION
Update payment/receipt schema:
 - Remove global nonce
 - Add `data` property under sender property to payments
 - Add `operator: {id, data}` property to receipts

Update the hash function for these newly added properties.