### PR TITLE
Feature/currency strict constructor

### DIFF
--- a/lib/currency.js
+++ b/lib/currency.js
@@ -23,7 +23,7 @@ class Currency {
         if (!(ct instanceof EthereumAddress))
             throw new TypeError('ct is not an instance of EthereumAddress');
 
-        if (Number.isNaN(Number.parseInt(id)) || Number.parseInt(id) < 0)
+        if (typeof(id) !== 'number' || id < 0 || id !== Math.floor(id))
             throw new TypeError('id must be a positive integer');
 
         _ct.set(this, ct);
@@ -65,15 +65,18 @@ class Currency {
             return null;
 
         let id = input.id;
+
         if (id === undefined)
             id = 0;
-        if (input.id instanceof BSON.Int32)
-            id = input.id.valueOf();
+        if (id instanceof BSON.Int32)
+            id = id.valueOf();
+        if (typeof(id) === 'string')
+            id = Number.parseInt(id);
 
-        if (Number.isNaN(Number.parseInt(id)) || Number.parseInt(id) < 0)
+        if (Number.isNaN(id) || id < 0 || id !== Math.floor(id))
             return null;
 
-        return new Currency(ct, Number.parseInt(id));
+        return new Currency(ct, id);
     }
 }
 

--- a/lib/currency.spec.js
+++ b/lib/currency.spec.js
@@ -47,16 +47,31 @@ const legalFactoryIds = [
 ];
 
 function toJSON(ct, id) {
+    if (id === undefined)
+        id = 0;
+    else if (typeof id === 'string')
+        id = Number.parseInt(id);
+    else if (id instanceof BSON.Int32)
+        id = id.valueOf();
+
     return {
         ct: ct.toString(),
-        id: id ? id.toString() : '0'
+        id: id.toString()
     };
 }
 
 function toBSON(ct, id) {
+    if (id === undefined) {
+        id = new BSON.Int32(0);
+    }
+    else if (!(id instanceof BSON.Int32)){
+        if (Number.isNaN(Number.parseInt(id)))
+            throw new Error(`Unexpected id property in toBSON() test helper: val=${id}, type=${typeof id}`);
+        id = new BSON.Int32(Number.parseInt(id));
+    }
     return {
         ct: EthereumAddress.from(ct).toBinary(),
-        id: id === undefined ? new BSON.Int32(0) : new BSON.Int32(id)
+        id: id
     };
 }
 
@@ -67,18 +82,29 @@ function typeStr (item) {
         return typeof item;
 }
 
-const addrx0 = '0x0000000000000000000000000000000000000000';
+const addrx0 = EthereumAddress.from('0x0000000000000000000000000000000000000000');
 
 const constructorArgs = [...cartesian(legalConstructorCts, legalConstructorIds)];
 
 const factoryArgs = [
     ...cartesian(legalFactoryCts, [0]),
-    ...cartesian([addrx0], legalConstructorIds)
+    ...cartesian([addrx0], legalFactoryIds)
 ];
 
 const badConstructorArgs = [
     [null, 0],
-    [EthereumAddress.from(addrx0), -1]
+    [addrx0, -1],
+    [addrx0, '0'],
+    [addrx0, '1'],
+    [addrx0, 3.14]
+];
+
+const badFactoryArgs = [
+    {id: 0},
+    {ct: addrx0, id: '-1'},
+    {ct: addrx0, id: -1},
+    {ct: addrx0, id: 'not a number'},
+    {ct: addrx0, id: 3.14}
 ];
 
 describe('Currency', () => {
@@ -111,12 +137,13 @@ describe('Currency', () => {
         }
     });
 
-    context('Factory return null on illegal input', () => {
-        for (const [ct, id] of badConstructorArgs) {
-            it (`with "${ct}" ${typeStr(ct)}, "${id}" ${typeStr(id)}`, () => {
-                expect(Currency.from({ct, id})).to.equal(null);
+    context('Factory returns null on illegal input', () => {
+        for (const input of badFactoryArgs) {
+            it (`with "${input.ct}" ${typeStr(input.ct)}, "${input.id}" ${typeStr(input.id)}`, () => {
+                expect(Currency.from(input)).to.equal(null);
             });
         }
+
         it ('with null', () => {
             expect(Currency.from(null)).to.equal(null);
         });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nahmii-sdk",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Javascript SDK for using hubii nahmii APIs",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Description
Enables strict type checking for `id` property in Currency constructor.

Enables test cases unintentionally disabled/not included for the `Currency.from()` constructor methods tests. Updated test helpers to cover all edge cases defined by the now included test cases.

### Issues
Issues: 


### Other information


### Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] The [Contribution Guidelines][1] has been followed
- [x] Tests for the changes have been added and all test pass (`npm test`)
- [x] JSDoc comments have been reviewed and added / updated as needed
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures
- [x] Package version number was updated according to semantic rules
- [x] Any changes to upstream dependencies have already been published


[1]: https://github.com/hubiinetwork/nahmii-sdk#contributing