### PR TITLE
NahmiiProvider#operatorAddress

### DIFF
--- a/Docs/nahmii-provider.md
+++ b/Docs/nahmii-provider.md
@@ -4,8 +4,9 @@
 
 * [nahmii-sdk](#module_nahmii-sdk)
     * [NahmiiProvider](#exp_module_nahmii-sdk--NahmiiProvider) ⏏
-        * [new NahmiiProvider(nahmiiDomain, apiAppId, apiAppSecret, nodeUrl, network)](#new_module_nahmii-sdk--NahmiiProvider_new)
+        * [new NahmiiProvider(nahmiiDomain, apiAppId, apiAppSecret, nodeUrl, network, [operator])](#new_module_nahmii-sdk--NahmiiProvider_new)
         * _instance_
+            * [.operatorAddress](#module_nahmii-sdk--NahmiiProvider+operatorAddress) ⇒ <code>EthereumAddress</code> \| <code>null</code>
             * [.nahmiiDomain](#module_nahmii-sdk--NahmiiProvider+nahmiiDomain) ⇒ <code>string</code>
             * [.isUpdating](#module_nahmii-sdk--NahmiiProvider+isUpdating) ⇒ <code>boolean</code>
             * [.startUpdate()](#module_nahmii-sdk--NahmiiProvider+startUpdate)
@@ -33,19 +34,20 @@ A class providing low-level access to the _hubii nahmii_ APIs.
 **Kind**: Exported class  
 <a name="new_module_nahmii-sdk--NahmiiProvider_new"></a>
 
-#### new NahmiiProvider(nahmiiDomain, apiAppId, apiAppSecret, nodeUrl, network)
+#### new NahmiiProvider(nahmiiDomain, apiAppId, apiAppSecret, nodeUrl, network, [operator])
 Construct a new NahmiiProvider.
 Instead of using this constructor directly it is recommended that you use
 the NahmiiProvider.from() factory function.
 
 
-| Param | Type | Description |
-| --- | --- | --- |
-| nahmiiDomain | <code>string</code> | The domain name for the nahmii API |
-| apiAppId | <code>string</code> | nahmii API app-ID |
-| apiAppSecret | <code>string</code> | nahmii API app-secret |
-| nodeUrl | <code>string</code> | url to an ethereum node to connect to |
-| network | <code>string</code> \| <code>number</code> | a known ethereum network name or ID |
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| nahmiiDomain | <code>string</code> |  | The domain name for the nahmii API |
+| apiAppId | <code>string</code> |  | nahmii API app-ID |
+| apiAppSecret | <code>string</code> |  | nahmii API app-secret |
+| nodeUrl | <code>string</code> |  | url to an ethereum node to connect to |
+| network | <code>string</code> \| <code>number</code> |  | a known ethereum network name or ID |
+| [operator] | <code>EthereumAddress</code> | <code></code> | The address of the nahmii operator |
 
 **Example**  
 ```js
@@ -53,6 +55,13 @@ const {NahmiiProvider} = require('nahmii-sdk');
 
 const provider = await NahmiiProvider.from('api.nahmii.io', app_id, app_secret);
 ```
+<a name="module_nahmii-sdk--NahmiiProvider+operatorAddress"></a>
+
+#### nahmiiProvider.operatorAddress ⇒ <code>EthereumAddress</code> \| <code>null</code>
+Returns the operator address of the nahmii cluster as it was defined at
+the time when this provider was created.
+
+**Kind**: instance property of [<code>NahmiiProvider</code>](#exp_module_nahmii-sdk--NahmiiProvider)  
 <a name="module_nahmii-sdk--NahmiiProvider+nahmiiDomain"></a>
 
 #### nahmiiProvider.nahmiiDomain ⇒ <code>string</code>

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ easier to get started with.
 ## About nahmii
 
 _nahmii_ is _hubii_'s scaling solution for the Ethereum block chain. It is a
-hybrid centralized/decentralized solution that enables instant
-(micro-) payments, trading and trustless settlements.
+hybrid centralized/decentralized solution that enables instant (micro-) 
+payments, trading and trustless settlements.
 
 ## About hubii
 
@@ -27,6 +27,23 @@ See www.hubii.com for more information.
 To install the SDK into your project, simply run:
 
     npm install nahmii-sdk
+
+## Dependency management
+
+After you have installed the nahmii-sdk module into your own project, please 
+make sure to install the dependencies listed as _peer dependencies_ into your 
+project to have it included in the end product.
+
+The reason this SDK uses _peer dependencies_ is that it is actively doing type 
+checking for some shared types in some situations. To have type checking work in 
+a nodejs environment, all npm-based types must be de-duplicated. 
+
+To force a de-duplication after you have installed several modules, just run the 
+following command:
+
+    npm ddp
+
+In most cases this should not be needed though.
 
 ## Usage
 

--- a/lib/nahmii-provider.js
+++ b/lib/nahmii-provider.js
@@ -11,6 +11,7 @@ const {createApiToken} = require('./identity-model');
 const NahmiiRequest = require('./nahmii-request');
 const ClusterInformation = require('./cluster-information');
 const InsufficientFundsError = require('./insufficient-funds-error');
+const {EthereumAddress} = require('nahmii-ethereum-address');
 
 // Private properties
 const _nahmiiDomain = new WeakMap();
@@ -20,6 +21,7 @@ const _apiAccessToken = new WeakMap();
 const _apiAccessTokenPending = new WeakMap();
 const _tokenInterval = new WeakMap();
 const _nahmii = new WeakMap();
+const _operator = new WeakMap();
 
 
 /**
@@ -41,9 +43,13 @@ class NahmiiProvider extends ethers.providers.JsonRpcProvider {
      * @param {string} apiAppSecret - nahmii API app-secret
      * @param {string} nodeUrl - url to an ethereum node to connect to
      * @param {string|number} network - a known ethereum network name or ID
+     * @param {EthereumAddress} [operator] - The address of the nahmii operator
      */
-    constructor(nahmiiDomain, apiAppId, apiAppSecret, nodeUrl, network) {
+    constructor(nahmiiDomain, apiAppId, apiAppSecret, nodeUrl, network, operator = null) {
         super(nodeUrl, network);
+
+        if (operator && !(operator instanceof EthereumAddress))
+            throw new TypeError('Invalid argument - operator not an EthereumAddress');
 
         _nahmiiDomain.set(this, nahmiiDomain);
         _appId.set(this, apiAppId);
@@ -51,6 +57,7 @@ class NahmiiProvider extends ethers.providers.JsonRpcProvider {
         _nahmii.set(this, new NahmiiRequest(nahmiiDomain, () => {
             return this.getApiAccessToken();
         }));
+        _operator.set(this, (operator || null));
     }
 
     /**
@@ -63,12 +70,17 @@ class NahmiiProvider extends ethers.providers.JsonRpcProvider {
      */
     static async from(nahmiiDomain, apiAppId, apiAppSecret) {
         const {ethereum} = await ClusterInformation.get(nahmiiDomain);
-        return new NahmiiProvider(nahmiiDomain, apiAppId, apiAppSecret, ethereum.node, ethereum.net);
+        const operator = EthereumAddress.from(ethereum.operatorAddress);
+        return new NahmiiProvider(nahmiiDomain, apiAppId, apiAppSecret, ethereum.node, ethereum.net, operator);
     }
 
+    /**
+     * Returns the operator address of the nahmii cluster as it was defined at
+     * the time when this provider was created.
+     * @returns {EthereumAddress|null}
+     */
     get operatorAddress() {
-        // TODO: implement
-        throw new Error('Not implemented');
+        return _operator.get(this);
     }
 
     /**

--- a/lib/nahmii-provider.spec.js
+++ b/lib/nahmii-provider.spec.js
@@ -8,6 +8,7 @@ chai.use(sinonChai);
 
 const proxyquire = require('proxyquire').noPreserveCache().noCallThru();
 const InsufficientFundsError = require('./insufficient-funds-error');
+const {EthereumAddress} = require('nahmii-ethereum-address');
 
 const stubbedIdentityModel = {
     createApiToken: sinon.stub()
@@ -63,7 +64,8 @@ describe('Nahmii Provider', () => {
         clusterInformation = {
             ethereum: {
                 node: node,
-                net: network
+                net: network,
+                operatorAddress: '0x0000000000000000000000000000000000000666'
             }
         };
         stubbedClusterInformation.get = sinon.stub();
@@ -87,7 +89,14 @@ describe('Nahmii Provider', () => {
                 .withArgs('/ethereum/supported-tokens')
                 .resolves(testTokens);
             const NahmiiProvider = proxyquireProvider();
-            provider = new NahmiiProvider(baseUrl, appId, appSecret, node, network);
+            provider = new NahmiiProvider(
+                baseUrl,
+                appId,
+                appSecret,
+                node,
+                network,
+                EthereumAddress.from(clusterInformation.ethereum.operatorAddress)
+            );
         });
 
         afterEach(() => {
@@ -380,6 +389,10 @@ describe('Nahmii Provider', () => {
 
         it('can retrieve cluster information', async () => {
             expect(await provider.getClusterInformation()).to.eql(clusterInformation);
+        });
+
+        it('has the operator address', () => {
+            expect(provider.operatorAddress.toString()).to.eql(clusterInformation.ethereum.operatorAddress);
         });
     }
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nahmii-sdk",
-  "version": "2.3.4",
+  "version": "2.4.0",
   "description": "Javascript SDK for using hubii nahmii APIs",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "chai-as-promised": "^7.1.1",
     "eslint": "^5.16.0",
     "jsdoc-to-markdown": "^5.0.0",
-    "mocha": "^6.0.2",
+    "mocha": "^6.2.0",
     "nock": "^10.0.6",
     "npm-install-peers": "^1.2.1",
     "nyc": "^14.1.0",

--- a/package.json
+++ b/package.json
@@ -67,15 +67,15 @@
     "lodash.get": "^4.4.2",
     "nahmii-contract-abstractions": "2.0.1",
     "nahmii-contract-abstractions-ropsten": "^3.1.0",
-    "nahmii-ethereum-address": "^2.0.1",
     "socket.io-client": "^2.2.0",
     "superagent": "^5.1.0",
     "uuid": "^3.3.2",
     "web3-utils": "1.0.0-beta.55"
   },
   "peerDependencies": {
-    "bson": "^4.0.0",
-    "ethers": "~4.0.0"
+    "bson": ">=1.1.1",
+    "ethers": "~4.0.0",
+    "nahmii-ethereum-address": "^2.0.1"
   },
   "peerInstallOptions": {
     "prefix": "./peer_modules"


### PR DESCRIPTION
### Description
<!-- Enter a description of what this PR changes -->

Implements the `operatorAddress` property on the NahmiiProvider class. 

The value of this property is determined from the cluster's meta information at the time of constructing the provider (using the `from()` factory function). If you use the constructor of the provider directly you are expected to provide this piece of information if it is required later on. 

### Issues
<!-- Enter references to relevant github issues -->

Issues: 


### Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

* `nahmii-ethereum-address` is now a peer dependency of this package.


### Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] The [Contribution Guidelines][1] has been followed
- [X] Tests for the changes have been added and all test pass (`npm test`)
- [X] JSDoc comments have been reviewed and added / updated as needed
- [X] Build (`npm run build`) was run locally and any changes were pushed
- [X] Lint (`npm run lint`) has passed locally and any fixes were made for failures
- [X] Package version number was updated according to semantic rules
- [X] Any changes to upstream dependencies have already been published


[1]: https://github.com/hubiinetwork/nahmii-sdk#contributing
