### PR TITLE
Support new signature of DriipSettlementByPayment#settlePayment()

### DIFF
--- a/lib/settlement/driip-settlement.js
+++ b/lib/settlement/driip-settlement.js
@@ -290,7 +290,7 @@ class DriipSettlement {
 
         try {
             const driipSettlementContract = new DriipSettlementContract(wallet);
-            return await driipSettlementContract.settlePayment(receipt.toJSON(), options);
+            return await driipSettlementContract.settlePayment(receipt.toJSON(), 'ERC20', options);
         }
         catch (error) {
             throw new NestedError(error, 'Unable to settle payment driip.');

--- a/lib/settlement/driip-settlement.spec.js
+++ b/lib/settlement/driip-settlement.spec.js
@@ -168,7 +168,7 @@ describe('Driip settlement operations', () => {
 
     it('can settle payment driip', async () => {
         stubbedDriipSettlementContract.settlePayment
-            .withArgs(receipt.toJSON(), {})
+            .withArgs(receipt.toJSON(), 'ERC20', {})
             .resolves(fakeTx);
         sinon.stub(driipSettlement, 'hasProposalExpired').resolves(true);
         sinon.stub(driipSettlement, 'getCurrentProposalStatus').resolves('Qualified');

--- a/package.json
+++ b/package.json
@@ -64,10 +64,11 @@
   },
   "dependencies": {
     "ethereumjs-util": "^6.1.0",
+    "ethers": "^4.0.29",
     "keythereum": "^1.0.4",
     "lodash.get": "^4.4.2",
     "nahmii-contract-abstractions": "1.2.2",
-    "nahmii-contract-abstractions-ropsten": "~1.5.3",
+    "nahmii-contract-abstractions-ropsten": "~2.0.0",
     "nahmii-ethereum-address": "^2.0.0",
     "node-yaml": "^3.2.0",
     "socket.io-client": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nahmii-sdk",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "Javascript SDK for using hubii nahmii APIs",
   "main": "index.js",
   "scripts": {
@@ -64,7 +64,6 @@
   },
   "dependencies": {
     "ethereumjs-util": "^6.1.0",
-    "ethers": "^4.0.29",
     "keythereum": "^1.0.4",
     "lodash.get": "^4.4.2",
     "nahmii-contract-abstractions": "1.2.2",


### PR DESCRIPTION
`DriipSettlementByPayment#settlePayment()` has been augmented by the addition of string parameter `standard`. By this update the registration of mapping of token contract address to standard in smart contract _TransferControllerManager_ is not required for the successful call of `DriipSettlement#settleDriipAsPayment()`. See hubiinetwork/nahmii-contracts#401 for details of possible argument values of `standard`.

In this repo `DriipSettlement#settleDriipAsPayment()` is updated with fixed standard argument `'ERC20'`, consistent with the overall assumption herein that all tokens currently are fungible ones of standard ERC20.