### PR TITLE
Use Configuration to check if settlement is disabled

### DIFF
--- a/lib/settlement/configuration-contract.js
+++ b/lib/settlement/configuration-contract.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const NahmiiContract = require('../contract');
+
+class ConfigurationContract extends NahmiiContract {
+    constructor(walletOrProvider) {
+        super('Configuration', walletOrProvider);
+    }
+}
+
+module.exports = ConfigurationContract;

--- a/lib/settlement/configuration-contract.spec.js
+++ b/lib/settlement/configuration-contract.spec.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const CONTRACT_NAME = 'Configuration';
+const CONTRACT_FILE = 'configuration-contract';
+
+const chai = require('chai');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+const expect = chai.expect;
+chai.use(sinonChai);
+
+const proxyquire = require('proxyquire').noPreserveCache().noCallThru();
+
+const stubbedNahmiiContractConstructor = sinon.stub();
+
+function createContract(walletOrProvider) {
+    const ConfigurationContract = proxyquire('./' + CONTRACT_FILE, {
+        '../contract': stubbedNahmiiContractConstructor
+    });
+    stubbedNahmiiContractConstructor
+        .withArgs(CONTRACT_NAME, walletOrProvider)
+        .returns(stubbedNahmiiContractConstructor);
+    return new ConfigurationContract(walletOrProvider);
+}
+
+describe(CONTRACT_NAME, () => {
+    const fakeProvider = {
+        network: {
+            chainId: '123456789',
+            name: 'some network'
+        }
+    };
+    const fakeWallet = {
+        provider: fakeProvider
+    };
+
+    [
+        ['wallet', fakeWallet],
+        ['provider', fakeProvider]
+    ].forEach(([description, walletOrProvider]) => {
+        context('with ' + description, () => {
+            it('is an instance of NahmiiContract', () => {
+                expect(createContract(walletOrProvider)).to.be.instanceOf(stubbedNahmiiContractConstructor);
+            });
+        });
+    });
+});

