### PR TITLE
Lazy instantiation

### DIFF
--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -34,9 +34,6 @@ class Wallet extends ethers.Signer {
             _signatureProvider.set(this, signerFromKey.call(this, signer));
         else
             _signatureProvider.set(this, signerFromExternalImpl.call(this, signer.signMessage, signer.signTransaction, signer.address));
-
-        _clientFund.set(this, new ClientFundContract(this));
-        _balanceTracker.set(this, new BalanceTrackerContract(this));
     }
 
     /**
@@ -94,7 +91,7 @@ class Wallet extends ethers.Signer {
      * @return {Promise<BigNumber>}
      */
     async getNahmiiStagedBalance(symbol) {
-        const balanceTracker = _balanceTracker.get(this);
+        const balanceTracker = acquireBalanceTrackerContract.call(this);
         const balanceType = await balanceTracker.stagedBalanceType();
         const tokenInfo = await this.provider.getTokenInfo(symbol);
         const stagedBalance = await balanceTracker.get(
@@ -128,7 +125,7 @@ class Wallet extends ethers.Signer {
     async depositEth(amountEth, options) {
         options = {gasLimit: 600000, ...options};
         const amountWei = ethers.utils.parseEther(amountEth.toString());
-        const clientFund = _clientFund.get(this);
+        const clientFund = acquireClientFundContract.call(this);
         const rawTx = {
             to: clientFund.address,
             value: amountWei,
@@ -147,7 +144,7 @@ class Wallet extends ethers.Signer {
      */
     async getDepositAllowance(symbol) {
         const contract = await Erc20Contract.from(symbol, this);
-        return contract.allowance(this.address, _clientFund.get(this).address);
+        return contract.allowance(this.address, acquireClientFundContract.call(this).address);
     }
 
     /**
@@ -166,7 +163,7 @@ class Wallet extends ethers.Signer {
         options = {gasLimit: 600000, ...options};
         const contract = await Erc20Contract.from(symbol, this);
         const amountBN = contract.parse(amount.toString());
-        const clientFund = _clientFund.get(this);
+        const clientFund = acquireClientFundContract.call(this);
         try {
             return await contract.approve(clientFund.address, amountBN, options);
         }
@@ -192,7 +189,7 @@ class Wallet extends ethers.Signer {
         options = {gasLimit: 600000, ...options};
         const contract = await Erc20Contract.from(symbol, this);
         const amountBN = contract.parse(amount.toString());
-        const clientFund = _clientFund.get(this);
+        const clientFund = acquireClientFundContract.call(this);
 
         try {
             return await clientFund.receiveTokens('', amountBN, contract.address, 0, 'ERC20', options);
@@ -215,7 +212,7 @@ class Wallet extends ethers.Signer {
      */
     async withdraw(monetaryAmount, options = {}) {
         const {amount, currency} = monetaryAmount.toJSON();
-        const clientFund = _clientFund.get(this);
+        const clientFund = acquireClientFundContract.call(this);
         return await clientFund.withdraw(amount, currency.ct, currency.id, 'ERC20', options);
     }
 
@@ -233,7 +230,7 @@ class Wallet extends ethers.Signer {
      */
     async unstage(monetaryAmount, options = {}) {
         const {amount, currency} = monetaryAmount.toJSON();
-        const clientFund = _clientFund.get(this);
+        const clientFund = acquireClientFundContract.call(this);
         return await clientFund.unstage(amount, currency.ct, currency.id, 'ERC20', options);
     }
 
@@ -335,4 +332,32 @@ function signerFromExternalImpl(signMessage, sign, address) {
         return {signMessage, sign, address};
 
     throw new Error('Invalid parameter passed to Wallet constructor');
+}
+
+/**
+ * @private - invoke bound to instance.
+ * Lazily instantiates client fund contract on first invocation.
+ * @returns {ClientFundContract} instance of client fund contract.
+ */
+function acquireClientFundContract() {
+    let contract = _clientFund.get(this);
+    if (!contract) {
+        contract = new ClientFundContract(this);
+        _clientFund.set(this, contract);
+    }
+    return contract;
+}
+
+/**
+ * @private - invoke bound to instance.
+ * Lazily instantiates balance tracked contract on first invocation.
+ * @returns {BalanceTrackerContract} instance of balance tracker contract.
+ */
+function acquireBalanceTrackerContract() {
+    let contract = _balanceTracker.get(this);
+    if (!contract) {
+        contract = new BalanceTrackerContract(this);
+        _balanceTracker.set(this, contract);
+    }
+    return contract;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nahmii-sdk",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "description": "Javascript SDK for using hubii nahmii APIs",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Description
<!-- Enter a description of what this PR changes -->

Avoids instantiating BalanceTracker and ClientFund contracts until they are actually used.

### Issues
<!-- Enter references to relevant github issues -->

Issues: 


### Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

This should make it easier to use the Wallet class in situations where a proper provider is not available, such as using wallets in a testing environment, since non-network based features will work without any further action.

### Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] The [Contribution Guidelines][1] has been followed
- [x] Tests for the changes have been added and all test pass (`npm test`)
- [x] JSDoc comments have been reviewed and added / updated as needed
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures
- [x] Package version number was updated according to semantic rules
- [x] Any changes to upstream dependencies have already been published


[1]: https://github.com/hubiinetwork/nahmii-sdk#contributing
