### PR TITLE
Use settlement property doneBlockNumber to gauge completion

### DIFF
--- a/lib/settlement/driip-settlement.js
+++ b/lib/settlement/driip-settlement.js
@@ -208,7 +208,7 @@ class DriipSettlement {
             let settled = false;
             if (historySettlement) {
                 ['origin', 'target'].forEach((key) => {
-                    if (historySettlement[key].done && caseInsensitiveCompare(historySettlement[key].wallet, address))
+                    if (!historySettlement[key].doneBlockNumber.isZero() && caseInsensitiveCompare(historySettlement[key].wallet, address))
                         settled = true;
                 });
             }

--- a/lib/settlement/driip-settlement.spec.js
+++ b/lib/settlement/driip-settlement.spec.js
@@ -208,8 +208,8 @@ describe('Driip settlement operations', () => {
 
     it('can not replay a payment driip settlement', (done) => {
         const settlement = {
-            origin: {wallet: wallet.address, done: true},
-            target: {wallet: '', done: false}
+            origin: {wallet: wallet.address, doneBlockNumber: ethers.utils.bigNumberify(1234)},
+            target: {wallet: '', doneBlockNumber: ethers.utils.bigNumberify(0)}
         };
         stubbedDriipSettlementContract.settlementByWalletAndNonce
             .withArgs(wallet.address, receipt.toJSON().sender.nonce)
@@ -441,8 +441,8 @@ describe('Driip settlement operations', () => {
         const address = '0x1';
         it('can get current settlement detailed object', async () => {
             const expectedSettlement = {
-                origin: {wallet: '', done: true},
-                target: {wallet: '', done: false}
+                origin: {wallet: '', doneBlockNumber: ethers.utils.bigNumberify(1234)},
+                target: {wallet: '', doneBlockNumber: ethers.utils.bigNumberify(0)}
             };
             stubbedDriipSettlementContract.settlementByWalletAndNonce
                 .withArgs(address, nonce)
@@ -511,8 +511,8 @@ describe('Driip settlement operations', () => {
                 reasons: [notExpiredError, replayError, restartError]
             };
             const settlement = {
-                origin: {wallet: wallet.address, done: true},
-                target: {wallet: '', done: false}
+                origin: {wallet: wallet.address, doneBlockNumber: ethers.utils.bigNumberify(1234)},
+                target: {wallet: '', doneBlockNumber: ethers.utils.bigNumberify(0)}
             };
 
             const {sender} = receipt.toJSON();
@@ -585,8 +585,8 @@ describe('Driip settlement operations', () => {
                 reasons: [notExpiredError, statusError, replayError]
             };
             const settlement = {
-                origin: {wallet: wallet.address.toUpperCase(), done: true},
-                target: {wallet: '', done: false}
+                origin: {wallet: wallet.address.toUpperCase(), doneBlockNumber: ethers.utils.bigNumberify(1234)},
+                target: {wallet: '', doneBlockNumber: ethers.utils.bigNumberify(0)}
             };
 
             stubbedDriipSettlementChallengeContract.hasProposalExpired

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nahmii-sdk",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Javascript SDK for using hubii nahmii APIs",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nahmii-sdk",
-  "version": "3.1.0",
+  "version": "3.0.1",
   "description": "Javascript SDK for using hubii nahmii APIs",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Description
<!-- Enter a description of what this PR changes -->
[PR433 of _nahmii-contracts_](https://github.com/hubiinetwork/nahmii-contracts/pull/433) removed the redundant property `done` of driip settlement objects stored by _DriipSettlementState_ contract. This PR updated the SDK accordingly to rely on the remaining `doneBlockNumber` property instead. Non-zero value of `doneBlockNumber` is equivalent to `true` value of the removed `done` property.

### Issues
<!-- Enter references to relevant github issues -->

Issues: 


### Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->



### Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] The [Contribution Guidelines][1] has been followed
- [x] Tests for the changes have been added and all test pass (`npm test`)
- [ ] JSDoc comments have been reviewed and added / updated as needed
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures
- [x] Package version number was updated according to semantic rules
- [x] Any changes to upstream dependencies have already been published


[1]: https://github.com/hubiinetwork/nahmii-sdk#contributing
