### PR TITLE
Fix wallet nonce comparison

### DIFF
--- a/lib/settlement/driip-settlement.js
+++ b/lib/settlement/driip-settlement.js
@@ -244,8 +244,8 @@ class DriipSettlement {
             if (settled)
                 invalidReasons.push(new Error('The settlement can not be replayed!'));
     
-            if (ethers.utils.bigNumberify(nonce) <= latestNonce)
-                invalidReasons.push(new Error('The challenge can not be restarted!'));
+            if (latestNonce && ethers.utils.bigNumberify(nonce).lte(latestNonce))
+                invalidReasons.push(new Error('The settlement can not be restarted!'));
     
             if (invalidReasons.length)
                 return {valid: false, reasons: invalidReasons};

--- a/lib/settlement/driip-settlement.spec.js
+++ b/lib/settlement/driip-settlement.spec.js
@@ -505,7 +505,7 @@ describe('Driip settlement operations', () => {
         it('should be invalid to start new challenge', async () => {
             const notExpiredError = new Error('Current challenge proposal has not expired yet!');
             const replayError = new Error('The settlement can not be replayed!');
-            const restartError = new Error('The challenge can not be restarted!');
+            const restartError = new Error('The settlement can not be restarted!');
             const expectedResult = {
                 valid: false,
                 reasons: [notExpiredError, replayError, restartError]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nahmii-sdk",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "Javascript SDK for using hubii nahmii APIs",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Description
This PR fixes an issue during checking if the wallet nonce is strictly greater than the one used in the last settlement.

Because the nonce retrieved from the contract are in BigNumber object type, which is not safe to use the operator such as `<=` to do the comparison. Using the JS operators like `<=` can introduce incorrect comparison result.

Instead, it should use the `BigNumber` library's built-in comparison function `lte`.

### Issues
<!-- Enter references to relevant github issues -->

Issues: 


### Other information
This issue could lead the SDK to start null settlement when it is supposed to start driip settlement beforehand. If so, it would fail to synchronise contract's active balance with the latest receipt, and the null settlement could fail with a stage amount greater than the current active balance.



### Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] The [Contribution Guidelines][1] has been followed
- [x] Tests for the changes have been added and all test pass (`npm test`)
- [x] JSDoc comments have been reviewed and added / updated as needed
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures
- [x] Package version number was updated according to semantic rules
- [x] Any changes to upstream dependencies have already been published


[1]: https://github.com/hubiinetwork/nahmii-sdk#contributing
