### PR TITLE
Check if driip settlement proposal has been terminated before staging.

### DIFF
--- a/Docs/driip-settlement.md
+++ b/Docs/driip-settlement.md
@@ -12,6 +12,7 @@
         * [.getCurrentProposalStatus(address, ct, id)](#module_nahmii-sdk--DriipSettlement+getCurrentProposalStatus) ⇒ <code>Promise</code>
         * [.getSettlementByNonce(address, nonce)](#module_nahmii-sdk--DriipSettlement+getSettlementByNonce) ⇒ <code>Promise</code>
         * [.getCurrentProposalStartBlockNumber(address, ct, id)](#module_nahmii-sdk--DriipSettlement+getCurrentProposalStartBlockNumber) ⇒ <code>Promise</code>
+        * [.hasCurrentProposalTerminated(address, ct, id)](#module_nahmii-sdk--DriipSettlement+hasCurrentProposalTerminated) ⇒ <code>Promise</code>
         * [.hasPaymentDriipSettled(nonce, address)](#module_nahmii-sdk--DriipSettlement+hasPaymentDriipSettled) ⇒ <code>Promise</code>
         * [.checkStartChallengeFromPayment(receipt, address)](#module_nahmii-sdk--DriipSettlement+checkStartChallengeFromPayment) ⇒ <code>Promise</code>
         * [.checkSettleDriipAsPayment(receipt, address)](#module_nahmii-sdk--DriipSettlement+checkSettleDriipAsPayment) ⇒ <code>Promise</code>
@@ -158,6 +159,20 @@ Returns block number of the start of the current settlement proposal
 
 **Kind**: instance method of [<code>DriipSettlement</code>](#exp_module_nahmii-sdk--DriipSettlement)  
 **Returns**: <code>Promise</code> - A promise that resolves into a BigNumber or throws errors  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| address | <code>Address</code> | The wallet address. |
+| ct | <code>Address</code> | The currency address. |
+| id | <code>Integer</code> | The currency id. |
+
+<a name="module_nahmii-sdk--DriipSettlement+hasCurrentProposalTerminated"></a>
+
+#### driipSettlement.hasCurrentProposalTerminated(address, ct, id) ⇒ <code>Promise</code>
+Check if current proposal has been terminated
+
+**Kind**: instance method of [<code>DriipSettlement</code>](#exp_module_nahmii-sdk--DriipSettlement)  
+**Returns**: <code>Promise</code> - A promise that resolves into boolean or throws errors  
 
 | Param | Type | Description |
 | --- | --- | --- |

--- a/lib/settlement/driip-settlement.js
+++ b/lib/settlement/driip-settlement.js
@@ -193,6 +193,26 @@ class DriipSettlement {
             throw new NestedError(err, 'Unable to get the start block number of the current proposal.');
         }
     }
+
+    /**
+     * Check if current proposal has been terminated
+     * @param {Address} address - The wallet address.
+     * @param {Address} ct - The currency address.
+     * @param {Integer} id - The currency id.
+     * @returns {Promise} A promise that resolves into boolean or throws errors
+     */
+    async hasCurrentProposalTerminated(address, ct, id) {
+        try {
+            const driipSettlementChallengeContract = _driipSettlementChallengeContract.get(this);
+            return await driipSettlementChallengeContract.hasProposalTerminated(address, ct, id);
+        }
+        catch (err) {
+            if (isRevertContractException(err)) 
+                return null;
+            
+            throw new NestedError(err, 'Unable to check if proposal is terminated.');
+        }
+    }
     
     /**
      * Check if the driip has been settled by a wallet
@@ -268,10 +288,11 @@ class DriipSettlement {
             const _receipt = receipt.toJSON();
             const {currency} = _receipt;
             const nonce = determineNonceFromReceipt(_receipt, address);
-            const [expired, currentStatus, settled] = await Promise.all([
+            const [expired, currentStatus, settled, terminated] = await Promise.all([
                 this.hasProposalExpired(address, currency.ct, currency.id),
                 this.getCurrentProposalStatus(address, currency.ct, currency.id),
-                this.hasPaymentDriipSettled(nonce, address)
+                this.hasPaymentDriipSettled(nonce, address),
+                this.hasCurrentProposalTerminated(address, currency.ct, currency.id)
             ]);
 
             const invalidReasons = [];
@@ -283,6 +304,9 @@ class DriipSettlement {
     
             if (settled)
                 invalidReasons.push(new Error('The settlement can not be replayed!'));
+
+            if (terminated)
+                invalidReasons.push(new Error('The current proposal is terminated!'));
     
             if (invalidReasons.length) 
                 return {valid: false, reasons: invalidReasons};

--- a/lib/settlement/driip-settlement.spec.js
+++ b/lib/settlement/driip-settlement.spec.js
@@ -39,6 +39,7 @@ const stubbedDriipSettlementChallengeContract = {
     proposalNonce: sinon.stub(),
     proposalExpirationTime: sinon.stub(),
     hasProposalExpired: sinon.stub(),
+    hasProposalTerminated: sinon.stub(),
     proposalStageAmount: sinon.stub()
 };
 
@@ -97,6 +98,7 @@ describe('Driip settlement operations', () => {
         stubbedDriipSettlementChallengeContract.proposalNonce.reset();
         stubbedDriipSettlementChallengeContract.proposalExpirationTime.reset();
         stubbedDriipSettlementChallengeContract.hasProposalExpired.reset();
+        stubbedDriipSettlementChallengeContract.hasProposalTerminated.reset();
         stubbedDriipSettlementChallengeContract.proposalStageAmount.reset();
         stubbedDriipSettlementChallengeContract.stopChallenge.reset();
         stubbedDriipSettlementChallengeStateContract.proposalDefinitionBlockNumber.reset();
@@ -178,8 +180,9 @@ describe('Driip settlement operations', () => {
         stubbedDriipSettlementContract.settlePayment
             .withArgs(receipt.toJSON(), 'ERC20', {})
             .resolves(fakeTx);
-        sinon.stub(driipSettlement, 'hasProposalExpired').resolves(true);
-        sinon.stub(driipSettlement, 'getCurrentProposalStatus').resolves('Qualified');
+        stubbedDriipSettlementChallengeContract.proposalStatus.resolves(0);
+        stubbedDriipSettlementChallengeContract.hasProposalExpired.resolves(true);
+        stubbedDriipSettlementChallengeContract.hasProposalTerminated.resolves(false);
         const tx = await driipSettlement.settleDriipAsPayment(receipt, wallet);
         expect(tx).to.equal(fakeTx);
     });
@@ -360,6 +363,41 @@ describe('Driip settlement operations', () => {
                 .throws(error);
             driipSettlement.hasProposalExpired(wallet.address, address0, address0id).catch(e => {
                 expect(e.message).to.match(/unable.*expired/i);
+                expect(e.innerError.message).to.match(/err/i);
+                done();
+            });
+        });
+    });
+
+    describe('hasProposalTerminated', () => {
+        it('can correctly return if terminated', async () => {
+            const hasTerminated = true;
+            stubbedDriipSettlementChallengeContract.hasProposalTerminated
+                .withArgs(wallet.address, address0, address0id)
+                .resolves(hasTerminated);
+            const _hasTerminated = await driipSettlement.hasCurrentProposalTerminated(wallet.address, address0, address0id);
+            expect(_hasTerminated).to.equal(hasTerminated);
+        });
+
+        [
+            {code: 'CALL_EXCEPTION'},
+            {code: -32000}
+        ].forEach(error => {
+            it(`should return null when ${error.code} exception thrown`, async () => {
+                stubbedDriipSettlementChallengeContract.hasProposalTerminated
+                    .withArgs(wallet.address, address0, address0id)
+                    .throws(error);
+                const expired = await driipSettlement.hasCurrentProposalTerminated(wallet.address, address0, address0id);
+                expect(expired).to.equal(null);
+            });
+        });
+        it('should rethrow unexpected exception', (done) => {
+            const error = new Error('err');
+            stubbedDriipSettlementChallengeContract.hasProposalTerminated
+                .withArgs(wallet.address, address0, address0id)
+                .throws(error);
+            driipSettlement.hasCurrentProposalTerminated(wallet.address, address0, address0id).catch(e => {
+                expect(e.message).to.match(/unable.*terminated/i);
                 expect(e.innerError.message).to.match(/err/i);
                 done();
             });
@@ -580,9 +618,10 @@ describe('Driip settlement operations', () => {
             const notExpiredError = new Error('Current challenge proposal has not expired yet!');
             const statusError = new Error('Current challenge proposal is disqualified!');
             const replayError = new Error('The settlement can not be replayed!');
+            const terminatedError = new Error('The current proposal is terminated!');
             const expectedResult = {
                 valid: false,
-                reasons: [notExpiredError, statusError, replayError]
+                reasons: [notExpiredError, statusError, replayError, terminatedError]
             };
             const settlement = {
                 origin: {wallet: wallet.address.toUpperCase(), doneBlockNumber: ethers.utils.bigNumberify(1234)},
@@ -592,6 +631,9 @@ describe('Driip settlement operations', () => {
             stubbedDriipSettlementChallengeContract.hasProposalExpired
                 .withArgs(wallet.address, currency.ct, currency.id)
                 .resolves(false);
+            stubbedDriipSettlementChallengeContract.hasProposalTerminated
+                .withArgs(wallet.address, currency.ct, currency.id)
+                .resolves(true);
             stubbedDriipSettlementChallengeContract.proposalStatus
                 .withArgs(wallet.address, currency.ct, currency.id)
                 .resolves(1);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nahmii-sdk",
-  "version": "3.1.4",
+  "version": "3.2.0",
   "description": "Javascript SDK for using hubii nahmii APIs",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nahmii-sdk",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "Javascript SDK for using hubii nahmii APIs",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Description
When a qualified settlement proposal has been stopped, it should be treated as a terminated proposal. So the clients can be aware of the actual proposal status and won't try to stage them.


### Issues
<!-- Enter references to relevant github issues -->

Issues: 


### Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->



### Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] The [Contribution Guidelines][1] has been followed
- [x] Tests for the changes have been added and all test pass (`npm test`)
- [x] JSDoc comments have been reviewed and added / updated as needed
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures
- [x] Package version number was updated according to semantic rules
- [ ] Any changes to upstream dependencies have already been published


[1]: https://github.com/hubiinetwork/nahmii-sdk#contributing
