### PR TITLE
Exception safety

### DIFF
--- a/lib/payment.js
+++ b/lib/payment.js
@@ -204,8 +204,15 @@ class Payment {
             _signature.set(p, json.seals.wallet.signature);
         }
         if (json.sender && json.sender.data && typeof json.sender.data === 'string') {
-            const senderData = JSON.parse(Buffer.from(json.sender.data, 'base64').toString('ascii'));
-            _senderRef.set(p, senderData.ref);
+            const jsonSenderData = Buffer.from(json.sender.data, 'base64').toString('ascii');
+            try {
+                const senderData = JSON.parse(jsonSenderData);
+                _senderRef.set(p, senderData.ref);
+            }
+            catch (e) {
+                // Ignore parse errors and leave the _senderRef undefined.
+                // TODO: Is there an exception safe alternative to JSON.parse?
+            }
         }
 
         return p;

--- a/lib/payment.spec.js
+++ b/lib/payment.spec.js
@@ -61,7 +61,7 @@ describe('Payment', () => {
     const uuidRegexp = /^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i;
     let fixture;
 
-    beforeEach(function() {
+    beforeEach(() => {
         fixture = new ApiPayloadFactory({
             senderPrivateKey: '3a1076bf45ab87712ad64ccb3b10217737f7faacbf2872e88fdd9a537d8fe266',
             recipient: '0x0000000000000000000000000000000000000003',
@@ -122,11 +122,11 @@ describe('Payment', () => {
                 expect(payment.isSigned()).to.be.false;
             });
 
-            it('has an UUID as sender ref', function() {
+            it('has an UUID as sender ref', () => {
                 expect(payment.senderRef).to.match(uuidRegexp);
             });
 
-            it('has sender data in JSON that is base64 encoding of sender ref', function() {
+            it('has sender data in JSON that is base64 encoding of sender ref', () => {
                 const expectedData = Buffer
                     .from(JSON.stringify({ref: payment.senderRef}))
                     .toString('base64');
@@ -168,11 +168,11 @@ describe('Payment', () => {
                 expect(payment.isSigned()).to.be.true;
             });
 
-            it('has an UUID as sender ref', function() {
+            it('has an UUID as sender ref', () => {
                 expect(payment.senderRef).to.match(uuidRegexp);
             });
 
-            it('has sender data in JSON that is base64 encoding of sender ref', function() {
+            it('has sender data in JSON that is base64 encoding of sender ref', () => {
                 const expectedData = Buffer
                     .from(JSON.stringify({ref: payment.senderRef}))
                     .toString('base64');
@@ -220,11 +220,11 @@ describe('Payment', () => {
                 expect(payment.isSigned()).to.be.false;
             });
 
-            it('has an UUID as sender ref', function() {
+            it('has an UUID as sender ref', () => {
                 expect(payment.senderRef).to.match(uuidRegexp);
             });
 
-            it('has sender data in JSON that is base64 encoding of sender ref', function() {
+            it('has sender data in JSON that is base64 encoding of sender ref', () => {
                 const expectedData = Buffer
                     .from(JSON.stringify({ref: payment.senderRef}))
                     .toString('base64');
@@ -265,11 +265,11 @@ describe('Payment', () => {
                 expect(payment.isSigned()).to.be.true;
             });
 
-            it('has an UUID as sender ref', function() {
+            it('has an UUID as sender ref', () => {
                 expect(payment.senderRef).to.match(uuidRegexp);
             });
 
-            it('has sender data in JSON that is base64 encoding of sender ref', function() {
+            it('has sender data in JSON that is base64 encoding of sender ref', () => {
                 const expectedData = Buffer
                     .from(JSON.stringify({ref: payment.senderRef}))
                     .toString('base64');
@@ -319,11 +319,11 @@ describe('Payment', () => {
                 expect(payment.isSigned()).to.be.false;
             });
 
-            it('has an UUID as sender ref', function() {
+            it('has an UUID as sender ref', () => {
                 expect(payment.senderRef).to.match(uuidRegexp);
             });
 
-            it('has sender data in JSON that is base64 encoding of sender ref', function() {
+            it('has sender data in JSON that is base64 encoding of sender ref', () => {
                 const expectedData = Buffer
                     .from(JSON.stringify({ref: payment.senderRef}))
                     .toString('base64');
@@ -371,11 +371,11 @@ describe('Payment', () => {
                 expect(payment.isSigned()).to.be.false;
             });
 
-            it('has an UUID as sender ref', function() {
+            it('has an UUID as sender ref', () => {
                 expect(payment.senderRef).to.match(uuidRegexp);
             });
 
-            it('has sender data in JSON that is base64 encoding of sender ref', function() {
+            it('has sender data in JSON that is base64 encoding of sender ref', () => {
                 const expectedData = Buffer
                     .from(JSON.stringify({ref: payment.senderRef}))
                     .toString('base64');
@@ -416,11 +416,11 @@ describe('Payment', () => {
                 expect(payment.isSigned()).to.be.true;
             });
 
-            it('has an UUID as sender ref', function() {
+            it('has an UUID as sender ref', () => {
                 expect(payment.senderRef).to.match(uuidRegexp);
             });
 
-            it('has sender data in JSON that is base64 encoding of sender ref', function() {
+            it('has sender data in JSON that is base64 encoding of sender ref', () => {
                 const expectedData = Buffer
                     .from(JSON.stringify({ref: payment.senderRef}))
                     .toString('base64');
@@ -473,11 +473,11 @@ describe('Payment', () => {
                 expect(payment.isSigned()).to.be.false;
             });
 
-            it('has an UUID as sender ref', function() {
+            it('has an UUID as sender ref', () => {
                 expect(payment.senderRef).to.match(uuidRegexp);
             });
 
-            it('has sender data in JSON that is base64 encoding of sender ref', function() {
+            it('has sender data in JSON that is base64 encoding of sender ref', () => {
                 const expectedData = Buffer
                     .from(JSON.stringify({ref: payment.senderRef}))
                     .toString('base64');
@@ -528,11 +528,11 @@ describe('Payment', () => {
                 expect(payment.isSigned()).to.be.false;
             });
 
-            it('has an UUID as sender ref', function() {
+            it('has an UUID as sender ref', () => {
                 expect(payment.senderRef).to.match(uuidRegexp);
             });
 
-            it('has sender data in JSON that is base64 encoding of sender ref', function() {
+            it('has sender data in JSON that is base64 encoding of sender ref', () => {
                 const expectedData = Buffer
                     .from(JSON.stringify({ref: payment.senderRef}))
                     .toString('base64');
@@ -575,11 +575,11 @@ describe('Payment', () => {
                 expect(payment.isSigned()).to.be.true;
             });
 
-            it('has an UUID as sender ref', function() {
+            it('has an UUID as sender ref', () => {
                 expect(payment.senderRef).to.match(uuidRegexp);
             });
 
-            it('has sender data in JSON that is base64 encoding of sender ref', function() {
+            it('has sender data in JSON that is base64 encoding of sender ref', () => {
                 const expectedData = Buffer
                     .from(JSON.stringify({ref: payment.senderRef}))
                     .toString('base64');
@@ -603,16 +603,42 @@ describe('Payment', () => {
             payment = Payment.from(modifiedPayload, stubbedWallet);
         });
 
-        it('has a new sender reference', function() {
+        it('has a new sender reference', () => {
             expect(payment.senderRef).to.not.eql('');
             expect(payment.senderRef).to.not.eql(senderRef);
         });
 
-        it('has an UUID as sender ref', function() {
+        it('has an UUID as sender ref', () => {
             expect(payment.senderRef).to.match(uuidRegexp);
         });
 
-        it('has sender data in JSON that is base64 encoding of sender ref', function() {
+        it('has sender data in JSON that is base64 encoding of sender ref', () => {
+            const expectedData = Buffer
+                .from(JSON.stringify({ref: payment.senderRef}))
+                .toString('base64');
+            expect(payment.toJSON().sender.data).to.eql(expectedData);
+        });
+    });
+
+    context('a de-serialized unsigned Payment that has malformed sender data', () => {
+        let payment;
+
+        beforeEach(() => {
+            const modifiedPayload = fixture.createUnsignedPayment(senderRef);
+            modifiedPayload.sender.data = 'asdasdasdasasd';
+            payment = Payment.from(modifiedPayload, stubbedWallet);
+        });
+
+        it('has a new sender reference', () => {
+            expect(payment.senderRef).to.not.eql('');
+            expect(payment.senderRef).to.not.eql(senderRef);
+        });
+
+        it('has an UUID as sender ref', () => {
+            expect(payment.senderRef).to.match(uuidRegexp);
+        });
+
+        it('has sender data in JSON that is base64 encoding of sender ref', () => {
             const expectedData = Buffer
                 .from(JSON.stringify({ref: payment.senderRef}))
                 .toString('base64');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nahmii-sdk",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Javascript SDK for using hubii nahmii APIs",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
No exception thrown if the is a parse error of sender data during the Payment.from() factory. 

A new Payment instance is returned and it will have a new unique senderRef by default.