--- a/lib/settlement/settlement.js
+++ b/lib/settlement/settlement.js
@@ -130,7 +130,7 @@ class Settlement {
             const earliestSettlementBlockNumber = await configurationContract.earliestSettlementBlockNumber();
             const latestBlockNumber = await provider.getBlockNumber();
             if (earliestSettlementBlockNumber.gt(latestBlockNumber)) 
-                throw new Error('Currently the settlement is disabled.');
+                throw new Error('Settlements are currently disabled.');
 
             const hasBalanceSynchronised = await this.hasOffchainSynchronised(walletAddress, currency.ct);
             if (!hasBalanceSynchronised) 

--- a/lib/settlement/settlement.js
+++ b/lib/settlement/settlement.js
@@ -6,6 +6,7 @@
 
 const ethers = require('ethers');
 const {determineNonceFromReceipt} = require('./utils');
+const ConfigurationContract = require('./configuration-contract');
 const DriipSettlement = require('./driip-settlement');
 const NullSettlement = require('./null-settlement');
 const Receipt = require('../receipt');
@@ -16,6 +17,7 @@ const {caseInsensitiveCompare} = require('../utils');
 const _provider = new WeakMap();
 const _driipSettlement = new WeakMap();
 const _nullSettlement = new WeakMap();
+const _configurationContract = new WeakMap();
 
 /**
  * @class Settlement
@@ -31,6 +33,7 @@ class Settlement {
         _provider.set(this, provider);
         _driipSettlement.set(this, new DriipSettlement(provider));
         _nullSettlement.set(this, new NullSettlement(provider));
+        _configurationContract.set(this, new ConfigurationContract(provider));
     }
 
     /**
@@ -117,11 +120,17 @@ class Settlement {
         const provider = _provider.get(this);
         const driipSettlement = _driipSettlement.get(this);
         const nullSettlement = _nullSettlement.get(this);
+        const configurationContract = _configurationContract.get(this);
 
         const allowedChallenges = [];
         const invalidReasons = [];
         try {
             const {amount, currency} = stageMonetaryAmount.toJSON();
+
+            const earliestSettlementBlockNumber = await configurationContract.earliestSettlementBlockNumber();
+            const latestBlockNumber = await provider.getBlockNumber();
+            if (earliestSettlementBlockNumber.gt(latestBlockNumber)) 
+                throw new Error('Currently the settlement is disabled.');
 
             const hasBalanceSynchronised = await this.hasOffchainSynchronised(walletAddress, currency.ct);
             if (!hasBalanceSynchronised) 

--- a/lib/settlement/settlement.spec.js
+++ b/lib/settlement/settlement.spec.js
@@ -17,6 +17,7 @@ const stubbedProvider = {
     getNahmiiBalances: sinon.stub(),
     getWalletReceipts: sinon.stub(),
     getTokenInfo: sinon.stub(),
+    getBlockNumber: sinon.stub(),
     getTransactionConfirmation: sinon.stub()
 };
 
@@ -26,6 +27,10 @@ const stubbedClientFundContract = {
 
 const stubbedErc20Contract = {
     approve: sinon.stub()
+};
+
+const stubbedConfiguration = {
+    earliestSettlementBlockNumber: sinon.stub()
 };
 
 const stubbedDriipSettlement = {
@@ -73,6 +78,9 @@ function proxyquireSettlement() {
         },
         './null-settlement': function() {
             return stubbedNullSettlement;
+        },
+        './configuration-contract': function() {
+            return stubbedConfiguration;
         }
     });
 }
@@ -139,8 +147,10 @@ describe('Settlement', () => {
         stubbedNullSettlement.checkStartChallenge.reset();
         stubbedNullSettlement.stopChallenge.reset();
         stubbedNullSettlement.getCurrentProposalStartBlockNumber.reset();
+        stubbedConfiguration.earliestSettlementBlockNumber.reset();
         stubbedProvider.getNahmiiBalances.reset();
         stubbedProvider.getTransactionConfirmation.reset();
+        stubbedProvider.getBlockNumber.reset();
     });
 
     describe('#getLatestReceiptForSettlement()', () => {
@@ -383,6 +393,12 @@ describe('Settlement', () => {
     describe('#checkStartChallenge()', () => {
         beforeEach(() => {
             settlement.getOngoingChallenges = sinon.stub();
+
+            stubbedConfiguration.earliestSettlementBlockNumber.resolves(ethers.utils.bigNumberify(1));
+            stubbedProvider.getBlockNumber.resolves(2);
+            stubbedProvider.getTokenInfo
+                .withArgs(currency.ct, true)
+                .resolves({symbol: 'ETH', decimals: 18});
         });
         afterEach(() => {
             settlement.getOngoingChallenges.reset();
@@ -447,9 +463,6 @@ describe('Settlement', () => {
                 const checkNull = stubbedNullSettlement.checkStartChallenge
                     .withArgs(stageMonetaryAmount, wallet.address);
 
-                stubbedProvider.getTokenInfo
-                    .withArgs(currency.ct, true)
-                    .resolves({symbol: 'ETH', decimals: 18});
                 stubbedProvider.getNahmiiBalances
                     .withArgs(wallet.address)
                     .resolves([{
@@ -485,9 +498,6 @@ describe('Settlement', () => {
             const amountBN = ethers.utils.bigNumberify('100');
             const amountAvailableBN = amountBN.sub(1);
             const stageMonetaryAmount = MonetaryAmount.from(amountBN.toString(), currency.ct, currency.id);
-            stubbedProvider.getTokenInfo
-                .withArgs(currency.ct, true)
-                .resolves({symbol: 'ETH', decimals: 18});
             stubbedProvider.getNahmiiBalances
                 .withArgs(wallet.address)
                 .resolves([{
@@ -514,6 +524,14 @@ describe('Settlement', () => {
 
             return settlement.checkStartChallenge(stageMonetaryAmount, null, wallet.address).catch(e => {
                 expect(e.innerError.message).to.match(/.*balances.*not.*sync.*/i);
+            });
+        });
+        it('should throw exception when settlement is disabled', () => {
+            const stageMonetaryAmount = MonetaryAmount.from('1', currency.ct, currency.id);
+            stubbedConfiguration.earliestSettlementBlockNumber.resolves(ethers.utils.bigNumberify(3));
+
+            return settlement.checkStartChallenge(stageMonetaryAmount, null, wallet.address).catch(e => {
+                expect(e.innerError.message).to.match(/.*settlement.*disabled/i);
             });
         });
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nahmii-sdk",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Javascript SDK for using hubii nahmii APIs",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Description
<!-- Enter a description of what this PR changes -->
When the settlement is disabled on-chain, we need a better way for the clients to know if it is disabled and prevent them from wasting gas costs in attempting to starting new settlements.

Using the `Configuration` contract, the SDK should be able to check if the settlement is disabled or not based on the earliest settlement block number before starting new settlements. It will throw an exception to notify the clients when the settlement is disabled.

### Issues
<!-- Enter references to relevant github issues -->

Issues: 


### Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->



### Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] The [Contribution Guidelines][1] has been followed
- [x] Tests for the changes have been added and all test pass (`npm test`)
- [x] JSDoc comments have been reviewed and added / updated as needed
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures
- [x] Package version number was updated according to semantic rules
- [x] Any changes to upstream dependencies have already been published


[1]: https://github.com/hubiinetwork/nahmii-sdk#contributing
