### PR TITLE
Update include of Ropsten abstractions and bump patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nahmii-sdk",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Javascript SDK for using hubii nahmii APIs",
   "main": "index.js",
   "scripts": {
@@ -67,7 +67,7 @@
     "keythereum": "^1.0.4",
     "lodash.get": "^4.4.2",
     "nahmii-contract-abstractions": "2.0.1",
-    "nahmii-contract-abstractions-ropsten": "~3.0.1",
+    "nahmii-contract-abstractions-ropsten": "^3.1.0",
     "nahmii-ethereum-address": "^2.0.0",
     "node-yaml": "^3.2.0",
     "socket.io-client": "^2.2.0",


### PR DESCRIPTION
### Description
This package does not depend on the latest release of _nahmii-contract-abstractions-ropsten_. It includes by `~3.0.1` where it rather should have included by `^3.0.1`.

With this PR the inclusion is updated to `^3.1.0` corresponding to release v1.4.0-ropsten.1 of nahmii-contracts.

### Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] The [Contribution Guidelines][1] has been followed
- [x] Tests for the changes have been added and all test pass (`npm test`)
- [x] JSDoc comments have been reviewed and added / updated as needed
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures
- [x] Package version number was updated according to semantic rules
- [x] Any changes to upstream dependencies have already been published


[1]: https://github.com/hubiinetwork/nahmii-sdk#contributing
