### PR TITLE
Disallow JSON to parse unkown error messages

### DIFF
--- a/lib/nahmii-provider.js
+++ b/lib/nahmii-provider.js
@@ -214,7 +214,7 @@ class NahmiiProvider extends ethers.providers.JsonRpcProvider {
                 case 422:
                     throw new Error(JSON.parse(err.response.text).message);
                 default:
-                    throw new Error(JSON.parse(err.response.text).message);
+                    throw new Error(err.response.error.message);
                 }
             });
     }

--- a/lib/nahmii-provider.spec.js
+++ b/lib/nahmii-provider.spec.js
@@ -289,12 +289,21 @@ describe('Nahmii Provider', () => {
         ].forEach(([statusCode, expectedMessage]) => {
             it(`sends back error messages with sensible messages when API fails to register payment (${statusCode})`, (done) => {
                 const expectedPayment = {};
-                const error = {
+                const error4xx = {
                     status: statusCode,
                     response: {
                         text: JSON.stringify({message: expectedMessage})
                     }
                 };
+                const errorDefault = {
+                    status: statusCode,
+                    response: {
+                        error: {
+                            message: expectedMessage
+                        }
+                    }
+                };
+                const error = statusCode >= 500 ? errorDefault : error4xx;
                 stubbedNahmiiRequest.post
                     .withArgs('/trading/payments', expectedPayment)
                     .rejects(error);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nahmii-sdk",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "Javascript SDK for using hubii nahmii APIs",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Description
Fixed incomprehensible default error message :"Unexpected token < in JSON at position 0"

### Other information
Expected something like: "cannot POST /trading/payments (502)"

### Pull request checklist
Please check if your PR fulfills the following requirements:
- [v] The [Contribution Guidelines][1] has been followed
- [v] Tests for the changes have been added and all test pass (`npm test`)
- [v] JSDoc comments have been reviewed and added / updated as needed
- [v] Build (`npm run build`) was run locally and any changes were pushed
- [v] Lint (`npm run lint`) has passed locally and any fixes were made for failures
- [v] Package version number was updated according to semantic rules
- [v] Any changes to upstream dependencies have already been published


[1]: https://github.com/hubiinetwork/nahmii-sdk#contributing
