### PR TITLE
Standard on null settlement, withdrawal and unstage

### DIFF
--- a/lib/settlement/null-settlement.js
+++ b/lib/settlement/null-settlement.js
@@ -226,7 +226,7 @@ class NullSettlement {
 
         try {
             const nullSettlementContract = new NullSettlementContract(wallet);
-            return await nullSettlementContract.settleNull(ct, id, options);
+            return await nullSettlementContract.settleNull(ct, id, 'ERC20', options);
         }
         catch (error) {
             throw new NestedError(error, 'Unable to settle null.');

--- a/lib/settlement/null-settlement.spec.js
+++ b/lib/settlement/null-settlement.spec.js
@@ -87,7 +87,7 @@ describe('Null settlement operations', () => {
                 .withArgs(stageAmount.toJSON().amount, stageAmount.toJSON().currency.ct, stageAmount.toJSON().currency.id, {})
                 .resolves(fakeTx);
             sinon.stub(nullSettlement, 'hasCurrentProposalExpired').resolves(t);
-            let tx = await nullSettlement.startChallenge(wallet, stageAmount);
+            const tx = await nullSettlement.startChallenge(wallet, stageAmount);
             expect(tx).to.equal(fakeTx);
         });
     });
@@ -113,7 +113,7 @@ describe('Null settlement operations', () => {
                 .withArgs(stageAmount.toJSON().amount, stageAmount.toJSON().currency.ct, stageAmount.toJSON().currency.id, {})
                 .resolves(fakeTx);
             sinon.stub(nullSettlement, 'hasCurrentProposalExpired').resolves(true);
-            let tx = await nullSettlement.startChallenge(wallet, stageAmount);
+            const tx = await nullSettlement.startChallenge(wallet, stageAmount);
             expect(tx).to.equal(fakeTx);
         });
     });
@@ -122,7 +122,7 @@ describe('Null settlement operations', () => {
         stubbedNullSettlementChallengeContract.stopChallenge
             .withArgs(address0, address0id, {})
             .resolves(fakeTx);
-        let tx = await nullSettlement.stopChallenge(wallet, address0, address0id);
+        const tx = await nullSettlement.stopChallenge(wallet, address0, address0id);
         expect(tx).to.equal(fakeTx);
     });
 
@@ -139,12 +139,12 @@ describe('Null settlement operations', () => {
         it('can settle null', async () => {
             const currency = address0;
             stubbedNullSettlementContract.settleNull
-                .withArgs(currency, 0, {})
+                .withArgs(currency, 0, 'ERC20', {})
                 .resolves(fakeTx);
             sinon.stub(nullSettlement, 'hasCurrentProposalExpired').resolves(true);
             sinon.stub(nullSettlement, 'getCurrentProposalStatus').resolves('Qualified');
             sinon.stub(nullSettlement, 'hasCurrentProposalTerminated').resolves(false);
-            let tx = await nullSettlement.settleNull(wallet, currency, 0);
+            const tx = await nullSettlement.settleNull(wallet, currency, 0);
             expect(tx).to.equal(fakeTx);
         });
 

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -216,7 +216,7 @@ class Wallet extends ethers.Signer {
     async withdraw(monetaryAmount, options = {}) {
         const {amount, currency} = monetaryAmount.toJSON();
         const clientFund = _clientFund.get(this);
-        return await clientFund.withdraw(amount, currency.ct, currency.id, '', options);
+        return await clientFund.withdraw(amount, currency.ct, currency.id, 'ERC20', options);
     }
 
     /**
@@ -234,7 +234,7 @@ class Wallet extends ethers.Signer {
     async unstage(monetaryAmount, options = {}) {
         const {amount, currency} = monetaryAmount.toJSON();
         const clientFund = _clientFund.get(this);
-        return await clientFund.unstage(amount, currency.ct, currency.id, '', options);
+        return await clientFund.unstage(amount, currency.ct, currency.id, 'ERC20', options);
     }
 
     /**

--- a/lib/wallet/wallet.spec.js
+++ b/lib/wallet/wallet.spec.js
@@ -369,7 +369,7 @@ describe('Wallet', () => {
                     const currency = '0x0000000000000000000000000000000000000000';
                     const amountBN = ethers.utils.parseUnits(amount, 18);
                     stubbedClientFundContract.withdraw
-                        .withArgs(amountBN.toString(), currency, '0', '', {})
+                        .withArgs(amountBN.toString(), currency, '0', 'ERC20', {})
                         .resolves(fakeTx);
                     const monetaryAmount = MonetaryAmount.from(amountBN, currency, 0);
                     let tx = await wallet.withdraw(monetaryAmount);
@@ -414,7 +414,7 @@ describe('Wallet', () => {
                     const currency = '0x0000000000000000000000000000000000004321';
                     const amountBN = ethers.utils.parseUnits(amount, 18);
                     stubbedClientFundContract.withdraw
-                        .withArgs(amountBN.toString(), currency, '0', '', {})
+                        .withArgs(amountBN.toString(), currency, '0', 'ERC20', {})
                         .resolves(fakeTx);
                     const monetaryAmount = MonetaryAmount.from(amountBN, currency, 0);
                     let tx = await wallet.withdraw(monetaryAmount);
@@ -558,7 +558,7 @@ describe('Wallet', () => {
                     const currency = '0x0000000000000000000000000000000000000000';
                     const amountBN = ethers.utils.parseUnits(amount, 18);
                     stubbedClientFundContract.unstage
-                        .withArgs(amountBN.toString(), currency, '0', '', {})
+                        .withArgs(amountBN.toString(), currency, '0', 'ERC20', {})
                         .resolves(fakeTx);
                     const monetaryAmount = MonetaryAmount.from(amountBN, currency, 0);
                     let tx = await wallet.unstage(monetaryAmount);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nahmii-sdk",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "description": "Javascript SDK for using hubii nahmii APIs",
   "main": "index.js",
   "scripts": {
@@ -67,7 +67,7 @@
     "keythereum": "^1.0.4",
     "lodash.get": "^4.4.2",
     "nahmii-contract-abstractions": "1.2.2",
-    "nahmii-contract-abstractions-ropsten": "~2.0.0",
+    "nahmii-contract-abstractions-ropsten": "~3.0.0",
     "nahmii-ethereum-address": "^2.0.0",
     "node-yaml": "^3.2.0",
     "socket.io-client": "^2.2.0",


### PR DESCRIPTION
`NullSettlement#settleNull()` of hubiinetwork/nahmii-contracts has been augmented by the addition of string parameter `standard`. By this update the registration of mapping of token contract address to standard in smart contract _TransferControllerManager_ is not required for the successful call of `NullSettlement#settleNull()`. See hubiinetwork/nahmii-contracts#404 for details of possible argument values of `standard`.

In this repo `NullSettlement#settleNull()` is updated with fixed standard argument `'ERC20'`, consistent with the overall assumption herein that all tokens currently are fungible ones of standard ERC20.

Also the calls to contract functions `ClientFund#withdraw()` and `ClientFund#unstage()` are now carried out with standard argument `'ERC20'`. Again by this change the registration of mapping of token contract address to standard in smart contract _TransferControllerManager_ is not required prior to calls of the _ClientFund_ functions.