### PR TITLE
Removal of NahmiiContract constructor warnings

### DIFF
--- a/lib/contract/index.js
+++ b/lib/contract/index.js
@@ -10,7 +10,7 @@ const {EthereumAddress} = require('nahmii-ethereum-address');
 
 const _provider = new WeakMap();
 const _contractName = new WeakMap();
-let _isCalledFromFactory = false;
+// let _isCalledFromFactory = false;
 
 /**
  * @class NahmiiContract
@@ -39,10 +39,10 @@ class NahmiiContract extends ethers.Contract {
      * @param {NahmiiProvider|Wallet} walletOrProvider - Wallet or provider connected to nahmii cluster
      */
     constructor(contractName, walletOrProvider) {
-        if (!_isCalledFromFactory) {
-            console.warn('WARNING: Calling NahmiiContract constructor directly is deprecated and will be removed.');
-            console.warn('         Use factory function NahmiiContract.from() instead.');
-        }
+        // if (!_isCalledFromFactory) {
+        //     console.warn('WARNING: Calling NahmiiContract constructor directly is deprecated and will be removed.');
+        //     console.warn('         Use factory function NahmiiContract.from() instead.');
+        // }
 
         const provider = walletOrProvider.provider || walletOrProvider;
         const deployment = contractAbstractions.get(provider.network.name, contractName);
@@ -84,9 +84,9 @@ class NahmiiContract extends ethers.Contract {
 
     static async from (contractName, walletOrProvider) {
 
-        _isCalledFromFactory = true;
+        // _isCalledFromFactory = true;
         let contract = new NahmiiContract(contractName, walletOrProvider);
-        _isCalledFromFactory = false;
+        // _isCalledFromFactory = false;
 
         if (!await contract.validate()) {
             const varName = 'ACCEPT_INVALID_CONTRACTS';

--- a/lib/nahmii-request.spec.js
+++ b/lib/nahmii-request.spec.js
@@ -84,7 +84,7 @@ describe('Nahmii Request', () => {
                             .reply(200, expectedBody);
                         const err = await request.get(uri).catch(err => err);
                         // return expect(err.errno).to.equal('ETIMEDOUT'); // ISSUE: https://github.com/visionmedia/superagent/issues/1487
-                        return expect(err.code).to.equal('ABORTED');
+                        return expect(err.code).to.equal('ECONNABORTED');
                     });
                 });
             });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nahmii-sdk",
-  "version": "4.1.3",
+  "version": "4.1.4",
   "description": "Javascript SDK for using hubii nahmii APIs",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Description
<!-- Enter a description of what this PR changes -->
This PR removes the warning that was called when instantiating a contract with the use of constructor of `NahmiiContract` called from descendant contract's constructor. The shift to using `NahmiiContract#from()` is deferred to separate issue.

### Issues
<!-- Enter references to relevant github issues -->

Issues: 
* #144

### Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->



### Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] The [Contribution Guidelines][1] has been followed
- [x] Tests for the changes have been added and all test pass (`npm test`)
- [x] JSDoc comments have been reviewed and added / updated as needed
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures
- [x] Package version number was updated according to semantic rules
- [x] Any changes to upstream dependencies have already been published


[1]: https://github.com/hubiinetwork/nahmii-sdk#contributing
