### PR TITLE
Adding encoding and decoding of sender data

### DIFF
--- a/Docs/monetary-amount.md
+++ b/Docs/monetary-amount.md
@@ -25,6 +25,10 @@ The class references the BigNumber implementation of ethers.
 #### new MonetaryAmount(amount, ct, [id])
 Constructs a new MonetaryAmount object.
 
+**Throws**:
+
+- <code>TypeError</code> - thrown if input arguments are unexpected.
+
 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |

--- a/Docs/payment.md
+++ b/Docs/payment.md
@@ -9,6 +9,7 @@
             * [.amount](#module_nahmii-sdk--Payment+amount) ⇒ <code>MonetaryAmount</code>
             * [.sender](#module_nahmii-sdk--Payment+sender) ⇒ <code>Address</code>
             * [.recipient](#module_nahmii-sdk--Payment+recipient) ⇒ <code>Address</code>
+            * [.senderRef](#module_nahmii-sdk--Payment+senderRef) ⇒ <code>string</code>
             * [.sign()](#module_nahmii-sdk--Payment+sign)
             * [.isSigned()](#module_nahmii-sdk--Payment+isSigned) ⇒ <code>Boolean</code>
             * [.register()](#module_nahmii-sdk--Payment+register) ⇒ <code>Promise</code>
@@ -72,6 +73,12 @@ The sender of the payment
 
 #### payment.recipient ⇒ <code>Address</code>
 The recipient of the payment
+
+**Kind**: instance property of [<code>Payment</code>](#exp_module_nahmii-sdk--Payment)  
+<a name="module_nahmii-sdk--Payment+senderRef"></a>
+
+#### payment.senderRef ⇒ <code>string</code>
+The sender's unique reference for the payment.
 
 **Kind**: instance property of [<code>Payment</code>](#exp_module_nahmii-sdk--Payment)  
 <a name="module_nahmii-sdk--Payment+sign"></a>

--- a/Docs/payment.md
+++ b/Docs/payment.md
@@ -31,6 +31,7 @@ supply a valid Wallet or NahmiiProvider instance.
 
 #### new Payment(amount, sender, recipient, [walletOrProvider])
 Constructor
+Creates a new payment with a unique sender reference.
 
 
 | Param | Type | Description |
@@ -78,7 +79,8 @@ The recipient of the payment
 <a name="module_nahmii-sdk--Payment+senderRef"></a>
 
 #### payment.senderRef ⇒ <code>string</code>
-The sender's unique reference for the payment.
+The sender's unique reference for the payment. A new unique reference is
+generated automatically at construction time.
 
 **Kind**: instance property of [<code>Payment</code>](#exp_module_nahmii-sdk--Payment)  
 <a name="module_nahmii-sdk--Payment+sign"></a>

--- a/lib/event-provider/index.spec.js
+++ b/lib/event-provider/index.spec.js
@@ -51,13 +51,6 @@ describe('Nahmii Event Provider', () => {
         receiptJSON = fixture.createUnsignedReceipt(
             await fixture.createSignedPayment(
                 fixture.createUnsignedPayment(senderRef)));
-
-        // receiptJSON = {
-        //     amount: '0',
-        //     currency: {ct: '0x0000000000000000000000000000000000000000', id: 0},
-        //     sender: {wallet: '', data: Buffer.from(JSON.stringify({ref: ''}).toString('base64'))},
-        //     recipient: {wallet: ''}
-        // };
     });
 
     afterEach(() => {

--- a/lib/event-provider/index.spec.js
+++ b/lib/event-provider/index.spec.js
@@ -44,7 +44,10 @@ describe('Nahmii Event Provider', () => {
             senderPrivateKey: '3a1076bf45ab87712ad64ccb3b10217737f7faacbf2872e88fdd9a537d8fe266',
             recipient: '0x0000000000000000000000000000000000000003',
             operatorPrivateKey: '252c772d9e9d570c726473927c52f23227cc674b6567935287d3f4a76a57d352',
-            currency: {ct: '0x0000000000000000000000000000000000000001', id: '0'},
+            currency: {
+                ct: '0x0000000000000000000000000000000000000001',
+                id: '0'
+            },
             amount: '1000'
         });
 

--- a/lib/event-provider/index.spec.js
+++ b/lib/event-provider/index.spec.js
@@ -10,6 +10,8 @@ const proxyquire = require('proxyquire').noPreserveCache().noCallThru();
 const EventEmitter = require('events');
 const Receipt = require('../receipt');
 
+const {ApiPayloadFactory} = require('../../test-utils');
+
 const nahmiiDomain = 'api.nahmii.somewhere';
 
 class FakeNahmiiProvider {
@@ -35,14 +37,27 @@ function proxyquireProvider() {
 
 describe('Nahmii Event Provider', () => {
     let provider, fakeSocket, receiptJSON;
+    const senderRef = '3f527f36-76e3-11e9-bcfb-705ab6aee958';
 
-    beforeEach(() => {
-        receiptJSON = {
-            amount: '0',
-            currency: {ct: '0x0000000000000000000000000000000000000000', id: 0},
-            sender: {wallet: '', data: Buffer.from(JSON.stringify({ref: ''}).toString('base64'))},
-            recipient: {wallet: ''}
-        };
+    beforeEach(async () => {
+        const fixture = new ApiPayloadFactory({
+            senderPrivateKey: '3a1076bf45ab87712ad64ccb3b10217737f7faacbf2872e88fdd9a537d8fe266',
+            recipient: '0x0000000000000000000000000000000000000003',
+            operatorPrivateKey: '252c772d9e9d570c726473927c52f23227cc674b6567935287d3f4a76a57d352',
+            currency: {ct: '0x0000000000000000000000000000000000000001', id: '0'},
+            amount: '1000'
+        });
+
+        receiptJSON = fixture.createUnsignedReceipt(
+            await fixture.createSignedPayment(
+                fixture.createUnsignedPayment(senderRef)));
+
+        // receiptJSON = {
+        //     amount: '0',
+        //     currency: {ct: '0x0000000000000000000000000000000000000000', id: 0},
+        //     sender: {wallet: '', data: Buffer.from(JSON.stringify({ref: ''}).toString('base64'))},
+        //     recipient: {wallet: ''}
+        // };
     });
 
     afterEach(() => {

--- a/lib/event-provider/index.spec.js
+++ b/lib/event-provider/index.spec.js
@@ -40,9 +40,8 @@ describe('Nahmii Event Provider', () => {
         receiptJSON = {
             amount: '0',
             currency: {ct: '0x0000000000000000000000000000000000000000', id: 0},
-            sender: {wallet: '', data: 'data'},
-            recipient: {wallet: ''},
-            operator: {id: 0, data: 'data'}
+            sender: {wallet: '', data: Buffer.from(JSON.stringify({ref: ''}).toString('base64'))},
+            recipient: {wallet: ''}
         };
     });
 

--- a/lib/payment.js
+++ b/lib/payment.js
@@ -161,12 +161,12 @@ class Payment {
         const clientData = {
             ref: _senderRef.get(this)
         };
-        const clientDataBase64 = Buffer.from(JSON.stringify(clientData)).toString('base64');
+        const senderDataB64 = Buffer.from(JSON.stringify(clientData)).toString('base64');
 
         const result = Object.assign({}, amount, {
             sender: {
                 wallet: _sender.get(this),
-                data: clientDataBase64
+                data: senderDataB64
             },
             recipient: {
                 wallet: _recipient.get(this)

--- a/lib/payment.js
+++ b/lib/payment.js
@@ -97,6 +97,10 @@ class Payment {
         return _recipient.get(this);
     }
 
+    /**
+     * The sender's unique reference for the payment.
+     * @returns {string}
+     */
     get senderRef() {
         return _senderRef.get(this);
     }

--- a/lib/payment.js
+++ b/lib/payment.js
@@ -158,10 +158,10 @@ class Payment {
      */
     toJSON() {
         const amount = _amount.get(this).toJSON();
-        const clientData = {
+        const senderData = {
             ref: _senderRef.get(this)
         };
-        const senderDataB64 = Buffer.from(JSON.stringify(clientData)).toString('base64');
+        const senderDataB64 = Buffer.from(JSON.stringify(senderData)).toString('base64');
 
         const result = Object.assign({}, amount, {
             sender: {

--- a/lib/payment.js
+++ b/lib/payment.js
@@ -197,8 +197,11 @@ class Payment {
             _hash.set(p, json.seals.wallet.hash);
             _signature.set(p, json.seals.wallet.signature);
         }
-        const senderData = JSON.parse(Buffer.from(json.sender.data, 'base64').toString('ascii'));
-        _senderRef.set(p, senderData.ref);
+        if (json.sender && json.sender.data && typeof json.sender.data === 'string') {
+            const senderData = JSON.parse(Buffer.from(json.sender.data, 'base64').toString('ascii'));
+            _senderRef.set(p, senderData.ref);
+        }
+
         return p;
     }
 }

--- a/lib/payment.js
+++ b/lib/payment.js
@@ -52,6 +52,7 @@ const PAYMENT_REQUEST_HASH_PARTS = [
 class Payment {
     /**
      * Constructor
+     * Creates a new payment with a unique sender reference.
      * @param {MonetaryAmount} amount - Amount in a currency
      * @param {Address} sender - Senders address
      * @param {Address} recipient - Recipient address
@@ -62,7 +63,7 @@ class Payment {
             throw new TypeError('amount is not an instance of MonetaryAmount');
 
         const wallet = walletOrProvider instanceof Wallet ? walletOrProvider : null;
-        const provider = wallet ? wallet.provider: walletOrProvider;
+        const provider = wallet ? wallet.provider : walletOrProvider;
 
         _wallet.set(this, wallet);
         _provider.set(this, provider);
@@ -98,7 +99,8 @@ class Payment {
     }
 
     /**
-     * The sender's unique reference for the payment.
+     * The sender's unique reference for the payment. A new unique reference is
+     * generated automatically at construction time.
      * @returns {string}
      */
     get senderRef() {

--- a/lib/payment.js
+++ b/lib/payment.js
@@ -8,6 +8,7 @@ const ethers = require('ethers');
 const MonetaryAmount = require('./monetary-amount');
 const {fromRpcSig, hashObject, hash, isSignedBy} = require('./utils');
 const Wallet = require('./wallet');
+const uuidv4 = require('uuid/v4');
 
 const _amount = new WeakMap();
 const _sender = new WeakMap();
@@ -17,6 +18,7 @@ const _hash = new WeakMap();
 const _signature = new WeakMap();
 const _wallet = new WeakMap();
 const _provider = new WeakMap();
+const _senderRef = new WeakMap();
 
 const PAYMENT_REQUEST_HASH_PARTS = [
     ['amount', 'currency.ct', 'currency.id'],
@@ -65,10 +67,10 @@ class Payment {
         _wallet.set(this, wallet);
         _provider.set(this, provider);
         _amount.set(this, amount);
-
         // TODO: ensure sender/recipient addresses are of EthereumAddress type.
         _sender.set(this, sender);
         _recipient.set(this, recipient);
+        _senderRef.set(this, uuidv4());
     }
 
     /**
@@ -93,6 +95,10 @@ class Payment {
      */
     get recipient() {
         return _recipient.get(this);
+    }
+
+    get senderRef() {
+        return _senderRef.get(this);
     }
 
     /**
@@ -152,11 +158,15 @@ class Payment {
      */
     toJSON() {
         const amount = _amount.get(this).toJSON();
+        const clientData = {
+            ref: _senderRef.get(this)
+        };
+        const clientDataBase64 = Buffer.from(JSON.stringify(clientData)).toString('base64');
 
         const result = Object.assign({}, amount, {
             sender: {
                 wallet: _sender.get(this),
-                data: _senderData.get(this) || ''
+                data: clientDataBase64
             },
             recipient: {
                 wallet: _recipient.get(this)
@@ -187,6 +197,8 @@ class Payment {
             _hash.set(p, json.seals.wallet.hash);
             _signature.set(p, json.seals.wallet.signature);
         }
+        const senderData = JSON.parse(Buffer.from(json.sender.data, 'base64').toString('ascii'));
+        _senderRef.set(p, senderData.ref);
         return p;
     }
 }

--- a/lib/payment.spec.js
+++ b/lib/payment.spec.js
@@ -499,9 +499,14 @@ describe('Payment', () => {
             modifiedPayload.sender.data = null;
             payment = Payment.from(modifiedPayload, stubbedWallet);
         });
-        
-        it('has empty string for the sender data', () => {
-            expect(payment.toJSON().sender.data).to.equal('');
+
+        it('has a new sender reference', function() {
+            expect(payment.senderRef).to.not.eql('');
+            expect(payment.senderRef).to.not.eql(senderRef);
+        });
+
+        it('has sender reference encoded in the sender data', () => {
+            expect(payment.toJSON().sender.data).to.eql(fixture.createUnsignedPayment(payment.senderRef).sender.data);
         });
     });
 

--- a/lib/payment.spec.js
+++ b/lib/payment.spec.js
@@ -7,11 +7,9 @@ const proxyquire = require('proxyquire').noPreserveCache().noCallThru();
 const expect = chai.expect;
 chai.use(sinonChai);
 
-const MonetaryAmount = require('./monetary-amount');
+const {ApiPayloadFactory} = require('../test-utils');
 
-const ethers = require('ethers');
-const {privateToAddress} = require('ethereumjs-util');
-const {hash, prefix0x, fromRpcSig} = require('./utils');
+const MonetaryAmount = require('./monetary-amount');
 
 const Wallet = proxyquire('./wallet/wallet', {
     './client-fund-contract': function() {
@@ -59,69 +57,18 @@ chai.use(_chai => {
 });
 
 describe('Payment', () => {
-    const amount = '1000';
-    const currency = {
-        ct: '0x0000000000000000000000000000000000000001',
-        id: '0'
-    };
-    const recipient = '0x0000000000000000000000000000000000000003';
-    const privateKey = '3a1076bf45ab87712ad64ccb3b10217737f7faacbf2872e88fdd9a537d8fe266';
-    const sender = prefix0x(privateToAddress(Buffer.from(privateKey, 'hex')).toString('hex'));
     const senderRef = 'c3cc73cc-756a-11e9-957c-705ab6aee958';
+    let fixture;
 
-    function hashPayment(payload) {
-        const amountCurrencyHash = hash(
-            payload.amount,
-            payload.currency.ct,
-            payload.currency.id
-        );
-        const senderHash = hash(
-            payload.sender.wallet,
-            payload.sender.data
-        );
-        const recipientHash = hash(
-            payload.recipient.wallet
-        );
-
-        return hash(amountCurrencyHash, senderHash, recipientHash);
-    }
-
-    async function signHash(hash) {
-        const senderWallet = new Wallet(privateKey);
-        const rpcSignature = await senderWallet.signMessage(ethers.utils.arrayify(hash));
-        return fromRpcSig(rpcSignature);
-    }
-
-    function createUnsignedPayload(senderRef) {
-        const senderData = Buffer
-            .from(JSON.stringify({ref: senderRef}))
-            .toString('base64');
-
-        return {
-            amount,
-            currency,
-            sender: {
-                wallet: sender,
-                data: senderData
-            },
-            recipient: {
-                wallet: recipient
-            }
-        };
-    }
-
-    async function createSignedPayload(unsignedPayload) {
-        const signedPayload = {
-            ...unsignedPayload,
-            seals: {
-                wallet: {
-                    hash: hashPayment(unsignedPayload)
-                }
-            }
-        };
-        signedPayload.seals.wallet.signature = await signHash(signedPayload.seals.wallet.hash);
-        return signedPayload;
-    }
+    beforeEach(function() {
+        fixture = new ApiPayloadFactory({
+            senderPrivateKey: '3a1076bf45ab87712ad64ccb3b10217737f7faacbf2872e88fdd9a537d8fe266',
+            recipient: '0x0000000000000000000000000000000000000003',
+            operatorPrivateKey: '252c772d9e9d570c726473927c52f23227cc674b6567935287d3f4a76a57d352',
+            currency: {ct: '0x0000000000000000000000000000000000000001', id: '0'},
+            amount: '1000'
+        });
+    });
 
     afterEach(() => {
         stubbedProvider.registerPayment.reset();
@@ -131,23 +78,23 @@ describe('Payment', () => {
         let wallet;
 
         beforeEach(() => {
-            wallet = new Wallet(privateKey, stubbedProvider);
+            wallet = new Wallet(fixture.senderPrivateKey, stubbedProvider);
         });
 
         context('a new Payment', () => {
             let payment;
 
             beforeEach(() => {
-                payment = Payment.from(unsignedPayload, wallet);
+                payment = new Payment(MonetaryAmount.from(fixture.amount, fixture.currency.ct, fixture.currency.id), fixture.sender, fixture.recipient, wallet);
             });
 
             it('can be serialized to an object literal', () => {
-                expect(payment.toJSON()).to.eql(createUnsignedPayload(payment.senderRef));
+                expect(payment.toJSON()).to.eql(fixture.createUnsignedPayment(payment.senderRef));
             });
 
             it('can be signed', async () => {
                 await payment.sign();
-                expect(payment.toJSON()).to.eql(await createSignedPayload(createUnsignedPayload(payment.senderRef)));
+                expect(payment.toJSON()).to.eql(await fixture.createSignedPayment(fixture.createUnsignedPayment(payment.senderRef)));
             });
 
             it('can be registered with the API', () => {
@@ -156,15 +103,15 @@ describe('Payment', () => {
             });
 
             it('has the supplied amount', () => {
-                expect(payment.amount).to.be.equalMoney(MonetaryAmount.from(amount, currency.ct, currency.id));
+                expect(payment.amount).to.be.equalMoney(MonetaryAmount.from(fixture.amount, fixture.currency.ct, fixture.currency.id));
             });
 
             it('has the supplied sender', () => {
-                expect(payment.sender).to.eql(sender);
+                expect(payment.sender).to.eql(fixture.sender);
             });
 
             it('has the supplied recipient', () => {
-                expect(payment.recipient).to.eql(recipient);
+                expect(payment.recipient).to.eql(fixture.recipient);
             });
 
             it('does not have a valid signature', () => {
@@ -187,9 +134,9 @@ describe('Payment', () => {
             let payment, expectedSignedPayload;
 
             beforeEach(async () => {
-                payment = Payment.from(unsignedPayload, wallet);
+                payment = new Payment(MonetaryAmount.from(fixture.amount, fixture.currency.ct, fixture.currency.id), fixture.sender, fixture.recipient, wallet);
                 await payment.sign();
-                expectedSignedPayload = await createSignedPayload(createUnsignedPayload(payment.senderRef));
+                expectedSignedPayload = await fixture.createSignedPayment(fixture.createUnsignedPayment(payment.senderRef));
             });
 
             it('can be serialized to an object literal', () => {
@@ -202,15 +149,15 @@ describe('Payment', () => {
             });
 
             it('has the supplied amount', () => {
-                expect(payment.amount).to.be.equalMoney(MonetaryAmount.from(amount, currency.ct, currency.id));
+                expect(payment.amount).to.be.equalMoney(MonetaryAmount.from(fixture.amount, fixture.currency.ct, fixture.currency.id));
             });
 
             it('has the supplied sender', () => {
-                expect(payment.sender).to.eql(sender);
+                expect(payment.sender).to.eql(fixture.sender);
             });
 
             it('has the supplied recipient', () => {
-                expect(payment.recipient).to.eql(recipient);
+                expect(payment.recipient).to.eql(fixture.recipient);
             });
 
             it('has a valid signature', () => {
@@ -222,12 +169,12 @@ describe('Payment', () => {
             let payment, expectedSignedPayload;
 
             beforeEach(async () => {
-                payment = Payment.from(createUnsignedPayload(senderRef), wallet);
-                expectedSignedPayload = await createSignedPayload(createUnsignedPayload(payment.senderRef));
+                payment = Payment.from(fixture.createUnsignedPayment(senderRef), wallet);
+                expectedSignedPayload = await fixture.createSignedPayment(fixture.createUnsignedPayment(payment.senderRef));
             });
 
-            it('can be serialized to a new object literal', () => {
-                expect(payment.toJSON()).to.eql(createUnsignedPayload(payment.senderRef));
+            it('can be serialized to a new object literal', async () => {
+                expect(payment.toJSON()).to.eql(fixture.createUnsignedPayment(payment.senderRef));
             });
 
             it('can be signed', async () => {
@@ -238,20 +185,20 @@ describe('Payment', () => {
             it('can be registered with the API', () => {
                 payment.register();
                 expect(stubbedProvider.registerPayment)
-                    .to.have.been.calledWith(createUnsignedPayload(payment.senderRef));
+                    .to.have.been.calledWith(fixture.createUnsignedPayment(payment.senderRef));
             });
 
             it('has the supplied amount', () => {
                 expect(payment.amount)
-                    .to.be.equalMoney(MonetaryAmount.from(amount, currency.ct, currency.id));
+                    .to.be.equalMoney(MonetaryAmount.from(fixture.amount, fixture.currency.ct, fixture.currency.id));
             });
 
             it('has the supplied sender', () => {
-                expect(payment.sender).to.eql(sender);
+                expect(payment.sender).to.eql(fixture.sender);
             });
 
             it('has the supplied recipient', () => {
-                expect(payment.recipient).to.eql(recipient);
+                expect(payment.recipient).to.eql(fixture.recipient);
             });
 
             it('does not have a valid signature', () => {
@@ -263,7 +210,7 @@ describe('Payment', () => {
             let payment, signedPayload;
 
             beforeEach(async () => {
-                signedPayload = await createSignedPayload(createUnsignedPayload('c3cc73cc-756a-11e9-957c-705ab6aee958'));
+                signedPayload = await fixture.createSignedPayment(fixture.createUnsignedPayment('c3cc73cc-756a-11e9-957c-705ab6aee958'));
                 payment = Payment.from(signedPayload, wallet);
             });
 
@@ -277,15 +224,15 @@ describe('Payment', () => {
             });
 
             it('has the supplied amount', () => {
-                expect(payment.amount).to.eql(MonetaryAmount.from(amount, currency.ct, currency.id));
+                expect(payment.amount).to.eql(MonetaryAmount.from(fixture.amount, fixture.currency.ct, fixture.currency.id));
             });
 
             it('has the supplied sender', () => {
-                expect(payment.sender).to.eql(sender);
+                expect(payment.sender).to.eql(fixture.sender);
             });
 
             it('has the supplied recipient', () => {
-                expect(payment.recipient).to.eql(recipient);
+                expect(payment.recipient).to.eql(fixture.recipient);
             });
 
             it('has a valid signature', () => {
@@ -299,11 +246,11 @@ describe('Payment', () => {
             let payment;
 
             beforeEach(() => {
-                payment = Payment.from(unsignedPayload, stubbedProvider);
+                payment = new Payment(MonetaryAmount.from(fixture.amount, fixture.currency.ct, fixture.currency.id), fixture.sender, fixture.recipient, stubbedProvider);
             });
 
             it('can be serialized to an object literal', () => {
-                expect(payment.toJSON()).to.eql(createUnsignedPayload(payment.senderRef));
+                expect(payment.toJSON()).to.eql(fixture.createUnsignedPayment(payment.senderRef));
             });
 
             it('can not be signed', (done) => {
@@ -320,15 +267,15 @@ describe('Payment', () => {
             });
 
             it('has the supplied amount', () => {
-                expect(payment.amount).to.be.equalMoney(MonetaryAmount.from(amount, currency.ct, currency.id));
+                expect(payment.amount).to.be.equalMoney(MonetaryAmount.from(fixture.amount, fixture.currency.ct, fixture.currency.id));
             });
 
             it('has the supplied sender', () => {
-                expect(payment.sender).to.eql(sender);
+                expect(payment.sender).to.eql(fixture.sender);
             });
 
             it('has the supplied recipient', () => {
-                expect(payment.recipient).to.eql(recipient);
+                expect(payment.recipient).to.eql(fixture.recipient);
             });
 
             it('does not have a valid signature', () => {
@@ -340,11 +287,11 @@ describe('Payment', () => {
             let payment;
 
             beforeEach(() => {
-                payment = Payment.from(createUnsignedPayload(senderRef), stubbedProvider);
+                payment = Payment.from(fixture.createUnsignedPayment(senderRef), stubbedProvider);
             });
 
             it('can be serialized to a new object literal', () => {
-                expect(payment.toJSON()).to.eql(createUnsignedPayload(senderRef));
+                expect(payment.toJSON()).to.eql(fixture.createUnsignedPayment(senderRef));
             });
 
             it('can not be signed', (done) => {
@@ -357,19 +304,19 @@ describe('Payment', () => {
 
             it('can be registered with the API', () => {
                 payment.register();
-                expect(stubbedProvider.registerPayment).to.have.been.calledWith(createUnsignedPayload(senderRef));
+                expect(stubbedProvider.registerPayment).to.have.been.calledWith(fixture.createUnsignedPayment(senderRef));
             });
 
             it('has the supplied amount', () => {
-                expect(payment.amount).to.be.equalMoney(MonetaryAmount.from(amount, currency.ct, currency.id));
+                expect(payment.amount).to.be.equalMoney(MonetaryAmount.from(fixture.amount, fixture.currency.ct, fixture.currency.id));
             });
 
             it('has the supplied sender', () => {
-                expect(payment.sender).to.eql(sender);
+                expect(payment.sender).to.eql(fixture.sender);
             });
 
             it('has the supplied recipient', () => {
-                expect(payment.recipient).to.eql(recipient);
+                expect(payment.recipient).to.eql(fixture.recipient);
             });
 
             it('does not have a valid signature', () => {
@@ -381,7 +328,7 @@ describe('Payment', () => {
             let payment, signedPayload;
 
             beforeEach(async () => {
-                signedPayload = await createSignedPayload(createUnsignedPayload(senderRef));
+                signedPayload = await fixture.createSignedPayment(fixture.createUnsignedPayment(senderRef));
                 payment = Payment.from(signedPayload, stubbedProvider);
             });
 
@@ -395,15 +342,15 @@ describe('Payment', () => {
             });
 
             it('has the supplied amount', () => {
-                expect(payment.amount).to.eql(MonetaryAmount.from(amount, currency.ct, currency.id));
+                expect(payment.amount).to.eql(MonetaryAmount.from(fixture.amount, fixture.currency.ct, fixture.currency.id));
             });
 
             it('has the supplied sender', () => {
-                expect(payment.sender).to.eql(sender);
+                expect(payment.sender).to.eql(fixture.sender);
             });
 
             it('has the supplied recipient', () => {
-                expect(payment.recipient).to.eql(recipient);
+                expect(payment.recipient).to.eql(fixture.recipient);
             });
 
             it('has a valid signature', () => {
@@ -417,11 +364,11 @@ describe('Payment', () => {
             let payment;
 
             beforeEach(() => {
-                payment = Payment.from(unsignedPayload);
+                payment = new Payment(MonetaryAmount.from(fixture.amount, fixture.currency.ct, fixture.currency.id), fixture.sender, fixture.recipient);
             });
 
             it('can be serialized to an object literal', () => {
-                expect(payment.toJSON()).to.eql(createUnsignedPayload(payment.senderRef));
+                expect(payment.toJSON()).to.eql(fixture.createUnsignedPayment(payment.senderRef));
             });
 
             it('can not be signed', (done) => {
@@ -441,15 +388,15 @@ describe('Payment', () => {
             });
 
             it('has the supplied amount', () => {
-                expect(payment.amount).to.be.equalMoney(MonetaryAmount.from(amount, currency.ct, currency.id));
+                expect(payment.amount).to.be.equalMoney(MonetaryAmount.from(fixture.amount, fixture.currency.ct, fixture.currency.id));
             });
 
             it('has the supplied sender', () => {
-                expect(payment.sender).to.eql(sender);
+                expect(payment.sender).to.eql(fixture.sender);
             });
 
             it('has the supplied recipient', () => {
-                expect(payment.recipient).to.eql(recipient);
+                expect(payment.recipient).to.eql(fixture.recipient);
             });
 
             it('does not have a valid signature', () => {
@@ -461,11 +408,11 @@ describe('Payment', () => {
             let payment;
 
             beforeEach(() => {
-                payment = Payment.from(createUnsignedPayload(senderRef));
+                payment = Payment.from(fixture.createUnsignedPayment(senderRef));
             });
 
             it('can be serialized to a new object literal', () => {
-                expect(payment.toJSON()).to.eql(createUnsignedPayload(senderRef));
+                expect(payment.toJSON()).to.eql(fixture.createUnsignedPayment(senderRef));
             });
 
             it('can not be signed', (done) => {
@@ -485,15 +432,15 @@ describe('Payment', () => {
             });
 
             it('has the supplied amount', () => {
-                expect(payment.amount).to.be.equalMoney(MonetaryAmount.from(amount, currency.ct, currency.id));
+                expect(payment.amount).to.be.equalMoney(MonetaryAmount.from(fixture.amount, fixture.currency.ct, fixture.currency.id));
             });
 
             it('has the supplied sender', () => {
-                expect(payment.sender).to.eql(sender);
+                expect(payment.sender).to.eql(fixture.sender);
             });
 
             it('has the supplied recipient', () => {
-                expect(payment.recipient).to.eql(recipient);
+                expect(payment.recipient).to.eql(fixture.recipient);
             });
 
             it('does not have a valid signature', () => {
@@ -505,11 +452,11 @@ describe('Payment', () => {
             let payment;
 
             beforeEach(async () => {
-                payment = Payment.from(await createSignedPayload(createUnsignedPayload(senderRef)));
+                payment = Payment.from(await fixture.createSignedPayment(fixture.createUnsignedPayment(senderRef)));
             });
 
             it('can be serialized to a new object literal', async () => {
-                expect(payment.toJSON()).to.eql(await createSignedPayload(createUnsignedPayload(senderRef)));
+                expect(payment.toJSON()).to.eql(await fixture.createSignedPayment(fixture.createUnsignedPayment(senderRef)));
             });
 
             it('can not be registered with the API', (done) => {
@@ -521,15 +468,15 @@ describe('Payment', () => {
             });
 
             it('has the supplied amount', () => {
-                expect(payment.amount).to.eql(MonetaryAmount.from(amount, currency.ct, currency.id));
+                expect(payment.amount).to.eql(MonetaryAmount.from(fixture.amount, fixture.currency.ct, fixture.currency.id));
             });
 
             it('has the supplied sender', () => {
-                expect(payment.sender).to.eql(sender);
+                expect(payment.sender).to.eql(fixture.sender);
             });
 
             it('has the supplied recipient', () => {
-                expect(payment.recipient).to.eql(recipient);
+                expect(payment.recipient).to.eql(fixture.recipient);
             });
 
             it('has a valid signature', () => {
@@ -548,7 +495,8 @@ describe('Payment', () => {
         let payment;
 
         beforeEach(() => {
-            const modifiedPayload = {...unsignedPayload, sender: {wallet: sender}};
+            const modifiedPayload = fixture.createUnsignedPayment(senderRef);
+            modifiedPayload.sender.data = null;
             payment = Payment.from(modifiedPayload, stubbedWallet);
         });
         
@@ -561,13 +509,13 @@ describe('Payment', () => {
         let payment, modifiedPayload;
 
         beforeEach(async () => {
-            modifiedPayload = await createSignedPayload(createUnsignedPayload(senderRef));
+            modifiedPayload = await fixture.createSignedPayment(fixture.createUnsignedPayment(senderRef));
             modifiedPayload.amount = '999999';
             payment = Payment.from(modifiedPayload, stubbedWallet);
         });
 
         it('has the modified amount', () => {
-            expect(payment.amount).to.eql(MonetaryAmount.from(modifiedPayload.amount, currency.ct, currency.id));
+            expect(payment.amount).to.eql(MonetaryAmount.from(modifiedPayload.amount, fixture.currency.ct, fixture.currency.id));
         });
 
         it('does not have a valid signature', () => {
@@ -579,7 +527,7 @@ describe('Payment', () => {
         let payment, modifiedPayload;
 
         beforeEach(async () => {
-            modifiedPayload = await createSignedPayload(createUnsignedPayload(senderRef));
+            modifiedPayload = await fixture.createSignedPayment(fixture.createUnsignedPayment(senderRef));
             modifiedPayload.sender.wallet = '0x0000000000000000000000000000000000000099';
             payment = Payment.from(modifiedPayload, stubbedWallet);
         });
@@ -597,7 +545,7 @@ describe('Payment', () => {
         let payment, modifiedPayload;
 
         beforeEach(async () => {
-            modifiedPayload = await createSignedPayload(createUnsignedPayload(senderRef));
+            modifiedPayload = await fixture.createSignedPayment(fixture.createUnsignedPayment(senderRef));
             modifiedPayload.seals.wallet.signature = '0xffff9e389115e663107162f9049da8ed06670a53dd6b3bb77165940b6a55eba3156f788625446d6e553dd448608445f122803556c015559b32cf66d781e7d85b18';
             payment = Payment.from(modifiedPayload, stubbedWallet);
         });

--- a/lib/payment.spec.js
+++ b/lib/payment.spec.js
@@ -58,6 +58,7 @@ chai.use(_chai => {
 
 describe('Payment', () => {
     const senderRef = 'c3cc73cc-756a-11e9-957c-705ab6aee958';
+    const uuidRegexp = /^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i;
     let fixture;
 
     beforeEach(function() {
@@ -65,7 +66,10 @@ describe('Payment', () => {
             senderPrivateKey: '3a1076bf45ab87712ad64ccb3b10217737f7faacbf2872e88fdd9a537d8fe266',
             recipient: '0x0000000000000000000000000000000000000003',
             operatorPrivateKey: '252c772d9e9d570c726473927c52f23227cc674b6567935287d3f4a76a57d352',
-            currency: {ct: '0x0000000000000000000000000000000000000001', id: '0'},
+            currency: {
+                ct: '0x0000000000000000000000000000000000000001',
+                id: '0'
+            },
             amount: '1000'
         });
     });
@@ -119,7 +123,7 @@ describe('Payment', () => {
             });
 
             it('has an UUID as sender ref', function() {
-                expect(payment.senderRef).to.match(/^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i);
+                expect(payment.senderRef).to.match(uuidRegexp);
             });
 
             it('has sender data in JSON that is base64 encoding of sender ref', function() {
@@ -165,7 +169,7 @@ describe('Payment', () => {
             });
 
             it('has an UUID as sender ref', function() {
-                expect(payment.senderRef).to.match(/^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i);
+                expect(payment.senderRef).to.match(uuidRegexp);
             });
 
             it('has sender data in JSON that is base64 encoding of sender ref', function() {
@@ -217,7 +221,7 @@ describe('Payment', () => {
             });
 
             it('has an UUID as sender ref', function() {
-                expect(payment.senderRef).to.match(/^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i);
+                expect(payment.senderRef).to.match(uuidRegexp);
             });
 
             it('has sender data in JSON that is base64 encoding of sender ref', function() {
@@ -262,7 +266,7 @@ describe('Payment', () => {
             });
 
             it('has an UUID as sender ref', function() {
-                expect(payment.senderRef).to.match(/^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i);
+                expect(payment.senderRef).to.match(uuidRegexp);
             });
 
             it('has sender data in JSON that is base64 encoding of sender ref', function() {
@@ -316,7 +320,7 @@ describe('Payment', () => {
             });
 
             it('has an UUID as sender ref', function() {
-                expect(payment.senderRef).to.match(/^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i);
+                expect(payment.senderRef).to.match(uuidRegexp);
             });
 
             it('has sender data in JSON that is base64 encoding of sender ref', function() {
@@ -368,7 +372,7 @@ describe('Payment', () => {
             });
 
             it('has an UUID as sender ref', function() {
-                expect(payment.senderRef).to.match(/^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i);
+                expect(payment.senderRef).to.match(uuidRegexp);
             });
 
             it('has sender data in JSON that is base64 encoding of sender ref', function() {
@@ -413,7 +417,7 @@ describe('Payment', () => {
             });
 
             it('has an UUID as sender ref', function() {
-                expect(payment.senderRef).to.match(/^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i);
+                expect(payment.senderRef).to.match(uuidRegexp);
             });
 
             it('has sender data in JSON that is base64 encoding of sender ref', function() {
@@ -470,7 +474,7 @@ describe('Payment', () => {
             });
 
             it('has an UUID as sender ref', function() {
-                expect(payment.senderRef).to.match(/^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i);
+                expect(payment.senderRef).to.match(uuidRegexp);
             });
 
             it('has sender data in JSON that is base64 encoding of sender ref', function() {
@@ -525,7 +529,7 @@ describe('Payment', () => {
             });
 
             it('has an UUID as sender ref', function() {
-                expect(payment.senderRef).to.match(/^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i);
+                expect(payment.senderRef).to.match(uuidRegexp);
             });
 
             it('has sender data in JSON that is base64 encoding of sender ref', function() {
@@ -572,7 +576,7 @@ describe('Payment', () => {
             });
 
             it('has an UUID as sender ref', function() {
-                expect(payment.senderRef).to.match(/^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i);
+                expect(payment.senderRef).to.match(uuidRegexp);
             });
 
             it('has sender data in JSON that is base64 encoding of sender ref', function() {
@@ -605,7 +609,7 @@ describe('Payment', () => {
         });
 
         it('has an UUID as sender ref', function() {
-            expect(payment.senderRef).to.match(/^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i);
+            expect(payment.senderRef).to.match(uuidRegexp);
         });
 
         it('has sender data in JSON that is base64 encoding of sender ref', function() {

--- a/lib/payment.spec.js
+++ b/lib/payment.spec.js
@@ -9,8 +9,9 @@ chai.use(sinonChai);
 
 const MonetaryAmount = require('./monetary-amount');
 
+const ethers = require('ethers');
 const {privateToAddress} = require('ethereumjs-util');
-const {hash, prefix0x} = require('./utils');
+const {hash, prefix0x, fromRpcSig} = require('./utils');
 
 const Wallet = proxyquire('./wallet/wallet', {
     './client-fund-contract': function() {
@@ -66,9 +67,9 @@ describe('Payment', () => {
     const recipient = '0x0000000000000000000000000000000000000003';
     const privateKey = '3a1076bf45ab87712ad64ccb3b10217737f7faacbf2872e88fdd9a537d8fe266';
     const sender = prefix0x(privateToAddress(Buffer.from(privateKey, 'hex')).toString('hex'));
-    let unsignedPayload, signedPayload;
+    const senderRef = 'c3cc73cc-756a-11e9-957c-705ab6aee958';
 
-    const hashPaymentAsWallet = payload => {
+    function hashPayment(payload) {
         const amountCurrencyHash = hash(
             payload.amount,
             payload.currency.ct,
@@ -76,41 +77,51 @@ describe('Payment', () => {
         );
         const senderHash = hash(
             payload.sender.wallet,
-            payload.sender.data,
+            payload.sender.data
         );
         const recipientHash = hash(
             payload.recipient.wallet
         );
 
         return hash(amountCurrencyHash, senderHash, recipientHash);
-    };
+    }
 
-    beforeEach(() => {
-        unsignedPayload = {
+    async function signHash(hash) {
+        const senderWallet = new Wallet(privateKey);
+        const rpcSignature = await senderWallet.signMessage(ethers.utils.arrayify(hash));
+        return fromRpcSig(rpcSignature);
+    }
+
+    function createUnsignedPayload(senderRef) {
+        const senderData = Buffer
+            .from(JSON.stringify({ref: senderRef}))
+            .toString('base64');
+
+        return {
             amount,
             currency,
             sender: {
                 wallet: sender,
-                data: 'data'
+                data: senderData
             },
             recipient: {
                 wallet: recipient
             }
         };
-        signedPayload = {
+    }
+
+    async function createSignedPayload(unsignedPayload) {
+        const signedPayload = {
             ...unsignedPayload,
             seals: {
                 wallet: {
-                    hash: hashPaymentAsWallet(unsignedPayload),
-                    signature: {
-                        r: '0x72e01a17545dfdd2cd5c7f34d7459f71579aad968cec0026fe34d1ae59168346',
-                        s: '0x767ac6c2d6e02bd092689c202e2f4935ca5779ac6e5c183f0e0d7095e01b1702',
-                        v: 27
-                    }
+                    hash: hashPayment(unsignedPayload)
                 }
             }
         };
-    });
+        signedPayload.seals.wallet.signature = await signHash(signedPayload.seals.wallet.hash);
+        return signedPayload;
+    }
 
     afterEach(() => {
         stubbedProvider.registerPayment.reset();
@@ -131,12 +142,12 @@ describe('Payment', () => {
             });
 
             it('can be serialized to an object literal', () => {
-                expect(payment.toJSON()).to.eql(unsignedPayload);
+                expect(payment.toJSON()).to.eql(createUnsignedPayload(payment.senderRef));
             });
 
             it('can be signed', async () => {
                 await payment.sign();
-                expect(payment.toJSON()).to.eql(signedPayload);
+                expect(payment.toJSON()).to.eql(await createSignedPayload(createUnsignedPayload(payment.senderRef)));
             });
 
             it('can be registered with the API', () => {
@@ -159,23 +170,35 @@ describe('Payment', () => {
             it('does not have a valid signature', () => {
                 expect(payment.isSigned()).to.be.false;
             });
+
+            it('has an UUID as sender ref', function() {
+                expect(payment.senderRef).to.match(/^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i);
+            });
+
+            it('has sender data in JSON that is base64 encoding of sender ref', function() {
+                const expectedData = Buffer
+                    .from(JSON.stringify({ref: payment.senderRef}))
+                    .toString('base64');
+                expect(payment.toJSON().sender.data).to.eql(expectedData);
+            });
         });
 
         context('a signed Payment', () => {
-            let payment;
+            let payment, expectedSignedPayload;
 
             beforeEach(async () => {
                 payment = Payment.from(unsignedPayload, wallet);
                 await payment.sign();
+                expectedSignedPayload = await createSignedPayload(createUnsignedPayload(payment.senderRef));
             });
 
             it('can be serialized to an object literal', () => {
-                expect(payment.toJSON()).to.eql(signedPayload);
+                expect(payment.toJSON()).to.eql(expectedSignedPayload);
             });
 
             it('can be registered with the API', () => {
                 payment.register();
-                expect(stubbedProvider.registerPayment).to.have.been.calledWith(signedPayload);
+                expect(stubbedProvider.registerPayment).to.have.been.calledWith(expectedSignedPayload);
             });
 
             it('has the supplied amount', () => {
@@ -196,28 +219,31 @@ describe('Payment', () => {
         });
 
         context('a de-serialized unsigned Payment', () => {
-            let payment;
+            let payment, expectedSignedPayload;
 
-            beforeEach(() => {
-                payment = Payment.from(unsignedPayload, wallet);
+            beforeEach(async () => {
+                payment = Payment.from(createUnsignedPayload(senderRef), wallet);
+                expectedSignedPayload = await createSignedPayload(createUnsignedPayload(payment.senderRef));
             });
 
             it('can be serialized to a new object literal', () => {
-                expect(payment.toJSON()).to.eql(unsignedPayload);
+                expect(payment.toJSON()).to.eql(createUnsignedPayload(payment.senderRef));
             });
 
             it('can be signed', async () => {
                 await payment.sign();
-                expect(payment.toJSON()).to.eql(signedPayload);
+                expect(payment.toJSON()).to.eql(expectedSignedPayload);
             });
 
             it('can be registered with the API', () => {
                 payment.register();
-                expect(stubbedProvider.registerPayment).to.have.been.calledWith(unsignedPayload);
+                expect(stubbedProvider.registerPayment)
+                    .to.have.been.calledWith(createUnsignedPayload(payment.senderRef));
             });
 
             it('has the supplied amount', () => {
-                expect(payment.amount).to.be.equalMoney(MonetaryAmount.from(amount, currency.ct, currency.id));
+                expect(payment.amount)
+                    .to.be.equalMoney(MonetaryAmount.from(amount, currency.ct, currency.id));
             });
 
             it('has the supplied sender', () => {
@@ -234,9 +260,10 @@ describe('Payment', () => {
         });
 
         context('a de-serialized signed Payment', () => {
-            let payment;
+            let payment, signedPayload;
 
-            beforeEach(() => {
+            beforeEach(async () => {
+                signedPayload = await createSignedPayload(createUnsignedPayload('c3cc73cc-756a-11e9-957c-705ab6aee958'));
                 payment = Payment.from(signedPayload, wallet);
             });
 
@@ -276,7 +303,7 @@ describe('Payment', () => {
             });
 
             it('can be serialized to an object literal', () => {
-                expect(payment.toJSON()).to.eql(unsignedPayload);
+                expect(payment.toJSON()).to.eql(createUnsignedPayload(payment.senderRef));
             });
 
             it('can not be signed', (done) => {
@@ -313,11 +340,11 @@ describe('Payment', () => {
             let payment;
 
             beforeEach(() => {
-                payment = Payment.from(unsignedPayload, stubbedProvider);
+                payment = Payment.from(createUnsignedPayload(senderRef), stubbedProvider);
             });
 
             it('can be serialized to a new object literal', () => {
-                expect(payment.toJSON()).to.eql(unsignedPayload);
+                expect(payment.toJSON()).to.eql(createUnsignedPayload(senderRef));
             });
 
             it('can not be signed', (done) => {
@@ -330,7 +357,7 @@ describe('Payment', () => {
 
             it('can be registered with the API', () => {
                 payment.register();
-                expect(stubbedProvider.registerPayment).to.have.been.calledWith(unsignedPayload);
+                expect(stubbedProvider.registerPayment).to.have.been.calledWith(createUnsignedPayload(senderRef));
             });
 
             it('has the supplied amount', () => {
@@ -351,9 +378,10 @@ describe('Payment', () => {
         });
 
         context('a de-serialized signed Payment', () => {
-            let payment;
+            let payment, signedPayload;
 
-            beforeEach(() => {
+            beforeEach(async () => {
+                signedPayload = await createSignedPayload(createUnsignedPayload(senderRef));
                 payment = Payment.from(signedPayload, stubbedProvider);
             });
 
@@ -393,7 +421,7 @@ describe('Payment', () => {
             });
 
             it('can be serialized to an object literal', () => {
-                expect(payment.toJSON()).to.eql(unsignedPayload);
+                expect(payment.toJSON()).to.eql(createUnsignedPayload(payment.senderRef));
             });
 
             it('can not be signed', (done) => {
@@ -433,11 +461,11 @@ describe('Payment', () => {
             let payment;
 
             beforeEach(() => {
-                payment = Payment.from(unsignedPayload);
+                payment = Payment.from(createUnsignedPayload(senderRef));
             });
 
             it('can be serialized to a new object literal', () => {
-                expect(payment.toJSON()).to.eql(unsignedPayload);
+                expect(payment.toJSON()).to.eql(createUnsignedPayload(senderRef));
             });
 
             it('can not be signed', (done) => {
@@ -476,12 +504,12 @@ describe('Payment', () => {
         context('a de-serialized signed Payment', () => {
             let payment;
 
-            beforeEach(() => {
-                payment = Payment.from(signedPayload);
+            beforeEach(async () => {
+                payment = Payment.from(await createSignedPayload(createUnsignedPayload(senderRef)));
             });
 
-            it('can be serialized to a new object literal', () => {
-                expect(payment.toJSON()).to.eql(signedPayload);
+            it('can be serialized to a new object literal', async () => {
+                expect(payment.toJSON()).to.eql(await createSignedPayload(createUnsignedPayload(senderRef)));
             });
 
             it('can not be registered with the API', (done) => {
@@ -532,8 +560,8 @@ describe('Payment', () => {
     context('a de-serialized signed Payment that has been tampered with (amount)', () => {
         let payment, modifiedPayload;
 
-        beforeEach(() => {
-            modifiedPayload = {...signedPayload};
+        beforeEach(async () => {
+            modifiedPayload = await createSignedPayload(createUnsignedPayload(senderRef));
             modifiedPayload.amount = '999999';
             payment = Payment.from(modifiedPayload, stubbedWallet);
         });
@@ -550,8 +578,8 @@ describe('Payment', () => {
     context('a de-serialized signed Payment that has been tampered with (sender)', () => {
         let payment, modifiedPayload;
 
-        beforeEach(() => {
-            modifiedPayload = {...signedPayload};
+        beforeEach(async () => {
+            modifiedPayload = await createSignedPayload(createUnsignedPayload(senderRef));
             modifiedPayload.sender.wallet = '0x0000000000000000000000000000000000000099';
             payment = Payment.from(modifiedPayload, stubbedWallet);
         });
@@ -568,8 +596,8 @@ describe('Payment', () => {
     context('a de-serialized incorrectly signed Payment', () => {
         let payment, modifiedPayload;
 
-        beforeEach(() => {
-            modifiedPayload = {...signedPayload};
+        beforeEach(async () => {
+            modifiedPayload = await createSignedPayload(createUnsignedPayload(senderRef));
             modifiedPayload.seals.wallet.signature = '0xffff9e389115e663107162f9049da8ed06670a53dd6b3bb77165940b6a55eba3156f788625446d6e553dd448608445f122803556c015559b32cf66d781e7d85b18';
             payment = Payment.from(modifiedPayload, stubbedWallet);
         });

--- a/lib/payment.spec.js
+++ b/lib/payment.spec.js
@@ -163,6 +163,17 @@ describe('Payment', () => {
             it('has a valid signature', () => {
                 expect(payment.isSigned()).to.be.true;
             });
+
+            it('has an UUID as sender ref', function() {
+                expect(payment.senderRef).to.match(/^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i);
+            });
+
+            it('has sender data in JSON that is base64 encoding of sender ref', function() {
+                const expectedData = Buffer
+                    .from(JSON.stringify({ref: payment.senderRef}))
+                    .toString('base64');
+                expect(payment.toJSON().sender.data).to.eql(expectedData);
+            });
         });
 
         context('a de-serialized unsigned Payment', () => {
@@ -204,6 +215,17 @@ describe('Payment', () => {
             it('does not have a valid signature', () => {
                 expect(payment.isSigned()).to.be.false;
             });
+
+            it('has an UUID as sender ref', function() {
+                expect(payment.senderRef).to.match(/^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i);
+            });
+
+            it('has sender data in JSON that is base64 encoding of sender ref', function() {
+                const expectedData = Buffer
+                    .from(JSON.stringify({ref: payment.senderRef}))
+                    .toString('base64');
+                expect(payment.toJSON().sender.data).to.eql(expectedData);
+            });
         });
 
         context('a de-serialized signed Payment', () => {
@@ -237,6 +259,17 @@ describe('Payment', () => {
 
             it('has a valid signature', () => {
                 expect(payment.isSigned()).to.be.true;
+            });
+
+            it('has an UUID as sender ref', function() {
+                expect(payment.senderRef).to.match(/^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i);
+            });
+
+            it('has sender data in JSON that is base64 encoding of sender ref', function() {
+                const expectedData = Buffer
+                    .from(JSON.stringify({ref: payment.senderRef}))
+                    .toString('base64');
+                expect(payment.toJSON().sender.data).to.eql(expectedData);
             });
         });
     });
@@ -281,6 +314,17 @@ describe('Payment', () => {
             it('does not have a valid signature', () => {
                 expect(payment.isSigned()).to.be.false;
             });
+
+            it('has an UUID as sender ref', function() {
+                expect(payment.senderRef).to.match(/^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i);
+            });
+
+            it('has sender data in JSON that is base64 encoding of sender ref', function() {
+                const expectedData = Buffer
+                    .from(JSON.stringify({ref: payment.senderRef}))
+                    .toString('base64');
+                expect(payment.toJSON().sender.data).to.eql(expectedData);
+            });
         });
 
         context('a de-serialized unsigned Payment', () => {
@@ -322,6 +366,17 @@ describe('Payment', () => {
             it('does not have a valid signature', () => {
                 expect(payment.isSigned()).to.be.false;
             });
+
+            it('has an UUID as sender ref', function() {
+                expect(payment.senderRef).to.match(/^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i);
+            });
+
+            it('has sender data in JSON that is base64 encoding of sender ref', function() {
+                const expectedData = Buffer
+                    .from(JSON.stringify({ref: payment.senderRef}))
+                    .toString('base64');
+                expect(payment.toJSON().sender.data).to.eql(expectedData);
+            });
         });
 
         context('a de-serialized signed Payment', () => {
@@ -355,6 +410,17 @@ describe('Payment', () => {
 
             it('has a valid signature', () => {
                 expect(payment.isSigned()).to.be.true;
+            });
+
+            it('has an UUID as sender ref', function() {
+                expect(payment.senderRef).to.match(/^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i);
+            });
+
+            it('has sender data in JSON that is base64 encoding of sender ref', function() {
+                const expectedData = Buffer
+                    .from(JSON.stringify({ref: payment.senderRef}))
+                    .toString('base64');
+                expect(payment.toJSON().sender.data).to.eql(expectedData);
             });
         });
     });
@@ -402,6 +468,17 @@ describe('Payment', () => {
             it('does not have a valid signature', () => {
                 expect(payment.isSigned()).to.be.false;
             });
+
+            it('has an UUID as sender ref', function() {
+                expect(payment.senderRef).to.match(/^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i);
+            });
+
+            it('has sender data in JSON that is base64 encoding of sender ref', function() {
+                const expectedData = Buffer
+                    .from(JSON.stringify({ref: payment.senderRef}))
+                    .toString('base64');
+                expect(payment.toJSON().sender.data).to.eql(expectedData);
+            });
         });
 
         context('a de-serialized unsigned Payment', () => {
@@ -446,6 +523,17 @@ describe('Payment', () => {
             it('does not have a valid signature', () => {
                 expect(payment.isSigned()).to.be.false;
             });
+
+            it('has an UUID as sender ref', function() {
+                expect(payment.senderRef).to.match(/^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i);
+            });
+
+            it('has sender data in JSON that is base64 encoding of sender ref', function() {
+                const expectedData = Buffer
+                    .from(JSON.stringify({ref: payment.senderRef}))
+                    .toString('base64');
+                expect(payment.toJSON().sender.data).to.eql(expectedData);
+            });
         });
 
         context('a de-serialized signed Payment', () => {
@@ -482,6 +570,17 @@ describe('Payment', () => {
             it('has a valid signature', () => {
                 expect(payment.isSigned()).to.be.true;
             });
+
+            it('has an UUID as sender ref', function() {
+                expect(payment.senderRef).to.match(/^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i);
+            });
+
+            it('has sender data in JSON that is base64 encoding of sender ref', function() {
+                const expectedData = Buffer
+                    .from(JSON.stringify({ref: payment.senderRef}))
+                    .toString('base64');
+                expect(payment.toJSON().sender.data).to.eql(expectedData);
+            });
         });
     });
 
@@ -505,8 +604,15 @@ describe('Payment', () => {
             expect(payment.senderRef).to.not.eql(senderRef);
         });
 
-        it('has sender reference encoded in the sender data', () => {
-            expect(payment.toJSON().sender.data).to.eql(fixture.createUnsignedPayment(payment.senderRef).sender.data);
+        it('has an UUID as sender ref', function() {
+            expect(payment.senderRef).to.match(/^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i);
+        });
+
+        it('has sender data in JSON that is base64 encoding of sender ref', function() {
+            const expectedData = Buffer
+                .from(JSON.stringify({ref: payment.senderRef}))
+                .toString('base64');
+            expect(payment.toJSON().sender.data).to.eql(expectedData);
         });
     });
 

--- a/lib/receipt.spec.js
+++ b/lib/receipt.spec.js
@@ -111,6 +111,71 @@ describe('Receipt', () => {
         json.seals.wallet = paymentJSON.seals.wallet;
     }
 
+    function createUnsignedPayload(senderRef) {
+        const senderData = Buffer
+            .from(JSON.stringify({ref: senderRef}))
+            .toString('base64');
+
+        return {
+            amount,
+            currency,
+            seals: {},
+            nonce: 1,
+            blockNumber: 1,
+            operatorId: 1,
+            sender: {
+                nonce: 1,
+                wallet: sender,
+                data: senderData,
+                balances: {
+                    current: '0',
+                    previous: '100'
+                },
+                fees: {
+                    single: {
+                        currency,
+                        amount: '1000000000000000000'
+                    },
+                    total: [
+                        {
+                            originId: '1',
+                            figure: {
+                                currency,
+                                amount: '1000000000000000000'
+                            }
+                        }
+                    ]
+                }
+            },
+            recipient: {
+                nonce: 1,
+                wallet: recipient,
+                balances: {
+                    current: '100',
+                    previous: '0'
+                },
+                fees: {
+                    total: [
+                        {
+                            originId: '1',
+                            figure: {
+                                currency: {
+                                    ct: '0x0000000000000000000000000000000000000001',
+                                    id: '1'
+                                },
+                                amount: '1000000000000000000'
+                            }
+                        }
+                    ]
+                }
+            },
+            transfers: {
+                single: '100',
+                total: '100'
+            }
+        };
+    }
+
     beforeEach(async () => {
         unsignedPayload = {
             amount,
@@ -120,6 +185,7 @@ describe('Receipt', () => {
             sender: {
                 nonce: 1,
                 wallet: sender,
+                data: Buffer.from(JSON.stringify({ref: ''})).toString('base64'),
                 balances: {
                     current: '0',
                     previous: '100'

--- a/lib/receipt.spec.js
+++ b/lib/receipt.spec.js
@@ -346,8 +346,9 @@ describe('Receipt', () => {
         context('a de-serialized unsigned Receipt that has a null operator data', () => {
             let receipt;
     
-            beforeEach(() => {
-                const modifiedPayload = {...unsignedPayload, operator: {id: 0}};
+            beforeEach(async () => {
+                const modifiedPayload = await createUnsignedReceiptPayload();
+                modifiedPayload.operator.data = null;
                 receipt = Receipt.from(modifiedPayload, stubbedProvider);
             });
             
@@ -607,7 +608,7 @@ describe('Receipt', () => {
 
         it('has an operator ID', async () => {
             const payload = await createUnsignedReceiptPayload();
-            expect(receipt.operatorId).to.eql(payload.operatorId);
+            expect(receipt.operatorId).to.eql(payload.operator.id);
         });
 
         it('has a sender nonce', async () => {

--- a/lib/receipt.spec.js
+++ b/lib/receipt.spec.js
@@ -9,16 +9,7 @@ const expect = chai.expect;
 chai.use(sinonChai);
 chai.use(chaiAsPromised);
 
-const {privateToAddress} = require('ethereumjs-util');
-const {hash, prefix0x} = require('./utils');
-
-const amount = '1000';
-const currency = {ct: '0x0000000000000000000000000000000000000001', id: '0'};
-const recipient = '0x0000000000000000000000000000000000000003';
-const senderKey = '3a1076bf45ab87712ad64ccb3b10217737f7faacbf2872e88fdd9a537d8fe266';
-const sender = prefix0x(privateToAddress(Buffer.from(senderKey, 'hex')).toString('hex'));
-const operatorKey = '252c772d9e9d570c726473927c52f23227cc674b6567935287d3f4a76a57d352';
-const operatorAddress = prefix0x(privateToAddress(Buffer.from(operatorKey, 'hex')).toString('hex'));
+const {ApiPayloadFactory} = require('../test-utils');
 
 const Wallet = proxyquire('./wallet/wallet', {
     './client-fund-contract': function() {
@@ -41,219 +32,36 @@ const Receipt = proxyquire('./receipt', {
     './payment': Payment
 });
 
-const stubbedProvider = {
-    operatorAddress,
-    effectuatePayment: sinon.stub()
-};
-
 
 describe('Receipt', () => {
-    let signedPayload, unsignedPayload, receipt;
+    let receipt, fixture, stubbedProvider;
+    const senderRef = '3f527f36-76e3-11e9-bcfb-705ab6aee958';
 
-    function hashFeesTotal(totalFigures) {
-        let feesTotalHash = 0;
-        for (let i = 0; i < totalFigures.length; i++) {
-            feesTotalHash = hash(
-                feesTotalHash,
-                totalFigures[i].originId,
-                totalFigures[i].figure.amount,
-                totalFigures[i].figure.currency.ct,
-                totalFigures[i].figure.currency.id
-            );
-        }
-        return feesTotalHash;
+    async function createUnsignedReceiptPayload() {
+        return fixture.createUnsignedReceipt(
+            await fixture.createSignedPayment(
+                fixture.createUnsignedPayment(senderRef)
+            )
+        );
     }
 
-    function hashPaymentAsOperator(payment) {
-        const walletSignatureHash = hash(
-            {type: 'uint8', value: payment.seals.wallet.signature.v},
-            payment.seals.wallet.signature.r,
-            payment.seals.wallet.signature.s
+    async function createSignedReceiptPayload() {
+        return fixture.createSignedReceipt(
+            await createUnsignedReceiptPayload()
         );
-
-        const senderHash = hash(
-            hash(payment.sender.nonce),
-            hash(
-                payment.sender.balances.current,
-                payment.sender.balances.previous
-            ),
-            hash(
-                payment.sender.fees.single.amount,
-                payment.sender.fees.single.currency.ct,
-                payment.sender.fees.single.currency.id,
-            ),
-            hashFeesTotal(payment.sender.fees.total)
-        );
-
-        const recipientHash = hash(
-            hash(payment.recipient.nonce),
-            hash(
-                payment.recipient.balances.current,
-                payment.recipient.balances.previous
-            ),
-            hashFeesTotal(payment.recipient.fees.total)
-        );
-        const transfersHash = hash(
-            payment.transfers.single,
-            payment.transfers.total
-        );
-        const operatorHash = hash(
-            payment.operator.data
-        );
-        return hash(walletSignatureHash, senderHash, recipientHash, transfersHash, operatorHash);
     }
 
-    async function signPaymentAsWallet(json) {
-        const senderWallet = new Wallet(senderKey);
-        const payment = Payment.from(json, senderWallet);
-        await payment.sign();
-        const paymentJSON = payment.toJSON();
-        json.seals.wallet = paymentJSON.seals.wallet;
-    }
-
-    function createUnsignedPayload(senderRef) {
-        const senderData = Buffer
-            .from(JSON.stringify({ref: senderRef}))
-            .toString('base64');
-
-        return {
-            amount,
-            currency,
-            seals: {},
-            nonce: 1,
-            blockNumber: 1,
-            operatorId: 1,
-            sender: {
-                nonce: 1,
-                wallet: sender,
-                data: senderData,
-                balances: {
-                    current: '0',
-                    previous: '100'
-                },
-                fees: {
-                    single: {
-                        currency,
-                        amount: '1000000000000000000'
-                    },
-                    total: [
-                        {
-                            originId: '1',
-                            figure: {
-                                currency,
-                                amount: '1000000000000000000'
-                            }
-                        }
-                    ]
-                }
-            },
-            recipient: {
-                nonce: 1,
-                wallet: recipient,
-                balances: {
-                    current: '100',
-                    previous: '0'
-                },
-                fees: {
-                    total: [
-                        {
-                            originId: '1',
-                            figure: {
-                                currency: {
-                                    ct: '0x0000000000000000000000000000000000000001',
-                                    id: '1'
-                                },
-                                amount: '1000000000000000000'
-                            }
-                        }
-                    ]
-                }
-            },
-            transfers: {
-                single: '100',
-                total: '100'
-            }
-        };
-    }
-
-    beforeEach(async () => {
-        unsignedPayload = {
-            amount,
-            currency,
-            seals: {},
-            blockNumber: 1,
-            sender: {
-                nonce: 1,
-                wallet: sender,
-                data: Buffer.from(JSON.stringify({ref: ''})).toString('base64'),
-                balances: {
-                    current: '0',
-                    previous: '100'
-                },
-                fees: {
-                    single: {
-                        currency,
-                        amount: '1000000000000000000'
-                    },
-                    total: [
-                        {
-                            originId: '1',
-                            figure: {
-                                currency,
-                                amount: '1000000000000000000'
-                            }
-                        }
-                    ]
-                },
-                data: 'data'
-            },
-            recipient: {
-                nonce: 1,
-                wallet: recipient,
-                balances: {
-                    current: '100',
-                    previous: '0'
-                },
-                fees: {
-                    total: [
-                        {
-                            originId: '1',
-                            figure: {
-                                currency: {
-                                    ct: '0x0000000000000000000000000000000000000001',
-                                    id: '1'
-                                },
-                                amount: '1000000000000000000'
-                            }
-                        }
-                    ]
-                }
-            },
-            transfers: {
-                single: '100',
-                total: '100'
-            },
-            operator: {
-                id: 0,
-                data: 'data'
-            }
-        };
-
-        await signPaymentAsWallet(unsignedPayload);
-
-        signedPayload = {
-            ...unsignedPayload,
-            seals: {
-                ...unsignedPayload.seals,
-                operator: {
-                    hash: hashPaymentAsOperator(unsignedPayload),
-                    signature: {
-                        r: '0x259d290b4366a9346c88297f2e73dc7c2eb5a0e4636faea2bd5b8d9165cd7af8',
-                        s: '0x1643ae02ad76af082ac6cc5f2936b62378d505197869f86f2331c3b78e84fa3a',
-                        v: 27
-                    }
-                }
-            }
+    beforeEach(function() {
+        fixture = new ApiPayloadFactory({
+            senderPrivateKey: '3a1076bf45ab87712ad64ccb3b10217737f7faacbf2872e88fdd9a537d8fe266',
+            recipient: '0x0000000000000000000000000000000000000003',
+            operatorPrivateKey: '252c772d9e9d570c726473927c52f23227cc674b6567935287d3f4a76a57d352',
+            currency: {ct: '0x0000000000000000000000000000000000000001', id: '0'},
+            amount: '1000'
+        });
+        stubbedProvider = {
+            operatorAddress: fixture.operator,
+            effectuatePayment: sinon.stub()
         };
     });
 
@@ -265,7 +73,7 @@ describe('Receipt', () => {
         let wallet;
 
         beforeEach(() => {
-            wallet = new Wallet(operatorKey, stubbedProvider);
+            wallet = new Wallet(fixture.operatorPrivateKey, stubbedProvider);
         });
 
         context('a new Receipt', () => {
@@ -303,10 +111,10 @@ describe('Receipt', () => {
                 payload => delete payload.sender.balances.current
             ].forEach(modifier => {
                 context('when ' + modifier.toString(), () => {
-                    it('can not be signed', () => {
-                        let modifiedPayload = {...unsignedPayload};
-                        modifier(modifiedPayload);
-                        let incompleteReceipt = Receipt.from(modifiedPayload, wallet);
+                    it('can not be signed', async () => {
+                        let payload = await createUnsignedReceiptPayload();
+                        modifier(payload);
+                        let incompleteReceipt = Receipt.from(payload, wallet);
                         expect(incompleteReceipt.sign()).to.be.rejected;
                     });
                 });
@@ -314,12 +122,12 @@ describe('Receipt', () => {
         });
 
         context('a de-serialized unsigned Receipt', () => {
-            beforeEach(() => {
-                receipt = Receipt.from(unsignedPayload, wallet);
+            beforeEach(async () => {
+                receipt = Receipt.from(await createUnsignedReceiptPayload(), wallet);
             });
 
-            it('can be serialized to a new object literal', () => {
-                expect(receipt.toJSON()).to.eql(unsignedPayload);
+            it('can be serialized to a new object literal', async () => {
+                expect(receipt.toJSON()).to.eql(await createUnsignedReceiptPayload());
             });
 
             it('can be registered with the API', () => {
@@ -333,7 +141,7 @@ describe('Receipt', () => {
 
             it('can be signed', async () => {
                 await receipt.sign();
-                expect(receipt.toJSON()).to.eql(signedPayload);
+                expect(receipt.toJSON()).to.eql(await createSignedReceiptPayload());
                 expect(receipt.isSigned()).to.eql(true);
             });
 
@@ -343,8 +151,8 @@ describe('Receipt', () => {
         context('a de-serialized signed Receipt that has no recipient fees', () => {
             let modifiedPayload;
 
-            beforeEach(() => {
-                modifiedPayload = {...signedPayload};
+            beforeEach(async () => {
+                modifiedPayload = await createSignedReceiptPayload();
                 modifiedPayload.recipient.fees = {total: []};
                 receipt = Receipt.from(modifiedPayload, wallet);
             });
@@ -371,13 +179,13 @@ describe('Receipt', () => {
         });
 
         context('a de-serialized signed Receipt', () => {
-            beforeEach(() => {
-                wallet = new Wallet(operatorKey, stubbedProvider);
-                receipt = Receipt.from(signedPayload, wallet);
+            beforeEach(async () => {
+                wallet = new Wallet(fixture.operatorPrivateKey, stubbedProvider);
+                receipt = Receipt.from(await createSignedReceiptPayload(), wallet);
             });
 
-            it('can be serialized to a new object literal', () => {
-                expect(receipt.toJSON()).to.eql(signedPayload);
+            it('can be serialized to a new object literal', async () => {
+                expect(receipt.toJSON()).to.eql(await createSignedReceiptPayload());
             });
 
             it('can be registered with the API', () => {
@@ -389,9 +197,9 @@ describe('Receipt', () => {
                 expect(receipt.isSigned()).to.be.true;
             });
 
-            it('can be signed', () => {
-                receipt.sign(operatorKey);
-                expect(receipt.toJSON()).to.eql(signedPayload);
+            it('can be signed', async () => {
+                receipt.sign(fixture.operatorPrivateKey);
+                expect(receipt.toJSON()).to.eql(await createSignedReceiptPayload());
             });
 
             validateAllReceiptProperties();
@@ -400,8 +208,8 @@ describe('Receipt', () => {
         context('a de-serialized signed Receipt that has been tampered with (sender)', () => {
             let modifiedPayload;
 
-            beforeEach(() => {
-                modifiedPayload = {...signedPayload};
+            beforeEach(async () => {
+                modifiedPayload = await createSignedReceiptPayload();
                 modifiedPayload.sender.wallet = '0';
                 receipt = Receipt.from(modifiedPayload, wallet);
             });
@@ -462,8 +270,8 @@ describe('Receipt', () => {
                 payload => delete payload.nonce
             ].forEach(modifier => {
                 context('when ' + modifier.toString(), () => {
-                    it('can not be signed', () => {
-                        let modifiedPayload = {...unsignedPayload};
+                    it('can not be signed', async () => {
+                        let modifiedPayload = await createUnsignedReceiptPayload();
                         modifier(modifiedPayload);
                         let incompleteReceipt = Receipt.from(modifiedPayload, stubbedProvider);
                         expect(incompleteReceipt.sign()).to.be.rejected;
@@ -473,12 +281,13 @@ describe('Receipt', () => {
         });
 
         context('a de-serialized unsigned Receipt', () => {
-            beforeEach(() => {
-                receipt = Receipt.from(unsignedPayload, stubbedProvider);
+            beforeEach(async () => {
+                const payload = await createUnsignedReceiptPayload();
+                receipt = Receipt.from(payload, stubbedProvider);
             });
 
-            it('can be serialized to a new object literal', () => {
-                expect(receipt.toJSON()).to.eql(unsignedPayload);
+            it('can be serialized to a new object literal', async () => {
+                expect(receipt.toJSON()).to.eql(await createUnsignedReceiptPayload());
             });
 
             it('can be registered with the API', () => {
@@ -504,8 +313,8 @@ describe('Receipt', () => {
         context('a de-serialized unsigned Receipt that has no fees', () => {
             let modifiedPayload;
 
-            beforeEach(() => {
-                modifiedPayload = {...unsignedPayload};
+            beforeEach(async () => {
+                modifiedPayload = await createUnsignedReceiptPayload();
                 modifiedPayload.recipient.fees = {total: []};
                 receipt = Receipt.from(modifiedPayload, stubbedProvider);
             });
@@ -548,12 +357,12 @@ describe('Receipt', () => {
         });
 
         context('a de-serialized signed Receipt', () => {
-            beforeEach(() => {
-                receipt = Receipt.from(signedPayload, stubbedProvider);
+            beforeEach(async () => {
+                receipt = Receipt.from(await createSignedReceiptPayload(), stubbedProvider);
             });
 
-            it('can be serialized to a new object literal', () => {
-                expect(receipt.toJSON()).to.eql(signedPayload);
+            it('can be serialized to a new object literal', async () => {
+                expect(receipt.toJSON()).to.eql(await createSignedReceiptPayload());
             });
 
             it('can be registered with the API', () => {
@@ -579,8 +388,8 @@ describe('Receipt', () => {
         context('a de-serialized signed Receipt that has been tampered with (sender)', () => {
             let modifiedPayload;
 
-            beforeEach(() => {
-                modifiedPayload = {...signedPayload};
+            beforeEach(async () => {
+                modifiedPayload = await createSignedReceiptPayload();
                 modifiedPayload.sender.wallet = '0';
                 receipt = Receipt.from(modifiedPayload, stubbedProvider);
             });
@@ -644,8 +453,8 @@ describe('Receipt', () => {
                 payload => delete payload.nonce
             ].forEach(modifier => {
                 context('when ' + modifier.toString(), () => {
-                    it('can not be signed', () => {
-                        let modifiedPayload = {...unsignedPayload};
+                    it('can not be signed', async () => {
+                        let modifiedPayload = await createUnsignedReceiptPayload();
                         modifier(modifiedPayload);
                         let incompleteReceipt = Receipt.from(modifiedPayload);
                         expect(incompleteReceipt.sign()).to.be.rejected;
@@ -655,12 +464,12 @@ describe('Receipt', () => {
         });
 
         context('a de-serialized unsigned Receipt', () => {
-            beforeEach(() => {
-                receipt = Receipt.from(unsignedPayload);
+            beforeEach(async () => {
+                receipt = Receipt.from(await createUnsignedReceiptPayload());
             });
 
-            it('can be serialized to a new object literal', () => {
-                expect(receipt.toJSON()).to.eql(unsignedPayload);
+            it('can be serialized to a new object literal', async () => {
+                expect(receipt.toJSON()).to.eql(await createUnsignedReceiptPayload());
             });
 
             it('can not be registered with the API', (done) => {
@@ -689,8 +498,8 @@ describe('Receipt', () => {
         context('a de-serialized unsigned Receipt that has no fees', () => {
             let modifiedPayload;
 
-            beforeEach(() => {
-                modifiedPayload = {...unsignedPayload};
+            beforeEach(async () => {
+                modifiedPayload = await createUnsignedReceiptPayload();
                 modifiedPayload.recipient.fees = {total: []};
                 receipt = Receipt.from(modifiedPayload);
             });
@@ -723,12 +532,12 @@ describe('Receipt', () => {
         });
 
         context('a de-serialized signed Receipt', () => {
-            beforeEach(() => {
-                receipt = Receipt.from(signedPayload);
+            beforeEach(async () => {
+                receipt = Receipt.from(await createSignedReceiptPayload());
             });
 
-            it('can be serialized to a new object literal', () => {
-                expect(receipt.toJSON()).to.eql(signedPayload);
+            it('can be serialized to a new object literal', async () => {
+                expect(receipt.toJSON()).to.eql(await createSignedReceiptPayload());
             });
 
             it('can not be registered with the API', (done) => {
@@ -757,8 +566,8 @@ describe('Receipt', () => {
         context('a de-serialized signed Receipt that has been tampered with (sender)', () => {
             let modifiedPayload;
 
-            beforeEach(() => {
-                modifiedPayload = {...signedPayload};
+            beforeEach(async () => {
+                modifiedPayload = await createSignedReceiptPayload();
                 modifiedPayload.sender.wallet = '0';
                 receipt = Receipt.from(modifiedPayload);
             });
@@ -791,28 +600,34 @@ describe('Receipt', () => {
             expect(receipt.payment.isSigned()).to.be.true;
         });
 
-        it('has a block number', () => {
-            expect(receipt.blockNumber).to.eql(unsignedPayload.blockNumber);
+        it('has a block number', async () => {
+            const payload = await createUnsignedReceiptPayload();
+            expect(receipt.blockNumber).to.eql(payload.blockNumber);
         });
 
-        it('has an operator ID', () => {
-            expect(receipt.operatorId).to.eql(unsignedPayload.operator.id);
+        it('has an operator ID', async () => {
+            const payload = await createUnsignedReceiptPayload();
+            expect(receipt.operatorId).to.eql(payload.operatorId);
         });
 
-        it('has a sender nonce', () => {
-            expect(receipt.senderNonce).to.eql(unsignedPayload.sender.nonce);
+        it('has a sender nonce', async () => {
+            const payload = await createUnsignedReceiptPayload();
+            expect(receipt.senderNonce).to.eql(payload.sender.nonce);
         });
 
-        it('has a recipient nonce', () => {
-            expect(receipt.recipientNonce).to.eql(unsignedPayload.recipient.nonce);
+        it('has a recipient nonce', async () => {
+            const payload = await createUnsignedReceiptPayload();
+            expect(receipt.recipientNonce).to.eql(payload.recipient.nonce);
         });
 
-        it('has a sender', function() {
-            expect(receipt.sender).to.eql(unsignedPayload.sender.wallet);
+        it('has a sender', async () => {
+            const payload = await createUnsignedReceiptPayload();
+            expect(receipt.sender).to.eql(payload.sender.wallet);
         });
 
-        it('has a recipient', () => {
-            expect(receipt.recipient).to.eql(unsignedPayload.recipient.wallet);
+        it('has a recipient', async () => {
+            const payload = await createUnsignedReceiptPayload();
+            expect(receipt.recipient).to.eql(payload.recipient.wallet);
         });
     }
 });

--- a/lib/receipt.spec.js
+++ b/lib/receipt.spec.js
@@ -56,7 +56,10 @@ describe('Receipt', () => {
             senderPrivateKey: '3a1076bf45ab87712ad64ccb3b10217737f7faacbf2872e88fdd9a537d8fe266',
             recipient: '0x0000000000000000000000000000000000000003',
             operatorPrivateKey: '252c772d9e9d570c726473927c52f23227cc674b6567935287d3f4a76a57d352',
-            currency: {ct: '0x0000000000000000000000000000000000000001', id: '0'},
+            currency: {
+                ct: '0x0000000000000000000000000000000000000001',
+                id: '0'
+            },
             amount: '1000'
         });
         stubbedProvider = {
@@ -345,13 +348,13 @@ describe('Receipt', () => {
 
         context('a de-serialized unsigned Receipt that has a null operator data', () => {
             let receipt;
-    
+
             beforeEach(async () => {
                 const modifiedPayload = await createUnsignedReceiptPayload();
                 modifiedPayload.operator.data = null;
                 receipt = Receipt.from(modifiedPayload, stubbedProvider);
             });
-            
+
             it('has empty string for the operator data', () => {
                 expect(receipt.toJSON().operator.data).to.equal('');
             });

--- a/lib/settlement/driip-settlement.spec.js
+++ b/lib/settlement/driip-settlement.spec.js
@@ -495,7 +495,10 @@ describe('Driip settlement operations', () => {
             nonce: 1,
             amount: '100',
             currency: {ct: address0, id: 0},
-            sender: {wallet: ''},
+            sender: {
+                wallet: '',
+                data: Buffer.from(JSON.stringify({ref: ''})).toString('base64')
+            },
             recipient: {wallet: ''},
             operator: {id: 0, data: 'data'}
         });

--- a/lib/settlement/driip-settlement.spec.js
+++ b/lib/settlement/driip-settlement.spec.js
@@ -8,6 +8,7 @@ chai.use(sinonChai);
 
 const proxyquire = require('proxyquire').noPreserveCache().noCallThru();
 const ethers = require('ethers');
+const {ApiPayloadFactory} = require('../../test-utils');
 const Receipt = require('../receipt');
 const MonetaryAmount = require('../monetary-amount');
 
@@ -151,7 +152,7 @@ describe('Driip settlement operations', () => {
     testTokens.forEach(t => {
         it(`can start payment challenge period for token ${t.symbol}`, async () => {
             const _receipt = Receipt.from({
-                ...receipt.toJSON(), 
+                ...receipt.toJSON(),
                 currency: {ct: testTokens[1].currency, id: 0}
             });
             const amount = '1.23';
@@ -403,7 +404,7 @@ describe('Driip settlement operations', () => {
             stubbedDriipSettlementContract.settlementByWalletAndNonce
                 .withArgs(address, nonce)
                 .resolves(expectedSettlement);
-    
+
             const details = await driipSettlement.getSettlementByNonce(address, nonce);
             expect(details).to.equal(expectedSettlement);
         });
@@ -434,9 +435,12 @@ describe('Driip settlement operations', () => {
     });
 
     describe('#checkStartChallengeFromPayment', () => {
-        const stageAmount = MonetaryAmount.from({amount: 1, currency: {ct: address0, id: address0id}});
+        const stageAmount = MonetaryAmount.from({
+            amount: 1,
+            currency: {ct: address0, id: address0id}
+        });
         const {currency} = stageAmount.toJSON();
-        
+
         it('should be valid to start new challenge', (done) => {
             stubbedDriipSettlementChallengeContract.proposalNonce
                 .rejects(new Error());
@@ -497,12 +501,15 @@ describe('Driip settlement operations', () => {
             currency: {ct: address0, id: 0},
             sender: {
                 wallet: '',
-                data: Buffer.from(JSON.stringify({ref: ''})).toString('base64')
+                data: ApiPayloadFactory.createSenderData('')
             },
             recipient: {wallet: ''},
             operator: {id: 0, data: 'data'}
         });
-        const stageAmount = MonetaryAmount.from({amount: 1, currency: {ct: address0, id: address0id}});
+        const stageAmount = MonetaryAmount.from({
+            amount: 1,
+            currency: {ct: address0, id: address0id}
+        });
         const {currency} = stageAmount.toJSON();
 
         it('should be valid to settle', async () => {

--- a/lib/settlement/settlement.spec.js
+++ b/lib/settlement/settlement.spec.js
@@ -110,7 +110,7 @@ describe('Settlement', () => {
             nonce: 2
         },
         operator: {
-            id: 0, 
+            id: 0,
             data: ''
         }
     };
@@ -155,10 +155,11 @@ describe('Settlement', () => {
                 .resolves([
                     {
                         sender: {
-                            wallet: mockReceipt.sender.wallet, nonce: mockReceipt.sender.nonce - 1
-                        }, 
+                            wallet: mockReceipt.sender.wallet,
+                            nonce: mockReceipt.sender.nonce - 1
+                        },
                         currency
-                    }, 
+                    },
                     mockReceipt
                 ]);
 
@@ -320,7 +321,10 @@ describe('Settlement', () => {
                 notAllowNewNullChallenge: true,
                 expect: {
                     requiredChallenges: [],
-                    invalidReasons: [{type: 'payment-driip', reasons: []}, {type: 'null', reasons: []}]
+                    invalidReasons: [{
+                        type: 'payment-driip',
+                        reasons: []
+                    }, {type: 'null', reasons: []}]
                 }
             }
         ].forEach(t => {
@@ -400,7 +404,10 @@ describe('Settlement', () => {
                 receipt: mockReceipt,
                 allow: [],
                 ongoingChallenges: [{type: 'null'}],
-                disallow: [{type: 'payment-driip', reasons: []}, {type: 'null', reasons: []}]
+                disallow: [{type: 'payment-driip', reasons: []}, {
+                    type: 'null',
+                    reasons: []
+                }]
             },
             {
                 null: {allow: true},
@@ -414,7 +421,10 @@ describe('Settlement', () => {
                 driip: {allow: false},
                 receipt: mockReceipt,
                 allow: [],
-                disallow: [{type: 'payment-driip', reasons: []}, {type: 'null', reasons: []}]
+                disallow: [{type: 'payment-driip', reasons: []}, {
+                    type: 'null',
+                    reasons: []
+                }]
             },
             {
                 null: {allow: true},
@@ -424,7 +434,7 @@ describe('Settlement', () => {
                 disallow: [{type: 'payment-driip', reasons: []}]
             }
         ].forEach(t => {
-            it(`should not allow new challenge when allowed driip challenge: ${t.driip.allow}, null challenge: ${t.null.allow}, provided receipt: ${t.receipt? true: false}`, async () => {
+            it(`should not allow new challenge when allowed driip challenge: ${t.driip.allow}, null challenge: ${t.null.allow}, provided receipt: ${t.receipt ? true : false}`, async () => {
                 const amountBN = ethers.utils.bigNumberify('100');
                 const amountAvailableBN = ethers.utils.bigNumberify('90');
                 const stageMonetaryAmount = MonetaryAmount.from(amountAvailableBN.toString(), currency.ct, currency.id);
@@ -438,7 +448,14 @@ describe('Settlement', () => {
                     .resolves({symbol: 'ETH', decimals: 18});
                 stubbedProvider.getNahmiiBalances
                     .withArgs(wallet.address)
-                    .resolves([{currency: {...currency, ct: currency.ct.toUpperCase()}, amount: amountBN.toString(), amountAvailable: amountAvailableBN.toString()}]);
+                    .resolves([{
+                        currency: {
+                            ...currency,
+                            ct: currency.ct.toUpperCase()
+                        },
+                        amount: amountBN.toString(),
+                        amountAvailable: amountAvailableBN.toString()
+                    }]);
 
                 settlement.getOngoingChallenges
                     .withArgs(wallet.address, currency.ct, currency.id)
@@ -469,7 +486,11 @@ describe('Settlement', () => {
                 .resolves({symbol: 'ETH', decimals: 18});
             stubbedProvider.getNahmiiBalances
                 .withArgs(wallet.address)
-                .resolves([{currency, amount: amountBN.toString(), amountAvailable: amountAvailableBN.toString()}]);
+                .resolves([{
+                    currency,
+                    amount: amountBN.toString(),
+                    amountAvailable: amountAvailableBN.toString()
+                }]);
 
             return settlement.checkStartChallenge(stageMonetaryAmount, null, wallet.address).catch(e => {
                 expect(e.innerError.message).to.match(/.*maximum.*allowable.*balance.*/i);
@@ -576,7 +597,10 @@ describe('Settlement', () => {
                 .resolves({valid: false, reasons: []});
             const {settleableChallenges, invalidReasons} = await settlement.getSettleableChallenges(mockReceipt.sender.wallet, currency.ct, currency.id);
             expect(settleableChallenges).to.deep.equal([]);
-            expect(invalidReasons).to.deep.equal([{type: 'payment-driip', reasons: []}, {type: 'null', reasons: []}]);
+            expect(invalidReasons).to.deep.equal([{
+                type: 'payment-driip',
+                reasons: []
+            }, {type: 'null', reasons: []}]);
         });
         it('should rethrow exception', () => {
             stubbedDriipSettlement.getCurrentProposalNonce
@@ -640,7 +664,7 @@ describe('Settlement', () => {
                 expect: []
             }
         ].forEach(t => {
-            it(`when driip expiration time is ${t.driipExpirationTime ? t.driipExpirationTime.toNumber() : null} and null expiration time is ${t.nullExpirationTime ? t.nullExpirationTime.toNumber(): null}`, async () => {
+            it(`when driip expiration time is ${t.driipExpirationTime ? t.driipExpirationTime.toNumber() : null} and null expiration time is ${t.nullExpirationTime ? t.nullExpirationTime.toNumber() : null}`, async () => {
                 stubbedDriipSettlement.getCurrentProposalExpirationTime
                     .withArgs(wallet.address, currency.ct, currency.id)
                     .resolves(t.driipExpirationTime);
@@ -687,23 +711,57 @@ describe('Settlement', () => {
                 .resolves([mockReceipt]);
             settlement.getRequiredChallengesForIntendedStageAmount
                 .withArgs(stageAmount, wallet.address)
-                .resolves({
-                    requiredChallenges: [
-                        {
-                            type: 'payment-driip',
-                            stageMonetaryAmount: stageAmount,
-                            receipt: mockReceipt
-                        }
-                    ]}
+                .resolves(
+                    {
+                        requiredChallenges: [
+                            {
+                                type: 'payment-driip',
+                                stageMonetaryAmount: stageAmount,
+                                receipt: mockReceipt
+                            }
+                        ]
+                    }
                 );
             stubbedDriipSettlement.startChallengeFromPayment
                 .withArgs(Receipt.from(mockReceipt, wallet), stageAmount, wallet)
                 .resolves(expectedTx);
 
             const txs = await settlement.startChallenge(stageAmount, wallet);
-            expect(JSON.parse(JSON.stringify(txs))).to.deep.equal([{tx: fakeTxReceipt, type: 'payment-driip', intendedStageAmount: stageAmount.toJSON()}]);
+            expect(JSON.parse(JSON.stringify(txs))).to.deep.equal([{
+                tx: fakeTxReceipt,
+                type: 'payment-driip',
+                intendedStageAmount: stageAmount.toJSON()
+            }]);
         });
         it('should start null settlement challenge', async () => {
+            const stageAmount = MonetaryAmount.from(mockReceipt.amount, currency.ct, currency.id);
+            stubbedProvider.getWalletReceipts
+                .withArgs(wallet.address, null, 100)
+                .resolves([mockReceipt]);
+            settlement.getRequiredChallengesForIntendedStageAmount
+                .withArgs(stageAmount, wallet.address)
+                .resolves(
+                    {
+                        requiredChallenges: [
+                            {
+                                type: 'null',
+                                stageMonetaryAmount: stageAmount
+                            }
+                        ]
+                    }
+                );
+            stubbedNullSettlement.startChallenge
+                .withArgs(wallet, stageAmount)
+                .resolves(expectedTx);
+
+            const txs = await settlement.startChallenge(stageAmount, wallet);
+            expect(JSON.parse(JSON.stringify(txs))).to.deep.equal([{
+                tx: fakeTxReceipt,
+                type: 'null',
+                intendedStageAmount: stageAmount.toJSON()
+            }]);
+        });
+        it('should start both null and driip settlement challenges', async () => {
             const stageAmount = MonetaryAmount.from(mockReceipt.amount, currency.ct, currency.id);
             stubbedProvider.getWalletReceipts
                 .withArgs(wallet.address, null, 100)
@@ -715,34 +773,14 @@ describe('Settlement', () => {
                         {
                             type: 'null',
                             stageMonetaryAmount: stageAmount
+                        },
+                        {
+                            type: 'payment-driip',
+                            stageMonetaryAmount: stageAmount,
+                            receipt: mockReceipt
                         }
-                    ]}
-                );
-            stubbedNullSettlement.startChallenge
-                .withArgs(wallet, stageAmount)
-                .resolves(expectedTx);
-
-            const txs = await settlement.startChallenge(stageAmount, wallet);
-            expect(JSON.parse(JSON.stringify(txs))).to.deep.equal([{tx: fakeTxReceipt, type: 'null', intendedStageAmount: stageAmount.toJSON()}]);
-        });
-        it('should start both null and driip settlement challenges', async () => {
-            const stageAmount = MonetaryAmount.from(mockReceipt.amount, currency.ct, currency.id);
-            stubbedProvider.getWalletReceipts
-                .withArgs(wallet.address, null, 100)
-                .resolves([mockReceipt]);
-            settlement.getRequiredChallengesForIntendedStageAmount
-                .withArgs(stageAmount, wallet.address)
-                .resolves({requiredChallenges: [
-                    {
-                        type: 'null',
-                        stageMonetaryAmount: stageAmount
-                    },
-                    {
-                        type: 'payment-driip',
-                        stageMonetaryAmount: stageAmount,
-                        receipt: mockReceipt
-                    }
-                ]});
+                    ]
+                });
             stubbedNullSettlement.startChallenge
                 .withArgs(wallet, stageAmount)
                 .resolves(expectedTx);
@@ -752,8 +790,16 @@ describe('Settlement', () => {
 
             const txs = await settlement.startChallenge(stageAmount, wallet);
             expect(JSON.parse(JSON.stringify(txs))).to.deep.equal([
-                {tx: fakeTxReceipt, type: 'null', intendedStageAmount: stageAmount.toJSON()},
-                {tx: fakeTxReceipt, type: 'payment-driip', intendedStageAmount: stageAmount.toJSON()}
+                {
+                    tx: fakeTxReceipt,
+                    type: 'null',
+                    intendedStageAmount: stageAmount.toJSON()
+                },
+                {
+                    tx: fakeTxReceipt,
+                    type: 'payment-driip',
+                    intendedStageAmount: stageAmount.toJSON()
+                }
             ]);
         });
         it('should not start any challenges when the conditions are not allowed', async () => {
@@ -772,13 +818,15 @@ describe('Settlement', () => {
                 .resolves([mockReceipt]);
             settlement.getRequiredChallengesForIntendedStageAmount
                 .withArgs(stageAmount, wallet.address)
-                .resolves({requiredChallenges: [
-                    {
-                        type: 'payment-driip',
-                        stageMonetaryAmount: stageAmount,
-                        receipt: mockReceipt
-                    }
-                ]});
+                .resolves({
+                    requiredChallenges: [
+                        {
+                            type: 'payment-driip',
+                            stageMonetaryAmount: stageAmount,
+                            receipt: mockReceipt
+                        }
+                    ]
+                });
             stubbedDriipSettlement.startChallengeFromPayment
                 .withArgs(Receipt.from(mockReceipt, wallet), stageAmount, wallet)
                 .resolves(expectedTx);
@@ -789,7 +837,7 @@ describe('Settlement', () => {
 
             return settlement.startChallenge(stageAmount, wallet).catch(e => {
                 expect(e).to.be.an.instanceOf(Error);
-                const regex = new RegExp( `sent.*payment.*failed.*${expectedTx.hash}`, 'i' );
+                const regex = new RegExp(`sent.*payment.*failed.*${expectedTx.hash}`, 'i');
                 expect(e.innerError.message).to.match(regex);
             });
         });
@@ -839,7 +887,10 @@ describe('Settlement', () => {
                 .resolves(expectedTx);
 
             const txs = await settlement.stopChallenges(wallet, currency.ct, currency.id);
-            expect(txs).to.deep.equal([{type: 'payment-driip', tx: fakeTxReceipt}, {type: 'null', tx: fakeTxReceipt}]);
+            expect(txs).to.deep.equal([{
+                type: 'payment-driip',
+                tx: fakeTxReceipt
+            }, {type: 'null', tx: fakeTxReceipt}]);
         });
         it('should handle exception thrown from #stopByOngoingChallenge', async () => {
             settlement.getOngoingChallenges
@@ -886,53 +937,67 @@ describe('Settlement', () => {
             const stageAmount = MonetaryAmount.from('1', currency.ct, currency.id);
             settlement.getSettleableChallenges
                 .withArgs(wallet.address, currency.ct, currency.id)
-                .resolves({settleableChallenges: [
-                    {
-                        type: 'payment-driip',
-                        receipt: mockReceipt,
-                        intendedStageAmount: stageAmount
-                    }
-                ]});
+                .resolves({
+                    settleableChallenges: [
+                        {
+                            type: 'payment-driip',
+                            receipt: mockReceipt,
+                            intendedStageAmount: stageAmount
+                        }
+                    ]
+                });
             stubbedDriipSettlement.settleDriipAsPayment
                 .withArgs(Receipt.from(mockReceipt, wallet), wallet)
                 .resolves(expectedTx);
 
             const txs = await settlement.settle(currency.ct, currency.id, wallet);
-            expect(JSON.parse(JSON.stringify(txs))).to.deep.equal([{tx: fakeTxReceipt, type: 'payment-driip', intendedStageAmount: stageAmount.toJSON()}]);
+            expect(JSON.parse(JSON.stringify(txs))).to.deep.equal([{
+                tx: fakeTxReceipt,
+                type: 'payment-driip',
+                intendedStageAmount: stageAmount.toJSON()
+            }]);
         });
         it('should settle a null', async () => {
             const stageAmount = MonetaryAmount.from('1', currency.ct, currency.id);
             settlement.getSettleableChallenges
                 .withArgs(wallet.address, currency.ct, currency.id)
-                .resolves({settleableChallenges: [
-                    {
-                        type: 'null',
-                        intendedStageAmount: stageAmount
-                    }
-                ]});
+                .resolves({
+                    settleableChallenges: [
+                        {
+                            type: 'null',
+                            intendedStageAmount: stageAmount
+                        }
+                    ]
+                });
             stubbedNullSettlement.settleNull
                 .withArgs(wallet, currency.ct, currency.id)
                 .resolves(expectedTx);
 
             const txs = await settlement.settle(currency.ct, currency.id, wallet);
-            expect(JSON.parse(JSON.stringify(txs))).to.deep.equal([{tx: fakeTxReceipt, type: 'null', intendedStageAmount: stageAmount.toJSON()}]);
+            expect(JSON.parse(JSON.stringify(txs))).to.deep.equal([{
+                tx: fakeTxReceipt,
+                type: 'null',
+                intendedStageAmount: stageAmount.toJSON()
+            }]);
         });
         it('should settle both a driip and a null', async () => {
             const stageAmountOne = MonetaryAmount.from('1', currency.ct, currency.id);
             const stageAmountTwo = MonetaryAmount.from('2', currency.ct, currency.id);
             settlement.getSettleableChallenges
                 .withArgs(wallet.address, currency.ct, currency.id)
-                .resolves({settleableChallenges: [
-                    {
-                        type: 'payment-driip',
-                        receipt: mockReceipt,
-                        intendedStageAmount: stageAmountOne
-                    },
-                    {
-                        type: 'null',
-                        intendedStageAmount: stageAmountTwo
-                    }
-                ]});
+                .resolves({
+                    settleableChallenges: [
+                        {
+                            type: 'payment-driip',
+                            receipt: mockReceipt,
+                            intendedStageAmount: stageAmountOne
+                        },
+                        {
+                            type: 'null',
+                            intendedStageAmount: stageAmountTwo
+                        }
+                    ]
+                });
             stubbedDriipSettlement.settleDriipAsPayment
                 .withArgs(Receipt.from(mockReceipt, wallet), wallet)
                 .resolves(expectedTx);
@@ -942,8 +1007,16 @@ describe('Settlement', () => {
 
             const txs = await settlement.settle(currency.ct, currency.id, wallet);
             expect(JSON.parse(JSON.stringify(txs))).to.deep.equal([
-                {tx: fakeTxReceipt, type: 'payment-driip', intendedStageAmount: stageAmountOne.toJSON()},
-                {tx: fakeTxReceipt, type: 'null', intendedStageAmount: stageAmountTwo.toJSON()}
+                {
+                    tx: fakeTxReceipt,
+                    type: 'payment-driip',
+                    intendedStageAmount: stageAmountOne.toJSON()
+                },
+                {
+                    tx: fakeTxReceipt,
+                    type: 'null',
+                    intendedStageAmount: stageAmountTwo.toJSON()
+                }
             ]);
         });
         it('should not settle if there are no settleable challenges', async () => {
@@ -958,13 +1031,15 @@ describe('Settlement', () => {
             const stageAmount = MonetaryAmount.from('1', currency.ct, currency.id);
             settlement.getSettleableChallenges
                 .withArgs(wallet.address, currency.ct, currency.id)
-                .resolves({settleableChallenges: [
-                    {
-                        type: 'payment-driip',
-                        receipt: mockReceipt,
-                        intendedStageAmount: stageAmount
-                    }
-                ]});
+                .resolves({
+                    settleableChallenges: [
+                        {
+                            type: 'payment-driip',
+                            receipt: mockReceipt,
+                            intendedStageAmount: stageAmount
+                        }
+                    ]
+                });
             stubbedDriipSettlement.settleDriipAsPayment
                 .withArgs(Receipt.from(mockReceipt, wallet), wallet)
                 .resolves(expectedTx);
@@ -974,7 +1049,7 @@ describe('Settlement', () => {
 
             return settlement.settle(currency.ct, currency.id, wallet).catch(e => {
                 expect(e).to.be.an.instanceOf(Error);
-                const regex = new RegExp( `sent.*payment.*failed.*${expectedTx.hash}`, 'i' );
+                const regex = new RegExp(`sent.*payment.*failed.*${expectedTx.hash}`, 'i');
                 expect(e.innerError.message).to.match(regex);
             });
         });

--- a/lib/settlement/settlement.spec.js
+++ b/lib/settlement/settlement.spec.js
@@ -100,7 +100,7 @@ describe('Settlement', () => {
                 current: 200
             },
             nonce: 1,
-            data: 'data'
+            data: ''
         },
         recipient: {
             wallet: '0x2',
@@ -111,7 +111,7 @@ describe('Settlement', () => {
         },
         operator: {
             id: 0, 
-            data: 'data'
+            data: ''
         }
     };
 
@@ -139,8 +139,8 @@ describe('Settlement', () => {
         stubbedProvider.getTransactionConfirmation.reset();
     });
 
-    describe('#getLatestReceiptForSettlement', () => {
-        it('should return latest receipt matching the currency', async () => {
+    describe('#getLatestReceiptForSettlement()', () => {
+        it('returns latest receipt matching the currency', async () => {
             stubbedProvider.getWalletReceipts
                 .withArgs(mockReceipt.sender.wallet, null, 100)
                 .resolves([mockReceipt, {nonce: 1, currency: {ct: '0x1'}}]);
@@ -149,7 +149,7 @@ describe('Settlement', () => {
             expect(latestReceipt).to.deep.equal(mockReceipt);
         });
 
-        it('should return latest receipt sorted by nonce in desc', async () => {
+        it('returns latest receipt sorted by nonce in desc', async () => {
             stubbedProvider.getWalletReceipts
                 .withArgs(mockReceipt.sender.wallet, null, 100)
                 .resolves([
@@ -166,7 +166,7 @@ describe('Settlement', () => {
             expect(latestReceipt).to.deep.equal(mockReceipt);
         });
 
-        it('should return null when returned no receipts', async () => {
+        it('returns null when returned no receipts', async () => {
             stubbedProvider.getWalletReceipts
                 .withArgs(mockReceipt.sender.wallet, null, 100)
                 .resolves([]);
@@ -175,7 +175,7 @@ describe('Settlement', () => {
             expect(latestReceipt).to.equal(null);
         });
 
-        it('should return null when no receipts matched the currency', async () => {
+        it('returns null when no receipts matched the currency', async () => {
             stubbedProvider.getWalletReceipts
                 .withArgs(mockReceipt.sender.wallet, null, 100)
                 .resolves([{currency: {ct: '0x1'}}, {currency: {ct: '0x2'}}]);
@@ -184,7 +184,7 @@ describe('Settlement', () => {
             expect(latestReceipt).to.equal(null);
         });
 
-        it('should rethrow exception', () => {
+        it('rethrows exception', () => {
             stubbedProvider.getWalletReceipts.rejects(new Error());
             return settlement.getLatestReceiptForSettlement().catch(e => {
                 expect(e).to.be.an.instanceOf(Error);
@@ -193,19 +193,22 @@ describe('Settlement', () => {
         });
     });
 
-    describe('#getRequiredChallengesForIntendedStageAmount', () => {
+    describe('#getRequiredChallengesForIntendedStageAmount()', () => {
         const stubs = {};
+
         beforeEach(() => {
             stubs.getLatestReceiptForSettlement = sinon.stub(settlement, 'getLatestReceiptForSettlement');
             stubs.checkStartChallenge = sinon.stub(settlement, 'checkStartChallenge');
         });
+
         afterEach(() => {
             settlement.checkStartChallenge.restore();
             settlement.getLatestReceiptForSettlement.restore();
         });
+
         [
             {
-                describe: 'should return driip settlement as an required challenge',
+                describe: 'returns driip settlement as an required challenge',
                 stageAmount: 100,
                 receipt: mockReceipt,
                 walletAddress: mockReceipt.sender.wallet,
@@ -221,7 +224,7 @@ describe('Settlement', () => {
                 }
             },
             {
-                describe: 'should return null settlement as an required challenge',
+                describe: 'returns null settlement as an required challenge',
                 stageAmount: 100,
                 receipt: null,
                 notAllowNewDriipChallenge: true,
@@ -237,7 +240,7 @@ describe('Settlement', () => {
                 }
             },
             {
-                describe: 'should return both null and driip settlements as required challenges for sender',
+                describe: 'returns both null and driip settlements as required challenges for sender',
                 stageAmount: 300,
                 receipt: mockReceipt,
                 walletAddress: mockReceipt.sender.wallet,
@@ -257,7 +260,7 @@ describe('Settlement', () => {
                 }
             },
             {
-                describe: 'should return both null and driip settlements as required challenges for recipient',
+                describe: 'returns both null and driip settlements as required challenges for recipient',
                 stageAmount: 300,
                 receipt: mockReceipt,
                 walletAddress: mockReceipt.recipient.wallet,
@@ -277,7 +280,7 @@ describe('Settlement', () => {
                 }
             },
             {
-                describe: 'should return null settlement if can not start driip challenge',
+                describe: 'returns null settlement if can not start driip challenge',
                 stageAmount: 300,
                 receipt: null,
                 walletAddress: mockReceipt.sender.wallet,
@@ -293,7 +296,7 @@ describe('Settlement', () => {
                 }
             },
             {
-                describe: 'should return driip settlement if can not start null challenge',
+                describe: 'returns driip settlement if can not start null challenge',
                 stageAmount: 300,
                 receipt: mockReceipt,
                 walletAddress: mockReceipt.sender.wallet,
@@ -310,7 +313,7 @@ describe('Settlement', () => {
                 }
             },
             {
-                describe: 'should return empty array if both settlement types are not allowed to start new challenges',
+                describe: 'returns empty array if both settlement types are not allowed to start new challenges',
                 stageAmount: 300,
                 receipt: mockReceipt,
                 walletAddress: mockReceipt.sender.wallet,
@@ -328,18 +331,14 @@ describe('Settlement', () => {
                 if (!t.notAllowNewDriipChallenge)
                     allowedChallenges.push('payment-driip');
 
-
                 if (!t.notAllowNewNullChallenge)
                     allowedChallenges.push('null');
-
 
                 if (t.notAllowNewDriipChallenge === true)
                     invalidReasons.push({type: 'payment-driip', reasons: []});
 
-
                 if (t.notAllowNewNullChallenge === true)
                     invalidReasons.push({type: 'null', reasons: []});
-
 
                 if (t.receipt) {
                     stubs.getLatestReceiptForSettlement
@@ -351,7 +350,6 @@ describe('Settlement', () => {
                         .withArgs(t.walletAddress, currency.ct)
                         .resolves(null);
                 }
-
 
                 stubs.checkStartChallenge
                     .withArgs(MonetaryAmount.from(t.stageAmount, currency.ct, currency.id), t.receipt, t.walletAddress)
@@ -481,7 +479,7 @@ describe('Settlement', () => {
     });
     describe('#getSettleableChallenges', () => {
         ['sender', 'recipient'].forEach(t => {
-            it(`should return driip settlement as a settleable challenge for the ${t} wallet`, async () => {
+            it(`returns driip settlement as a settleable challenge for the ${t} wallet`, async () => {
                 const stageAmount = ethers.utils.bigNumberify(1);
                 stubbedDriipSettlement.getCurrentProposalNonce
                     .withArgs(mockReceipt[t].wallet, currency.ct, currency.id)
@@ -509,7 +507,7 @@ describe('Settlement', () => {
                 expect(invalidReasons[0].reasons).to.deep.equal([]);
             });
         });
-        it('should return null settlement as a settleable challenge', async () => {
+        it('returns null settlement as a settleable challenge', async () => {
             const stageAmount = ethers.utils.bigNumberify(1);
             stubbedProvider.getWalletReceipts
                 .withArgs(mockReceipt.sender.wallet)
@@ -535,7 +533,7 @@ describe('Settlement', () => {
             expect(invalidReasons[0].type).to.equal('payment-driip');
             expect(invalidReasons[0].reasons).to.deep.equal([]);
         });
-        it('should return both null and driip settlements as settleable challenges', async () => {
+        it('returns both null and driip settlements as settleable challenges', async () => {
             const stageAmount = ethers.utils.bigNumberify(1);
             const stageMonetaryAmount = MonetaryAmount.from(stageAmount, currency.ct, currency.id);
             stubbedProvider.getWalletReceipts
@@ -570,7 +568,7 @@ describe('Settlement', () => {
                 }
             ]);
         });
-        it('should return empty settleable challenges when there are no qualified settlements', async () => {
+        it('returns empty settleable challenges when there are no qualified settlements', async () => {
             stubbedDriipSettlement.getCurrentProposalNonce
                 .resolves(ethers.utils.bigNumberify(mockReceipt.sender.nonce));
             stubbedDriipSettlement.checkSettleDriipAsPayment
@@ -997,7 +995,7 @@ describe('Settlement', () => {
         afterEach(() => {
             settlement.getOngoingChallenges.restore();
         });
-        it('should return the max expiration time from ongoing challenges', async () => {
+        it('returns the max expiration time from ongoing challenges', async () => {
             stubbedGetOngoingChallenges
                 .withArgs(wallet.address, currency.ct, currency.id)
                 .resolves([
@@ -1007,7 +1005,7 @@ describe('Settlement', () => {
             const time = await settlement.getMaxChallengesTimeout(wallet.address, currency.ct, currency.id);
             expect(time).to.equal(2);
         });
-        it('should return null when there is no ongoing challenges', async () => {
+        it('returns null when there is no ongoing challenges', async () => {
             stubbedGetOngoingChallenges
                 .withArgs(wallet.address, currency.ct, currency.id)
                 .resolves([]);

--- a/lib/settlement/settlement.spec.js
+++ b/lib/settlement/settlement.spec.js
@@ -192,7 +192,6 @@ describe('Settlement', () => {
             });
         });
     });
-
     describe('#getRequiredChallengesForIntendedStageAmount()', () => {
         const stubs = {};
 
@@ -373,7 +372,7 @@ describe('Settlement', () => {
             });
         });
     });
-    describe('#checkStartChallenge', () => {
+    describe('#checkStartChallenge()', () => {
         beforeEach(() => {
             settlement.getOngoingChallenges = sinon.stub();
         });
@@ -477,7 +476,7 @@ describe('Settlement', () => {
             });
         });
     });
-    describe('#getSettleableChallenges', () => {
+    describe('#getSettleableChallenges()', () => {
         ['sender', 'recipient'].forEach(t => {
             it(`returns driip settlement as a settleable challenge for the ${t} wallet`, async () => {
                 const stageAmount = ethers.utils.bigNumberify(1);
@@ -588,7 +587,7 @@ describe('Settlement', () => {
             });
         });
     });
-    describe('#getOngoingChallenges', () => {
+    describe('#getOngoingChallenges()', () => {
         beforeEach(() => {
             this.clock = sinon.useFakeTimers(1);
         });
@@ -668,7 +667,7 @@ describe('Settlement', () => {
             });
         });
     });
-    describe('#startChallenge', () => {
+    describe('#startChallenge()', () => {
         const expectedTx = {hash: 'fake hash'};
         const fakeTxReceipt = {};
 
@@ -803,7 +802,7 @@ describe('Settlement', () => {
             });
         });
     });
-    describe('#stopChallenge', () => {
+    describe('#stopChallenge()', () => {
         const expectedTx = {hash: 'fake hash'};
         const fakeTxReceipt = {};
         const ongoingChallenges = [
@@ -870,7 +869,7 @@ describe('Settlement', () => {
             });
         });
     });
-    describe('#settle', () => {
+    describe('#settle()', () => {
         const expectedTx = {hash: 'fake hash'};
         const fakeTxReceipt = {};
 
@@ -987,7 +986,7 @@ describe('Settlement', () => {
             });
         });
     });
-    describe('#getMaxChallengesTimeout', () => {
+    describe('#getMaxChallengesTimeout()', () => {
         let stubbedGetOngoingChallenges;
         beforeEach(() => {
             stubbedGetOngoingChallenges = sinon.stub(settlement, 'getOngoingChallenges');

--- a/package.json
+++ b/package.json
@@ -67,13 +67,13 @@
     "keythereum": "^1.0.4",
     "lodash.get": "^4.4.2",
     "nahmii-contract-abstractions": "1.2.0",
-    "nahmii-contract-abstractions-ropsten": "1.4.0",
+    "nahmii-contract-abstractions-ropsten": "1.5.0",
     "nahmii-ethereum-address": "^2.0.0",
     "node-yaml": "^3.2.0",
     "socket.io-client": "^2.2.0",
     "superagent": "^5.0.2",
     "uuid": "^3.3.2",
-    "web3-utils": "1.0.0-beta.37"
+    "web3-utils": "1.0.0-beta.55"
   },
   "peerDependencies": {
     "ethers": "~4.0.0"

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "node-yaml": "^3.2.0",
     "socket.io-client": "^2.2.0",
     "superagent": "^5.0.2",
+    "uuid": "^3.3.2",
     "web3-utils": "1.0.0-beta.37"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nahmii-sdk",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Javascript SDK for using hubii nahmii APIs",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
     "eslint": "^5.16.0",
-    "jsdoc-to-markdown": "^4.0.1",
+    "jsdoc-to-markdown": "^5.0.0",
     "mocha": "^6.0.2",
     "nock": "^10.0.6",
     "npm-install-peers": "^1.2.1",

--- a/test-utils/index.js
+++ b/test-utils/index.js
@@ -1,0 +1,222 @@
+'use strict';
+
+const ethers = require('ethers');
+const {privateToAddress} = require('ethereumjs-util');
+const {hash, prefix0x, fromRpcSig} = require('../lib/utils');
+const proxyquire = require('proxyquire').noPreserveCache().noCallThru();
+
+const Wallet = proxyquire('../lib/wallet/wallet', {
+    './client-fund-contract'    : function() {
+        return {};
+    },
+    './balance-tracker-contract': function() {
+        return {};
+    },
+    './erc20-contract'          : function() {
+        return {};
+    }
+});
+
+class ApiPayloadFactory {
+    constructor(options) {
+        this.amount = options.amount;
+        this.currency = options.currency;
+
+        this.senderPrivateKey = options.senderPrivateKey;
+        this.sender = options.sender || this.senderPrivateKey ?
+            prefix0x(privateToAddress(Buffer.from(this.senderPrivateKey, 'hex')).toString('hex')) :
+            undefined;
+        this.recipient = options.recipient;
+        this.operatorPrivateKey = options.operatorPrivateKey;
+        this.operator = options.operator || this.operatorPrivateKey ?
+            prefix0x(privateToAddress(Buffer.from(this.operatorPrivateKey, 'hex')).toString('hex')) :
+            undefined;
+    }
+
+    createUnsignedPayment(senderRef) {
+        const senderData = Buffer
+            .from(JSON.stringify({ref: senderRef}))
+            .toString('base64');
+
+        return {
+            amount   : this.amount,
+            currency : this.currency,
+            sender   : {
+                wallet: this.sender,
+                data  : senderData
+            },
+            recipient: {
+                wallet: this.recipient
+            }
+        };
+    }
+
+    async createSignedPayment(unsignedPayment) {
+        const signedPayment = {
+            ...unsignedPayment,
+            seals: {
+                wallet: {
+                    hash: ApiPayloadFactory.hashPayment(unsignedPayment)
+                }
+            }
+        };
+        signedPayment.seals.wallet.signature = await this.signAsSender(signedPayment.seals.wallet.hash);
+        return signedPayment;
+    }
+
+    createUnsignedReceipt(signedPayment) {
+        return {
+            ...signedPayment,
+            nonce      : 1,
+            blockNumber: 1,
+            operatorId : 1,
+            sender     : {
+                ...signedPayment.sender,
+                nonce   : 1,
+                balances: {
+                    current : '0',
+                    previous: '100'
+                },
+                fees    : {
+                    single: {
+                        currency: this.currency,
+                        amount  : '1000000000000000000'
+                    },
+                    total : [
+                        {
+                            originId: '1',
+                            figure  : {
+                                currency: this.currency,
+                                amount  : '1000000000000000000'
+                            }
+                        }
+                    ]
+                }
+            },
+            recipient  : {
+                ...signedPayment.recipient,
+                nonce   : 1,
+                balances: {
+                    current : '100',
+                    previous: '0'
+                },
+                fees    : {
+                    total: [
+                        {
+                            originId: '1',
+                            figure  : {
+                                currency: {
+                                    ct: '0x0000000000000000000000000000000000000001',
+                                    id: '1'
+                                },
+                                amount  : '1000000000000000000'
+                            }
+                        }
+                    ]
+                }
+            },
+            transfers  : {
+                single: '100',
+                total : '100'
+            }
+        };
+    }
+
+    async createSignedReceipt(unsignedReceipt) {
+        let signedReceipt = {
+            ...unsignedReceipt,
+            seals: {
+                ...unsignedReceipt.seals,
+                operator: {
+                    hash: ApiPayloadFactory.hashReceipt(unsignedReceipt)
+                }
+            }
+        };
+        signedReceipt.seals.operator.signature = await this.signAsOperator(signedReceipt.seals.operator.hash);
+        return signedReceipt;
+    }
+
+    static hashPayment(unsignedPayment) {
+        const amountCurrencyHash = hash(
+            unsignedPayment.amount,
+            unsignedPayment.currency.ct,
+            unsignedPayment.currency.id
+        );
+        const senderHash = hash(
+            unsignedPayment.sender.wallet,
+            unsignedPayment.sender.data
+        );
+        const recipientHash = hash(
+            unsignedPayment.recipient.wallet
+        );
+
+        return hash(amountCurrencyHash, senderHash, recipientHash);
+    }
+
+    static hashReceipt(unsignedReceipt) {
+        const walletSignatureHash = hash(
+            {type: 'uint8', value: unsignedReceipt.seals.wallet.signature.v},
+            unsignedReceipt.seals.wallet.signature.r,
+            unsignedReceipt.seals.wallet.signature.s
+        );
+        const nonceHash = hash(
+            unsignedReceipt.nonce
+        );
+        const senderHash = hash(
+            hash(unsignedReceipt.sender.nonce),
+            hash(
+                unsignedReceipt.sender.balances.current,
+                unsignedReceipt.sender.balances.previous
+            ),
+            hash(
+                unsignedReceipt.sender.fees.single.amount,
+                unsignedReceipt.sender.fees.single.currency.ct,
+                unsignedReceipt.sender.fees.single.currency.id
+            ),
+            ApiPayloadFactory.hashFeesTotal(unsignedReceipt.sender.fees.total)
+        );
+        const recipientHash = hash(
+            hash(unsignedReceipt.recipient.nonce),
+            hash(
+                unsignedReceipt.recipient.balances.current,
+                unsignedReceipt.recipient.balances.previous
+            ),
+            ApiPayloadFactory.hashFeesTotal(unsignedReceipt.recipient.fees.total)
+        );
+        const transfersHash = hash(
+            unsignedReceipt.transfers.single,
+            unsignedReceipt.transfers.total
+        );
+        return hash(walletSignatureHash, nonceHash, senderHash, recipientHash, transfersHash);
+    }
+
+    static hashFeesTotal(totalFigures) {
+        let feesTotalHash = 0;
+        for (let i = 0; i < totalFigures.length; i++) {
+            feesTotalHash = hash(
+                feesTotalHash,
+                totalFigures[i].originId,
+                totalFigures[i].figure.amount,
+                totalFigures[i].figure.currency.ct,
+                totalFigures[i].figure.currency.id
+            );
+        }
+        return feesTotalHash;
+    }
+
+    async signAsSender(hash) {
+        const senderWallet = new Wallet(this.senderPrivateKey);
+        const rpcSignature = await senderWallet.signMessage(ethers.utils.arrayify(hash));
+        return fromRpcSig(rpcSignature);
+    }
+
+    async signAsOperator(hash) {
+        const operatorWallet = new Wallet(this.operatorPrivateKey);
+        const rpcSignature = await operatorWallet.signMessage(ethers.utils.arrayify(hash));
+        return fromRpcSig(rpcSignature);
+    }
+}
+
+module.exports = {
+    ApiPayloadFactory
+};

--- a/test-utils/index.js
+++ b/test-utils/index.js
@@ -6,13 +6,13 @@ const {hash, prefix0x, fromRpcSig} = require('../lib/utils');
 const proxyquire = require('proxyquire').noPreserveCache().noCallThru();
 
 const Wallet = proxyquire('../lib/wallet/wallet', {
-    './client-fund-contract'    : function() {
+    './client-fund-contract': function() {
         return {};
     },
     './balance-tracker-contract': function() {
         return {};
     },
-    './erc20-contract'          : function() {
+    './erc20-contract': function() {
         return {};
     }
 });
@@ -33,17 +33,21 @@ class ApiPayloadFactory {
             undefined;
     }
 
-    createUnsignedPayment(senderRef) {
-        const senderData = Buffer
+    static createSenderData(senderRef) {
+        return Buffer
             .from(JSON.stringify({ref: senderRef}))
             .toString('base64');
+    }
+
+    createUnsignedPayment(senderRef) {
+        const senderData = ApiPayloadFactory.createSenderData(senderRef);
 
         return {
-            amount   : this.amount,
-            currency : this.currency,
-            sender   : {
+            amount: this.amount,
+            currency: this.currency,
+            sender: {
                 wallet: this.sender,
-                data  : senderData
+                data: senderData
             },
             recipient: {
                 wallet: this.recipient
@@ -68,58 +72,58 @@ class ApiPayloadFactory {
         return {
             ...signedPayment,
             blockNumber: 1,
-            operator   : {
-                id  : 1,
+            operator: {
+                id: 1,
                 data: ''
             },
-            sender     : {
+            sender: {
                 ...signedPayment.sender,
-                nonce   : 1,
+                nonce: 1,
                 balances: {
-                    current : '0',
+                    current: '0',
                     previous: '100'
                 },
-                fees    : {
+                fees: {
                     single: {
                         currency: this.currency,
-                        amount  : '1000000000000000000'
+                        amount: '1000000000000000000'
                     },
-                    total : [
+                    total: [
                         {
                             originId: '1',
-                            figure  : {
+                            figure: {
                                 currency: this.currency,
-                                amount  : '1000000000000000000'
+                                amount: '1000000000000000000'
                             }
                         }
                     ]
                 }
             },
-            recipient  : {
+            recipient: {
                 ...signedPayment.recipient,
-                nonce   : 1,
+                nonce: 1,
                 balances: {
-                    current : '100',
+                    current: '100',
                     previous: '0'
                 },
-                fees    : {
+                fees: {
                     total: [
                         {
                             originId: '1',
-                            figure  : {
+                            figure: {
                                 currency: {
                                     ct: '0x0000000000000000000000000000000000000001',
                                     id: '1'
                                 },
-                                amount  : '1000000000000000000'
+                                amount: '1000000000000000000'
                             }
                         }
                     ]
                 }
             },
-            transfers  : {
+            transfers: {
                 single: '100',
-                total : '100'
+                total: '100'
             }
         };
     }

--- a/test-utils/index.js
+++ b/test-utils/index.js
@@ -67,9 +67,11 @@ class ApiPayloadFactory {
     createUnsignedReceipt(signedPayment) {
         return {
             ...signedPayment,
-            nonce      : 1,
             blockNumber: 1,
-            operatorId : 1,
+            operator   : {
+                id  : 1,
+                data: ''
+            },
             sender     : {
                 ...signedPayment.sender,
                 nonce   : 1,
@@ -159,9 +161,6 @@ class ApiPayloadFactory {
             unsignedReceipt.seals.wallet.signature.r,
             unsignedReceipt.seals.wallet.signature.s
         );
-        const nonceHash = hash(
-            unsignedReceipt.nonce
-        );
         const senderHash = hash(
             hash(unsignedReceipt.sender.nonce),
             hash(
@@ -187,7 +186,8 @@ class ApiPayloadFactory {
             unsignedReceipt.transfers.single,
             unsignedReceipt.transfers.total
         );
-        return hash(walletSignatureHash, nonceHash, senderHash, recipientHash, transfersHash);
+        const operatorHash = hash(unsignedReceipt.operator.data);
+        return hash(walletSignatureHash, senderHash, recipientHash, transfersHash, operatorHash);
     }
 
     static hashFeesTotal(totalFigures) {


### PR DESCRIPTION
Adds "senderRef" property to Payment class. New Payments will generate a UUID for sender ref. serialization and de-serialization will encode and decode the sender ref accordingly.