### PR TITLE
Support determining whether the offchain balance has been synchronised since the start of the last settlement

### DIFF
--- a/Docs/driip-settlement.md
+++ b/Docs/driip-settlement.md
@@ -11,7 +11,7 @@
         * [.getCurrentProposalStageAmount(address, ct, id)](#module_nahmii-sdk--DriipSettlement+getCurrentProposalStageAmount) ⇒ <code>Promise</code>
         * [.getCurrentProposalStatus(address, ct, id)](#module_nahmii-sdk--DriipSettlement+getCurrentProposalStatus) ⇒ <code>Promise</code>
         * [.getSettlementByNonce(address, nonce)](#module_nahmii-sdk--DriipSettlement+getSettlementByNonce) ⇒ <code>Promise</code>
-        * [.getCurrentProposalStartBlockNumber(address, ct)](#module_nahmii-sdk--DriipSettlement+getCurrentProposalStartBlockNumber) ⇒ <code>Promise</code>
+        * [.getCurrentProposalStartBlockNumber(address, ct, id)](#module_nahmii-sdk--DriipSettlement+getCurrentProposalStartBlockNumber) ⇒ <code>Promise</code>
         * [.hasPaymentDriipSettled(nonce, address)](#module_nahmii-sdk--DriipSettlement+hasPaymentDriipSettled) ⇒ <code>Promise</code>
         * [.checkStartChallengeFromPayment(receipt, address)](#module_nahmii-sdk--DriipSettlement+checkStartChallengeFromPayment) ⇒ <code>Promise</code>
         * [.checkSettleDriipAsPayment(receipt, address)](#module_nahmii-sdk--DriipSettlement+checkSettleDriipAsPayment) ⇒ <code>Promise</code>
@@ -153,7 +153,7 @@ let settlement = await driipSettlement.settlementByWalletAndNonce('0x00000000000
 ```
 <a name="module_nahmii-sdk--DriipSettlement+getCurrentProposalStartBlockNumber"></a>
 
-#### driipSettlement.getCurrentProposalStartBlockNumber(address, ct) ⇒ <code>Promise</code>
+#### driipSettlement.getCurrentProposalStartBlockNumber(address, ct, id) ⇒ <code>Promise</code>
 Returns block number of the start of the current settlement proposal
 
 **Kind**: instance method of [<code>DriipSettlement</code>](#exp_module_nahmii-sdk--DriipSettlement)  
@@ -163,6 +163,7 @@ Returns block number of the start of the current settlement proposal
 | --- | --- | --- |
 | address | <code>Address</code> | The wallet address. |
 | ct | <code>Address</code> | The currency address. |
+| id | <code>Integer</code> | The currency id. |
 
 <a name="module_nahmii-sdk--DriipSettlement+hasPaymentDriipSettled"></a>
 

--- a/Docs/driip-settlement.md
+++ b/Docs/driip-settlement.md
@@ -11,6 +11,7 @@
         * [.getCurrentProposalStageAmount(address, ct, id)](#module_nahmii-sdk--DriipSettlement+getCurrentProposalStageAmount) ⇒ <code>Promise</code>
         * [.getCurrentProposalStatus(address, ct, id)](#module_nahmii-sdk--DriipSettlement+getCurrentProposalStatus) ⇒ <code>Promise</code>
         * [.getSettlementByNonce(address, nonce)](#module_nahmii-sdk--DriipSettlement+getSettlementByNonce) ⇒ <code>Promise</code>
+        * [.getCurrentProposalStartBlockNumber(address, ct)](#module_nahmii-sdk--DriipSettlement+getCurrentProposalStartBlockNumber) ⇒ <code>Promise</code>
         * [.hasPaymentDriipSettled(nonce, address)](#module_nahmii-sdk--DriipSettlement+hasPaymentDriipSettled) ⇒ <code>Promise</code>
         * [.checkStartChallengeFromPayment(receipt, address)](#module_nahmii-sdk--DriipSettlement+checkStartChallengeFromPayment) ⇒ <code>Promise</code>
         * [.checkSettleDriipAsPayment(receipt, address)](#module_nahmii-sdk--DriipSettlement+checkSettleDriipAsPayment) ⇒ <code>Promise</code>
@@ -150,6 +151,19 @@ Returns settlement details object.
 ```js
 let settlement = await driipSettlement.settlementByWalletAndNonce('0x0000000000000000000000000000000000000001', 1);
 ```
+<a name="module_nahmii-sdk--DriipSettlement+getCurrentProposalStartBlockNumber"></a>
+
+#### driipSettlement.getCurrentProposalStartBlockNumber(address, ct) ⇒ <code>Promise</code>
+Returns block number of the start of the current settlement proposal
+
+**Kind**: instance method of [<code>DriipSettlement</code>](#exp_module_nahmii-sdk--DriipSettlement)  
+**Returns**: <code>Promise</code> - A promise that resolves into true or throws errors  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| address | <code>Address</code> | The wallet address. |
+| ct | <code>Address</code> | The currency address. |
+
 <a name="module_nahmii-sdk--DriipSettlement+hasPaymentDriipSettled"></a>
 
 #### driipSettlement.hasPaymentDriipSettled(nonce, address) ⇒ <code>Promise</code>

--- a/Docs/driip-settlement.md
+++ b/Docs/driip-settlement.md
@@ -157,7 +157,7 @@ let settlement = await driipSettlement.settlementByWalletAndNonce('0x00000000000
 Returns block number of the start of the current settlement proposal
 
 **Kind**: instance method of [<code>DriipSettlement</code>](#exp_module_nahmii-sdk--DriipSettlement)  
-**Returns**: <code>Promise</code> - A promise that resolves into true or throws errors  
+**Returns**: <code>Promise</code> - A promise that resolves into a BigNumber or throws errors  
 
 | Param | Type | Description |
 | --- | --- | --- |

--- a/Docs/null-settlement.md
+++ b/Docs/null-settlement.md
@@ -10,7 +10,7 @@
         * [.getCurrentProposalExpirationTime(address, ct, id)](#module_nahmii-sdk--NullSettlement+getCurrentProposalExpirationTime) ⇒ <code>Promise</code>
         * [.getCurrentProposalStageAmount(address, ct, id)](#module_nahmii-sdk--NullSettlement+getCurrentProposalStageAmount) ⇒ <code>Promise</code>
         * [.getCurrentProposalStatus(address, ct, id)](#module_nahmii-sdk--NullSettlement+getCurrentProposalStatus) ⇒ <code>Promise</code>
-        * [.getCurrentProposalStartBlockNumber(address, ct)](#module_nahmii-sdk--NullSettlement+getCurrentProposalStartBlockNumber) ⇒ <code>Promise</code>
+        * [.getCurrentProposalStartBlockNumber(address, ct, id)](#module_nahmii-sdk--NullSettlement+getCurrentProposalStartBlockNumber) ⇒ <code>Promise</code>
         * [.checkStartChallenge(stageAmount, address)](#module_nahmii-sdk--NullSettlement+checkStartChallenge) ⇒ <code>Promise</code>
         * [.checkSettleNull(address, ct, id)](#module_nahmii-sdk--NullSettlement+checkSettleNull) ⇒ <code>Promise</code>
         * [.settleNull(wallet, ct, id, [options])](#module_nahmii-sdk--NullSettlement+settleNull) ⇒ <code>Promise</code>
@@ -134,7 +134,7 @@ let status = await nullSettlement.getCurrentProposalStatus(address, ct, id);
 ```
 <a name="module_nahmii-sdk--NullSettlement+getCurrentProposalStartBlockNumber"></a>
 
-#### nullSettlement.getCurrentProposalStartBlockNumber(address, ct) ⇒ <code>Promise</code>
+#### nullSettlement.getCurrentProposalStartBlockNumber(address, ct, id) ⇒ <code>Promise</code>
 Returns block number of the start of the current settlement proposal
 
 **Kind**: instance method of [<code>NullSettlement</code>](#exp_module_nahmii-sdk--NullSettlement)  
@@ -144,6 +144,7 @@ Returns block number of the start of the current settlement proposal
 | --- | --- | --- |
 | address | <code>Address</code> | The wallet address. |
 | ct | <code>Address</code> | The currency address. |
+| id | <code>Integer</code> | The currency id. |
 
 <a name="module_nahmii-sdk--NullSettlement+checkStartChallenge"></a>
 

--- a/Docs/null-settlement.md
+++ b/Docs/null-settlement.md
@@ -138,7 +138,7 @@ let status = await nullSettlement.getCurrentProposalStatus(address, ct, id);
 Returns block number of the start of the current settlement proposal
 
 **Kind**: instance method of [<code>NullSettlement</code>](#exp_module_nahmii-sdk--NullSettlement)  
-**Returns**: <code>Promise</code> - A promise that resolves into true or throws errors  
+**Returns**: <code>Promise</code> - A promise that resolves into a BigNumber or throws errors  
 
 | Param | Type | Description |
 | --- | --- | --- |

--- a/Docs/null-settlement.md
+++ b/Docs/null-settlement.md
@@ -10,6 +10,7 @@
         * [.getCurrentProposalExpirationTime(address, ct, id)](#module_nahmii-sdk--NullSettlement+getCurrentProposalExpirationTime) ⇒ <code>Promise</code>
         * [.getCurrentProposalStageAmount(address, ct, id)](#module_nahmii-sdk--NullSettlement+getCurrentProposalStageAmount) ⇒ <code>Promise</code>
         * [.getCurrentProposalStatus(address, ct, id)](#module_nahmii-sdk--NullSettlement+getCurrentProposalStatus) ⇒ <code>Promise</code>
+        * [.getCurrentProposalStartBlockNumber(address, ct)](#module_nahmii-sdk--NullSettlement+getCurrentProposalStartBlockNumber) ⇒ <code>Promise</code>
         * [.checkStartChallenge(stageAmount, address)](#module_nahmii-sdk--NullSettlement+checkStartChallenge) ⇒ <code>Promise</code>
         * [.checkSettleNull(address, ct, id)](#module_nahmii-sdk--NullSettlement+checkSettleNull) ⇒ <code>Promise</code>
         * [.settleNull(wallet, ct, id, [options])](#module_nahmii-sdk--NullSettlement+settleNull) ⇒ <code>Promise</code>
@@ -131,6 +132,19 @@ Returns status of the current challenge proposal
 ```js
 let status = await nullSettlement.getCurrentProposalStatus(address, ct, id);
 ```
+<a name="module_nahmii-sdk--NullSettlement+getCurrentProposalStartBlockNumber"></a>
+
+#### nullSettlement.getCurrentProposalStartBlockNumber(address, ct) ⇒ <code>Promise</code>
+Returns block number of the start of the current settlement proposal
+
+**Kind**: instance method of [<code>NullSettlement</code>](#exp_module_nahmii-sdk--NullSettlement)  
+**Returns**: <code>Promise</code> - A promise that resolves into true or throws errors  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| address | <code>Address</code> | The wallet address. |
+| ct | <code>Address</code> | The currency address. |
+
 <a name="module_nahmii-sdk--NullSettlement+checkStartChallenge"></a>
 
 #### nullSettlement.checkStartChallenge(stageAmount, address) ⇒ <code>Promise</code>

--- a/Docs/settlement.md
+++ b/Docs/settlement.md
@@ -17,6 +17,7 @@
         * [.startChallenge(stageMonetaryAmount, wallet, [options])](#module_nahmii-sdk--Settlement+startChallenge) ⇒ <code>Promise</code>
         * [.stopChallenges(wallet, ct, id, [options])](#module_nahmii-sdk--Settlement+stopChallenges) ⇒ <code>Promise</code>
         * [.settle(stageMonetaryAmount, wallet, [options])](#module_nahmii-sdk--Settlement+settle) ⇒ <code>Promise</code>
+        * [.hasOffchainSynchronised(address, ct, [options])](#module_nahmii-sdk--Settlement+hasOffchainSynchronised) ⇒ <code>Promise</code>
 
 <a name="exp_module_nahmii-sdk--Settlement"></a>
 
@@ -200,5 +201,19 @@ Settle the qualified challenges for a currency.
 | --- | --- | --- |
 | stageMonetaryAmount | <code>MonetaryAmount</code> | The intended stage amount |
 | wallet | <code>Wallet</code> | The nahmii wallet object |
+| [options] |  |  |
+
+<a name="module_nahmii-sdk--Settlement+hasOffchainSynchronised"></a>
+
+#### settlement.hasOffchainSynchronised(address, ct, [options]) ⇒ <code>Promise</code>
+Check if the offchain balance has been synchronised.
+
+**Kind**: instance method of [<code>Settlement</code>](#exp_module_nahmii-sdk--Settlement)  
+**Returns**: <code>Promise</code> - A promise that resolves into a boolean value.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| address | <code>Address</code> | The wallet address |
+| ct | <code>Address</code> | The currency address |
 | [options] |  |  |
 

--- a/lib/settlement/driip-settlement-challenge-state-contract.js
+++ b/lib/settlement/driip-settlement-challenge-state-contract.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const NahmiiContract = require('../contract');
+
+class DriipSettlementChallengeState extends NahmiiContract {
+    constructor(walletOrProvider) {
+        super('DriipSettlementChallengeState', walletOrProvider);
+    }
+}
+
+module.exports = DriipSettlementChallengeState;

--- a/lib/settlement/driip-settlement-challenge-state-contract.spec.js
+++ b/lib/settlement/driip-settlement-challenge-state-contract.spec.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const CONTRACT_NAME = 'DriipSettlementChallengeByPayment';
+const CONTRACT_FILE = 'driip-settlement-challenge-state-contract';
+
+const chai = require('chai');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+const expect = chai.expect;
+chai.use(sinonChai);
+
+const proxyquire = require('proxyquire').noPreserveCache().noCallThru();
+
+const stubbedNahmiiContractConstructor = sinon.stub();
+
+function createContract(walletOrProvider) {
+    const DriipSettlementChallengeStateContract = proxyquire('./' + CONTRACT_FILE, {
+        '../contract': stubbedNahmiiContractConstructor
+    });
+    stubbedNahmiiContractConstructor
+        .withArgs(CONTRACT_NAME, walletOrProvider)
+        .returns(stubbedNahmiiContractConstructor);
+    return new DriipSettlementChallengeStateContract(walletOrProvider);
+}
+
+describe(CONTRACT_NAME, () => {
+    const fakeProvider = {
+        network: {
+            chainId: '123456789',
+            name: 'some network'
+        }
+    };
+    const fakeWallet = {
+        provider: fakeProvider
+    };
+
+    [
+        ['wallet', fakeWallet],
+        ['provider', fakeProvider]
+    ].forEach(([description, walletOrProvider]) => {
+        context('with ' + description, () => {
+            it('is an instance of NahmiiContract', () => {
+                expect(createContract(walletOrProvider)).to.be.instanceOf(stubbedNahmiiContractConstructor);
+            });
+        });
+    });
+});

--- a/lib/settlement/driip-settlement.js
+++ b/lib/settlement/driip-settlement.js
@@ -7,12 +7,14 @@
 const ethers = require('ethers');
 const {isRevertContractException, determineNonceFromReceipt} = require('./utils');
 const DriipSettlementChallengeContract = require('./driip-settlement-challenge-contract');
+const DriipSettlementChallengeStateContract = require('./driip-settlement-challenge-state-contract');
 const DriipSettlementContract = require('./driip-settlement-contract');
 const NestedError = require('../nested-error');
 const {caseInsensitiveCompare} = require('../utils');
 
 const _provider = new WeakMap();
 const _driipSettlementChallengeContract = new WeakMap();
+const _driipSettlementChallengeStateContract = new WeakMap();
 const _driipSettlementContract = new WeakMap();
 
 /**
@@ -34,6 +36,7 @@ class DriipSettlement {
     constructor(provider) {
         _provider.set(this, provider);
         _driipSettlementChallengeContract.set(this, new DriipSettlementChallengeContract(provider));
+        _driipSettlementChallengeStateContract.set(this, new DriipSettlementChallengeStateContract(provider));
         _driipSettlementContract.set(this, new DriipSettlementContract(provider));
     }
 
@@ -168,6 +171,25 @@ class DriipSettlement {
                 return null;
             
             throw new NestedError(err, 'Unable to get the settlement object by nonce.');
+        }
+    }
+
+    /**
+     * Returns block number of the start of the current settlement proposal
+     * @param {Address} address - The wallet address.
+     * @param {Address} ct - The currency address.
+     * @returns {Promise} A promise that resolves into true or throws errors
+     */
+    async getCurrentProposalStartBlockNumber(address, ct) {
+        try {
+            const driipSettlementChallengeStateContract = _driipSettlementChallengeStateContract.get(this);
+            return await driipSettlementChallengeStateContract.proposalDefinitionBlockNumber(address, ct);
+        }
+        catch (err) {
+            if (isRevertContractException(err)) 
+                return null;
+            
+            throw new NestedError(err, 'Unable to get the start block number of the current proposal.');
         }
     }
     

--- a/lib/settlement/driip-settlement.js
+++ b/lib/settlement/driip-settlement.js
@@ -178,7 +178,7 @@ class DriipSettlement {
      * Returns block number of the start of the current settlement proposal
      * @param {Address} address - The wallet address.
      * @param {Address} ct - The currency address.
-     * @returns {Promise} A promise that resolves into true or throws errors
+     * @returns {Promise} A promise that resolves into a BigNumber or throws errors
      */
     async getCurrentProposalStartBlockNumber(address, ct) {
         try {

--- a/lib/settlement/driip-settlement.js
+++ b/lib/settlement/driip-settlement.js
@@ -178,12 +178,13 @@ class DriipSettlement {
      * Returns block number of the start of the current settlement proposal
      * @param {Address} address - The wallet address.
      * @param {Address} ct - The currency address.
+     * @param {Integer} id - The currency id.
      * @returns {Promise} A promise that resolves into a BigNumber or throws errors
      */
-    async getCurrentProposalStartBlockNumber(address, ct) {
+    async getCurrentProposalStartBlockNumber(address, ct, id) {
         try {
             const driipSettlementChallengeStateContract = _driipSettlementChallengeStateContract.get(this);
-            return await driipSettlementChallengeStateContract.proposalDefinitionBlockNumber(address, ct);
+            return await driipSettlementChallengeStateContract.proposalDefinitionBlockNumber(address, {ct, id});
         }
         catch (err) {
             if (isRevertContractException(err)) 

--- a/lib/settlement/driip-settlement.spec.js
+++ b/lib/settlement/driip-settlement.spec.js
@@ -370,7 +370,7 @@ describe('Driip settlement operations', () => {
         it('can correctly return proposal block number', async () => {
             const blockNumber = ethers.utils.bigNumberify(1);
             stubbedDriipSettlementChallengeStateContract.proposalDefinitionBlockNumber
-                .withArgs(wallet.address, address0)
+                .withArgs(wallet.address, {ct: address0, id: address0id})
                 .resolves(blockNumber);
             const _blockNumber = await driipSettlement.getCurrentProposalStartBlockNumber(wallet.address, address0, address0id);
             expect(_blockNumber).to.equal(blockNumber);
@@ -382,7 +382,7 @@ describe('Driip settlement operations', () => {
         ].forEach(error => {
             it(`should return null when ${error.code} exception thrown`, async () => {
                 stubbedDriipSettlementChallengeStateContract.proposalDefinitionBlockNumber
-                    .withArgs(wallet.address, address0)
+                    .withArgs(wallet.address, {ct: address0, id: address0id})
                     .throws(error);
                 const blockNumber = await driipSettlement.getCurrentProposalStartBlockNumber(wallet.address, address0, address0id);
                 expect(blockNumber).to.equal(null);
@@ -391,7 +391,7 @@ describe('Driip settlement operations', () => {
         it('should rethrow unexpected exception', (done) => {
             const error = new Error('err');
             stubbedDriipSettlementChallengeStateContract.proposalDefinitionBlockNumber
-                .withArgs(wallet.address, address0)
+                .withArgs(wallet.address, {ct: address0, id: address0id})
                 .throws(error);
             driipSettlement.getCurrentProposalStartBlockNumber(wallet.address, address0, address0id).catch(e => {
                 expect(e.message).to.match(/unable.*block number/i);

--- a/lib/settlement/driip-settlement.spec.js
+++ b/lib/settlement/driip-settlement.spec.js
@@ -42,6 +42,10 @@ const stubbedDriipSettlementChallengeContract = {
     proposalStageAmount: sinon.stub()
 };
 
+const stubbedDriipSettlementChallengeStateContract = {
+    proposalDefinitionBlockNumber: sinon.stub()
+};
+
 const stubbedDriipSettlementContract = {
     settlePayment: sinon.stub(),
     settlementByWalletAndNonce: sinon.stub()
@@ -51,6 +55,9 @@ function proxyquireSettlementChallenge() {
     return proxyquire('./driip-settlement', {
         './driip-settlement-challenge-contract': function() {
             return stubbedDriipSettlementChallengeContract;
+        },
+        './driip-settlement-challenge-state-contract': function() {
+            return stubbedDriipSettlementChallengeStateContract;
         },
         './driip-settlement-contract': function() {
             return stubbedDriipSettlementContract;
@@ -92,6 +99,7 @@ describe('Driip settlement operations', () => {
         stubbedDriipSettlementChallengeContract.hasProposalExpired.reset();
         stubbedDriipSettlementChallengeContract.proposalStageAmount.reset();
         stubbedDriipSettlementChallengeContract.stopChallenge.reset();
+        stubbedDriipSettlementChallengeStateContract.proposalDefinitionBlockNumber.reset();
         stubbedDriipSettlementContract.settlePayment.reset();
         stubbedDriipSettlementContract.settlementByWalletAndNonce.reset();
     });
@@ -352,6 +360,41 @@ describe('Driip settlement operations', () => {
                 .throws(error);
             driipSettlement.hasProposalExpired(wallet.address, address0, address0id).catch(e => {
                 expect(e.message).to.match(/unable.*expired/i);
+                expect(e.innerError.message).to.match(/err/i);
+                done();
+            });
+        });
+    });
+
+    describe('#getCurrentProposalStartBlockNumber', () => {
+        it('can correctly return proposal block number', async () => {
+            const blockNumber = ethers.utils.bigNumberify(1);
+            stubbedDriipSettlementChallengeStateContract.proposalDefinitionBlockNumber
+                .withArgs(wallet.address, address0)
+                .resolves(blockNumber);
+            const _blockNumber = await driipSettlement.getCurrentProposalStartBlockNumber(wallet.address, address0, address0id);
+            expect(_blockNumber).to.equal(blockNumber);
+        });
+
+        [
+            {code: 'CALL_EXCEPTION'},
+            {code: -32000}
+        ].forEach(error => {
+            it(`should return null when ${error.code} exception thrown`, async () => {
+                stubbedDriipSettlementChallengeStateContract.proposalDefinitionBlockNumber
+                    .withArgs(wallet.address, address0)
+                    .throws(error);
+                const blockNumber = await driipSettlement.getCurrentProposalStartBlockNumber(wallet.address, address0, address0id);
+                expect(blockNumber).to.equal(null);
+            });
+        });
+        it('should rethrow unexpected exception', (done) => {
+            const error = new Error('err');
+            stubbedDriipSettlementChallengeStateContract.proposalDefinitionBlockNumber
+                .withArgs(wallet.address, address0)
+                .throws(error);
+            driipSettlement.getCurrentProposalStartBlockNumber(wallet.address, address0, address0id).catch(e => {
+                expect(e.message).to.match(/unable.*block number/i);
                 expect(e.innerError.message).to.match(/err/i);
                 done();
             });

--- a/lib/settlement/null-settlement-challenge-state-contract.js
+++ b/lib/settlement/null-settlement-challenge-state-contract.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const NahmiiContract = require('../contract');
+
+class NullSettlementChallengeState extends NahmiiContract {
+    constructor(walletOrProvider) {
+        super('NullSettlementChallengeState', walletOrProvider);
+    }
+}
+
+module.exports = NullSettlementChallengeState;

--- a/lib/settlement/null-settlement-challenge-state-contract.spec.js
+++ b/lib/settlement/null-settlement-challenge-state-contract.spec.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const CONTRACT_NAME = 'NullSettlementChallengeByPayment';
+const CONTRACT_FILE = 'null-settlement-challenge-state-contract';
+
+const chai = require('chai');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+const expect = chai.expect;
+chai.use(sinonChai);
+
+const proxyquire = require('proxyquire').noPreserveCache().noCallThru();
+
+const stubbedNahmiiContractConstructor = sinon.stub();
+
+function createContract(walletOrProvider) {
+    const NullSettlementChallengeStateContract = proxyquire('./' + CONTRACT_FILE, {
+        '../contract': stubbedNahmiiContractConstructor
+    });
+    stubbedNahmiiContractConstructor
+        .withArgs(CONTRACT_NAME, walletOrProvider)
+        .returns(stubbedNahmiiContractConstructor);
+    return new NullSettlementChallengeStateContract(walletOrProvider);
+}
+
+describe(CONTRACT_NAME, () => {
+    const fakeProvider = {
+        network: {
+            chainId: '123456789',
+            name: 'some network'
+        }
+    };
+    const fakeWallet = {
+        provider: fakeProvider
+    };
+
+    [
+        ['wallet', fakeWallet],
+        ['provider', fakeProvider]
+    ].forEach(([description, walletOrProvider]) => {
+        context('with ' + description, () => {
+            it('is an instance of NahmiiContract', () => {
+                expect(createContract(walletOrProvider)).to.be.instanceOf(stubbedNahmiiContractConstructor);
+            });
+        });
+    });
+});

--- a/lib/settlement/null-settlement.js
+++ b/lib/settlement/null-settlement.js
@@ -6,11 +6,13 @@
 
 const {isRevertContractException} = require('./utils');
 const NullSettlementChallengeContract = require('./null-settlement-challenge-contract');
+const NullSettlementChallengeStateContract = require('./null-settlement-challenge-state-contract');
 const NullSettlementContract = require('./null-settlement-contract');
 const NestedError = require('../nested-error');
 
 const _provider = new WeakMap();
 const _nullSettlementChallengeContract = new WeakMap();
+const _nullSettlementChallengeStateContract = new WeakMap();
 
 /**
  * @class NullSettlement
@@ -31,6 +33,7 @@ class NullSettlement {
     constructor(provider) {
         _provider.set(this, provider);
         _nullSettlementChallengeContract.set(this, new NullSettlementChallengeContract(provider));
+        _nullSettlementChallengeStateContract.set(this, new NullSettlementChallengeStateContract(provider));
     }
 
     /**
@@ -142,6 +145,25 @@ class NullSettlement {
                 return null;
 
             throw new NestedError(err, 'Unable to get the status for current proposal.');
+        }
+    }
+
+    /**
+     * Returns block number of the start of the current settlement proposal
+     * @param {Address} address - The wallet address.
+     * @param {Address} ct - The currency address.
+     * @returns {Promise} A promise that resolves into true or throws errors
+     */
+    async getCurrentProposalStartBlockNumber(address, ct) {
+        try {
+            const nullSettlementChallengeStateContract = _nullSettlementChallengeStateContract.get(this);
+            return await nullSettlementChallengeStateContract.proposalDefinitionBlockNumber(address, ct);
+        }
+        catch (err) {
+            if (isRevertContractException(err)) 
+                return null;
+            
+            throw new NestedError(err, 'Unable to get the start block number of the current proposal.');
         }
     }
 

--- a/lib/settlement/null-settlement.js
+++ b/lib/settlement/null-settlement.js
@@ -152,12 +152,13 @@ class NullSettlement {
      * Returns block number of the start of the current settlement proposal
      * @param {Address} address - The wallet address.
      * @param {Address} ct - The currency address.
+     * @param {Integer} id - The currency id.
      * @returns {Promise} A promise that resolves into a BigNumber or throws errors
      */
-    async getCurrentProposalStartBlockNumber(address, ct) {
+    async getCurrentProposalStartBlockNumber(address, ct, id) {
         try {
             const nullSettlementChallengeStateContract = _nullSettlementChallengeStateContract.get(this);
-            return await nullSettlementChallengeStateContract.proposalDefinitionBlockNumber(address, ct);
+            return await nullSettlementChallengeStateContract.proposalDefinitionBlockNumber(address, {ct, id});
         }
         catch (err) {
             if (isRevertContractException(err)) 

--- a/lib/settlement/null-settlement.js
+++ b/lib/settlement/null-settlement.js
@@ -152,7 +152,7 @@ class NullSettlement {
      * Returns block number of the start of the current settlement proposal
      * @param {Address} address - The wallet address.
      * @param {Address} ct - The currency address.
-     * @returns {Promise} A promise that resolves into true or throws errors
+     * @returns {Promise} A promise that resolves into a BigNumber or throws errors
      */
     async getCurrentProposalStartBlockNumber(address, ct) {
         try {

--- a/lib/settlement/null-settlement.spec.js
+++ b/lib/settlement/null-settlement.spec.js
@@ -397,7 +397,7 @@ describe('Null settlement operations', () => {
         it('can correctly return proposal block number', async () => {
             const blockNumber = ethers.utils.bigNumberify(1);
             stubbedNullSettlementChallengeStateContract.proposalDefinitionBlockNumber
-                .withArgs(wallet.address, address0)
+                .withArgs(wallet.address, {ct: address0, id: address0id})
                 .resolves(blockNumber);
             const _blockNumber = await nullSettlement.getCurrentProposalStartBlockNumber(wallet.address, address0, address0id);
             expect(_blockNumber).to.equal(blockNumber);
@@ -409,7 +409,7 @@ describe('Null settlement operations', () => {
         ].forEach(error => {
             it(`should return null when ${error.code} exception thrown`, async () => {
                 stubbedNullSettlementChallengeStateContract.proposalDefinitionBlockNumber
-                    .withArgs(wallet.address, address0)
+                    .withArgs(wallet.address, {ct: address0, id: address0id})
                     .throws(error);
                 const blockNumber = await nullSettlement.getCurrentProposalStartBlockNumber(wallet.address, address0, address0id);
                 expect(blockNumber).to.equal(null);
@@ -418,7 +418,7 @@ describe('Null settlement operations', () => {
         it('should rethrow unexpected exception', (done) => {
             const error = new Error('err');
             stubbedNullSettlementChallengeStateContract.proposalDefinitionBlockNumber
-                .withArgs(wallet.address, address0)
+                .withArgs(wallet.address, {ct: address0, id: address0id})
                 .throws(error);
             nullSettlement.getCurrentProposalStartBlockNumber(wallet.address, address0, address0id).catch(e => {
                 expect(e.message).to.match(/unable.*block number/i);

--- a/lib/settlement/null-settlement.spec.js
+++ b/lib/settlement/null-settlement.spec.js
@@ -38,6 +38,10 @@ const stubbedNullSettlementChallengeContract = {
     hasProposalTerminated: sinon.stub()
 };
 
+const stubbedNullSettlementChallengeStateContract = {
+    proposalDefinitionBlockNumber: sinon.stub()
+};
+
 const stubbedNullSettlementContract = {
     settleNull: sinon.stub()
 };
@@ -46,6 +50,9 @@ function proxyquireSettlementChallenge() {
     return proxyquire('./null-settlement', {
         './null-settlement-challenge-contract': function() {
             return stubbedNullSettlementChallengeContract;
+        },
+        './null-settlement-challenge-state-contract': function() {
+            return stubbedNullSettlementChallengeStateContract;
         },
         './null-settlement-contract': function() {
             return stubbedNullSettlementContract;
@@ -71,6 +78,7 @@ describe('Null settlement operations', () => {
         stubbedNullSettlementChallengeContract.proposalStageAmount.reset();
         stubbedNullSettlementChallengeContract.hasProposalExpired.reset();
         stubbedNullSettlementChallengeContract.hasProposalTerminated.reset();
+        stubbedNullSettlementChallengeStateContract.proposalDefinitionBlockNumber.reset();
         stubbedNullSettlementContract.settleNull.reset();
     });
 
@@ -379,6 +387,41 @@ describe('Null settlement operations', () => {
                 .throws(error);
             nullSettlement.getCurrentProposalStageAmount(wallet.address, address0, address0id).catch(e => {
                 expect(e.message).to.match(/unable.*get.*stage/i);
+                expect(e.innerError.message).to.match(/err/i);
+                done();
+            });
+        });
+    });
+
+    describe('#getCurrentProposalStartBlockNumber', () => {
+        it('can correctly return proposal block number', async () => {
+            const blockNumber = ethers.utils.bigNumberify(1);
+            stubbedNullSettlementChallengeStateContract.proposalDefinitionBlockNumber
+                .withArgs(wallet.address, address0)
+                .resolves(blockNumber);
+            const _blockNumber = await nullSettlement.getCurrentProposalStartBlockNumber(wallet.address, address0, address0id);
+            expect(_blockNumber).to.equal(blockNumber);
+        });
+
+        [
+            {code: 'CALL_EXCEPTION'},
+            {code: -32000}
+        ].forEach(error => {
+            it(`should return null when ${error.code} exception thrown`, async () => {
+                stubbedNullSettlementChallengeStateContract.proposalDefinitionBlockNumber
+                    .withArgs(wallet.address, address0)
+                    .throws(error);
+                const blockNumber = await nullSettlement.getCurrentProposalStartBlockNumber(wallet.address, address0, address0id);
+                expect(blockNumber).to.equal(null);
+            });
+        });
+        it('should rethrow unexpected exception', (done) => {
+            const error = new Error('err');
+            stubbedNullSettlementChallengeStateContract.proposalDefinitionBlockNumber
+                .withArgs(wallet.address, address0)
+                .throws(error);
+            nullSettlement.getCurrentProposalStartBlockNumber(wallet.address, address0, address0id).catch(e => {
+                expect(e.message).to.match(/unable.*block number/i);
                 expect(e.innerError.message).to.match(/err/i);
                 done();
             });

--- a/lib/settlement/settlement.js
+++ b/lib/settlement/settlement.js
@@ -122,10 +122,13 @@ class Settlement {
         const invalidReasons = [];
         try {
             const {amount, currency} = stageMonetaryAmount.toJSON();
+
+            const hasBalanceSynchronised = await this.hasOffchainSynchronised(walletAddress, currency.ct);
+            if (!hasBalanceSynchronised) 
+                throw new Error('The balances have not yet synchronised with the latest states of the on-chain contracts.');
+                
             const tokenInfo = await provider.getTokenInfo(currency.ct, true);
-
             const stageAmountBN = ethers.utils.bigNumberify(amount);
-
             const balances = await provider.getNahmiiBalances(walletAddress);
             const balance = balances.find(bal => caseInsensitiveCompare(bal.currency.ct, currency.ct));
             const balanceAvailableBN = ethers.utils.bigNumberify(balance.amountAvailable);
@@ -484,6 +487,31 @@ class Settlement {
         catch (error) {
             throw new NestedError(error, 'Unable to settle a challenge');
         }
+    }
+
+    /**
+     * Check if the offchain balance has been synchronised.
+     * @param {Address} address - The wallet address
+     * @param {Address} ct - The currency address
+     * @param [options]
+     * @returns {Promise} A promise that resolves into a boolean value.
+     */
+    async hasOffchainSynchronised(address, ct) {
+        const provider = _provider.get(this);
+        const driipSettlement = _driipSettlement.get(this);
+        const nullSettlement = _nullSettlement.get(this);
+
+        const startBlockNumbers = await Promise.all([
+            driipSettlement.getCurrentProposalStartBlockNumber(address, ct, 0),
+            nullSettlement.getCurrentProposalStartBlockNumber(address, ct, 0)
+        ]);
+        const balances = await provider.getNahmiiBalances(address);
+        const currencyBalance = balances.find(bal => caseInsensitiveCompare(bal.currency.ct, ct));
+        for (const startBlockNumber of startBlockNumbers) {
+            if (startBlockNumber && startBlockNumber.toNumber() > currencyBalance.blockNumber) 
+                return false;
+        }
+        return true;
     }
 }
 

--- a/lib/settlement/settlement.spec.js
+++ b/lib/settlement/settlement.spec.js
@@ -35,6 +35,7 @@ const stubbedDriipSettlement = {
     startChallengeFromPayment: sinon.stub(),
     settleDriipAsPayment: sinon.stub(),
     getCurrentProposalExpirationTime: sinon.stub(),
+    getCurrentProposalStartBlockNumber: sinon.stub(),
     checkStartChallengeFromPayment: sinon.stub(),
     stopChallenge: sinon.stub()
 };
@@ -45,6 +46,7 @@ const stubbedNullSettlement = {
     settleNull: sinon.stub(),
     getCurrentProposalExpirationTime: sinon.stub(),
     getCurrentProposalStageAmount: sinon.stub(),
+    getCurrentProposalStartBlockNumber: sinon.stub(),
     checkStartChallenge: sinon.stub(),
     stopChallenge: sinon.stub()
 };
@@ -128,6 +130,7 @@ describe('Settlement', () => {
         stubbedDriipSettlement.getCurrentProposalExpirationTime.reset();
         stubbedDriipSettlement.checkStartChallengeFromPayment.reset();
         stubbedDriipSettlement.stopChallenge.reset();
+        stubbedDriipSettlement.getCurrentProposalStartBlockNumber.reset();
         stubbedNullSettlement.checkSettleNull.reset();
         stubbedNullSettlement.startChallenge.reset();
         stubbedNullSettlement.settleNull.reset();
@@ -135,6 +138,7 @@ describe('Settlement', () => {
         stubbedNullSettlement.getCurrentProposalStageAmount.reset();
         stubbedNullSettlement.checkStartChallenge.reset();
         stubbedNullSettlement.stopChallenge.reset();
+        stubbedNullSettlement.getCurrentProposalStartBlockNumber.reset();
         stubbedProvider.getNahmiiBalances.reset();
         stubbedProvider.getTransactionConfirmation.reset();
     });
@@ -494,6 +498,22 @@ describe('Settlement', () => {
 
             return settlement.checkStartChallenge(stageMonetaryAmount, null, wallet.address).catch(e => {
                 expect(e.innerError.message).to.match(/.*maximum.*allowable.*balance.*/i);
+            });
+        });
+        it('should throw exception when the nahmii balance has not yet synchronised with the latest on-chain states', () => {
+            const stageMonetaryAmount = MonetaryAmount.from('1', currency.ct, currency.id);
+            stubbedProvider.getNahmiiBalances
+                .withArgs(wallet.address)
+                .resolves([{
+                    currency,
+                    blockNumber: 1
+                }]);
+            stubbedNullSettlement.getCurrentProposalStartBlockNumber
+                .withArgs(wallet.address, currency.ct)
+                .resolves(ethers.utils.bigNumberify(2));
+
+            return settlement.checkStartChallenge(stageMonetaryAmount, null, wallet.address).catch(e => {
+                expect(e.innerError.message).to.match(/.*balances.*not.*sync.*/i);
             });
         });
     });
@@ -1093,6 +1113,40 @@ describe('Settlement', () => {
             return settlement.getMaxChallengesTimeout(wallet.address, currency.ct, currency.id).catch(e => {
                 expect(e).to.be.an.instanceOf(Error);
                 expect(e.innerError).not.be.undefined;
+            });
+        });
+    });
+    describe('#hasOffchainSynchronised()', async () => {
+        [
+            [1, null, null, true],
+            [1, 1, null, true],
+            [1, null, 1, true],
+            [1, 1, 1, true],
+            [2, 1, 1, true],
+            [3, 2, 1, true],
+            [3, 2, 3, true],
+            [1, 2, null, false],
+            [1, null, 2, false],
+            [1, 2, 2, false],
+            [1, 1, 2, false],
+            [2, 1, 3, false]
+        ].forEach(([balanceBlockNumber, nullSettlementStartBlockNumber, driipSettlementStartBlockNumber, hasSynchronised]) => {
+            it(`returns ${hasSynchronised} when block numbers are [balance: ${balanceBlockNumber}, nullSettlement: ${nullSettlementStartBlockNumber}], driipSettlement: ${driipSettlementStartBlockNumber}`, async () => {
+                stubbedProvider.getNahmiiBalances
+                    .withArgs(wallet.address)
+                    .resolves([{
+                        currency,
+                        blockNumber: balanceBlockNumber
+                    }]);
+                stubbedNullSettlement.getCurrentProposalStartBlockNumber
+                    .withArgs(wallet.address, currency.ct)
+                    .resolves(nullSettlementStartBlockNumber ? ethers.utils.bigNumberify(nullSettlementStartBlockNumber) : null);
+                stubbedDriipSettlement.getCurrentProposalStartBlockNumber
+                    .withArgs(wallet.address, currency.ct)
+                    .resolves(driipSettlementStartBlockNumber ? ethers.utils.bigNumberify(driipSettlementStartBlockNumber) : null);
+                const synced = await settlement.hasOffchainSynchronised(wallet.address, currency.ct);
+                
+                expect(synced).to.equal(hasSynchronised);
             });
         });
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nahmii-sdk",
-  "version": "2.2.7",
+  "version": "2.3.0",
   "description": "Javascript SDK for using hubii nahmii APIs",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Description
When making a payment or starting a new settlement, it requires the off-chain balance has been synchronised with the latest states of the smart contracts, so as to avoid the potential balance overrun. At the moment, the front-end hubii-core is utilising a fixed time blocker(lock for 30 block confirmations) to prevent any new payments or settlements per currency after started a new settlement. 

This PR will enable the front ends to deprecate such time blocker. It will be more reliable to use this mechanism to ensure the off-chain balance is synchronised as it is checking against the actual states between the off-chain and on-chain instead of using a fixed time blocker at the client side.

### Other information
The newly created function is currently integrated into the starting settlement process, but it is not included when making a payment. The reason is to leave the current payment function decoupled from this sychronisation checking, which will need to pull data from both balance API and the on-chain contracts so could introduce noticeable performance overhead when making batch payments such as monthly airdriip.

So for now, the decision of whether to call this check before making payments is left to the front ends.

### Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] The [Contribution Guidelines][1] has been followed
- [x] Tests for the changes have been added and all test pass (`npm test`)
- [x] JSDoc comments have been reviewed and added / updated as needed
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures
- [x] Package version number was updated according to semantic rules
- [x] Any changes to upstream dependencies have already been published

