### PR TITLE
Added semantic  Payment senderRef

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -18,8 +18,8 @@
   ],
   "check-coverage": true,
   "per-file": false,
-  "statements": 96.03,
-  "branches": 92.84,
-  "functions": 94.19,
-  "lines": 96.01
+  "statements": 97,
+  "branches": 93,
+  "functions": 96,
+  "lines": 97
 }

--- a/Docs/payment.md
+++ b/Docs/payment.md
@@ -4,7 +4,7 @@
 
 * [nahmii-sdk](#module_nahmii-sdk)
     * [Payment](#exp_module_nahmii-sdk--Payment) ⏏
-        * [new Payment(amount, sender, recipient, [walletOrProvider])](#new_module_nahmii-sdk--Payment_new)
+        * [new Payment(amount, sender, recipient, [walletOrProvider], [senderRef])](#new_module_nahmii-sdk--Payment_new)
         * _instance_
             * [.amount](#module_nahmii-sdk--Payment+amount) ⇒ <code>MonetaryAmount</code>
             * [.sender](#module_nahmii-sdk--Payment+sender) ⇒ <code>Address</code>
@@ -29,7 +29,7 @@ supply a valid Wallet or NahmiiProvider instance.
 **Kind**: Exported class  
 <a name="new_module_nahmii-sdk--Payment_new"></a>
 
-#### new Payment(amount, sender, recipient, [walletOrProvider])
+#### new Payment(amount, sender, recipient, [walletOrProvider], [senderRef])
 Constructor
 Creates a new payment with a unique sender reference.
 
@@ -40,23 +40,21 @@ Creates a new payment with a unique sender reference.
 | sender | <code>Address</code> | Senders address |
 | recipient | <code>Address</code> | Recipient address |
 | [walletOrProvider] | <code>Wallet</code> \| <code>NahmiiProvider</code> | An optional Wallet or NahmiiProvider instance |
+| [senderRef] | <code>String</code> | Optional uuid identifying the payment. Must be unique per sender wallet. Random if undefined. |
 
 **Example**  
 ```js
-const nahmii = require('nahmii-sdk');
-const wallet = new nahmii.Wallet(...);
+// Normal, random sender reference
+const senderWallet = new nahmii.Wallet(...);
+const recipientWallet = new nahmii.Wallet(...);
+const paymentAmount = nahmii.MonetaryAmount.from(...);
+const payment = new nahmii.Payment(paymentAmount, senderWallet.address, recipientWallet.address, senderWallet);
 
-// Creates a new Payment, providing essential inputs such as the amount,
-// the currency, the sender, and the recipient.
-const monetaryAmount = new nahmii.MonetaryAmount(amount, erc20_token_address);
-const payment = new nahmii.Payment(monetaryAmount, wallet_address, recipient_address, wallet);
-
-// Signs the payment with the private key belonging to your wallet.
-payment.sign();
-
-// Sends the signed payment to the API for registration and execution and
-// logs the API response to the console.
-payment.register().then(console.log);
+// Advanced, semantic sender reference. See: https://github.com/uuidjs/uuid
+const uuidNamespace = '706ac453-2691-41af-9fde-ac5f787da1ec';
+const paymentSubject = '...';
+const senderRef = uuidv5(paymentSubject, uuidNamespace);
+const payment = new nahmii.Payment(paymentAmount, senderWallet.address, recipientWallet.address, senderWallet, senderRef);
 ```
 <a name="module_nahmii-sdk--Payment+amount"></a>
 

--- a/lib/payment.js
+++ b/lib/payment.js
@@ -79,7 +79,7 @@ class Payment {
         senderRef = senderRef || uuidv4();
 
         if (!/^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i.test(senderRef))
-            throw new TypeError('senderRef is not an uuid string');
+            throw new TypeError('senderRef is not a uuid string');
 
         const wallet = walletOrProvider instanceof Wallet ? walletOrProvider : null;
         const provider = wallet ? wallet.provider : walletOrProvider;

--- a/lib/payment.js
+++ b/lib/payment.js
@@ -57,10 +57,29 @@ class Payment {
      * @param {Address} sender - Senders address
      * @param {Address} recipient - Recipient address
      * @param {Wallet|NahmiiProvider} [walletOrProvider] - An optional Wallet or NahmiiProvider instance
+     * @param {String} [senderRef] - Optional uuid identifying the payment. Must be unique per sender wallet. Random if undefined.
+     *
+     * @example
+     * // Normal, random sender reference
+     * const senderWallet = new nahmii.Wallet(...);
+     * const recipientWallet = new nahmii.Wallet(...);
+     * const paymentAmount = nahmii.MonetaryAmount.from(...);
+     * const payment = new nahmii.Payment(paymentAmount, senderWallet.address, recipientWallet.address, senderWallet);
+     *
+     * // Advanced, semantic sender reference. See: https://github.com/uuidjs/uuid
+     * const uuidNamespace = '706ac453-2691-41af-9fde-ac5f787da1ec';
+     * const paymentSubject = '...';
+     * const senderRef = uuidv5(paymentSubject, uuidNamespace);
+     * const payment = new nahmii.Payment(paymentAmount, senderWallet.address, recipientWallet.address, senderWallet, senderRef);
      */
-    constructor(amount, sender, recipient, walletOrProvider) {
+    constructor(amount, sender, recipient, walletOrProvider, senderRef) {
         if (!(amount instanceof MonetaryAmount))
             throw new TypeError('amount is not an instance of MonetaryAmount');
+
+        senderRef = senderRef || uuidv4();
+
+        if (!/^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i.test(senderRef))
+            throw new TypeError('senderRef is not an uuid string');
 
         const wallet = walletOrProvider instanceof Wallet ? walletOrProvider : null;
         const provider = wallet ? wallet.provider : walletOrProvider;
@@ -71,7 +90,7 @@ class Payment {
         // TODO: ensure sender/recipient addresses are of EthereumAddress type.
         _sender.set(this, sender);
         _recipient.set(this, recipient);
-        _senderRef.set(this, uuidv4());
+        _senderRef.set(this, senderRef);
     }
 
     /**

--- a/lib/payment.spec.js
+++ b/lib/payment.spec.js
@@ -126,7 +126,7 @@ describe('Payment', () => {
                 expect(payment.isSigned()).to.be.false;
             });
 
-            it('has an UUID as sender ref', () => {
+            it('has a UUID as sender ref', () => {
                 expect(payment.senderRef).to.match(uuidRegexp);
             });
 
@@ -172,7 +172,7 @@ describe('Payment', () => {
                 expect(payment.isSigned()).to.be.true;
             });
 
-            it('has an UUID as sender ref', () => {
+            it('has a UUID as sender ref', () => {
                 expect(payment.senderRef).to.match(uuidRegexp);
             });
 
@@ -224,7 +224,7 @@ describe('Payment', () => {
                 expect(payment.isSigned()).to.be.false;
             });
 
-            it('has an UUID as sender ref', () => {
+            it('has a UUID as sender ref', () => {
                 expect(payment.senderRef).to.match(uuidRegexp);
             });
 
@@ -269,7 +269,7 @@ describe('Payment', () => {
                 expect(payment.isSigned()).to.be.true;
             });
 
-            it('has an UUID as sender ref', () => {
+            it('has a UUID as sender ref', () => {
                 expect(payment.senderRef).to.match(uuidRegexp);
             });
 
@@ -323,7 +323,7 @@ describe('Payment', () => {
                 expect(payment.isSigned()).to.be.false;
             });
 
-            it('has an UUID as sender ref', () => {
+            it('has a UUID as sender ref', () => {
                 expect(payment.senderRef).to.match(uuidRegexp);
             });
 
@@ -375,7 +375,7 @@ describe('Payment', () => {
                 expect(payment.isSigned()).to.be.false;
             });
 
-            it('has an UUID as sender ref', () => {
+            it('has a UUID as sender ref', () => {
                 expect(payment.senderRef).to.match(uuidRegexp);
             });
 
@@ -420,7 +420,7 @@ describe('Payment', () => {
                 expect(payment.isSigned()).to.be.true;
             });
 
-            it('has an UUID as sender ref', () => {
+            it('has a UUID as sender ref', () => {
                 expect(payment.senderRef).to.match(uuidRegexp);
             });
 
@@ -477,7 +477,7 @@ describe('Payment', () => {
                 expect(payment.isSigned()).to.be.false;
             });
 
-            it('has an UUID as sender ref', () => {
+            it('has a UUID as sender ref', () => {
                 expect(payment.senderRef).to.match(uuidRegexp);
             });
 
@@ -532,7 +532,7 @@ describe('Payment', () => {
                 expect(payment.isSigned()).to.be.false;
             });
 
-            it('has an UUID as sender ref', () => {
+            it('has a UUID as sender ref', () => {
                 expect(payment.senderRef).to.match(uuidRegexp);
             });
 
@@ -579,7 +579,7 @@ describe('Payment', () => {
                 expect(payment.isSigned()).to.be.true;
             });
 
-            it('has an UUID as sender ref', () => {
+            it('has a UUID as sender ref', () => {
                 expect(payment.senderRef).to.match(uuidRegexp);
             });
 
@@ -612,7 +612,7 @@ describe('Payment', () => {
             expect(payment.senderRef).to.not.eql(senderRef);
         });
 
-        it('has an UUID as sender ref', () => {
+        it('has a UUID as sender ref', () => {
             expect(payment.senderRef).to.match(uuidRegexp);
         });
 
@@ -638,7 +638,7 @@ describe('Payment', () => {
             expect(payment.senderRef).to.not.eql(senderRef);
         });
 
-        it('has an UUID as sender ref', () => {
+        it('has a UUID as sender ref', () => {
             expect(payment.senderRef).to.match(uuidRegexp);
         });
 
@@ -735,7 +735,7 @@ describe('Payment', () => {
             });
 
             it ('throws if input input senderRef is not valid', () => {
-                expect(() => new Payment(amount, sender, recipient, wallet, 'something weird')).to.throw(/senderRef is not an uuid string/);
+                expect(() => new Payment(amount, sender, recipient, wallet, 'something weird')).to.throw(/senderRef is not a uuid string/);
             });
         });
     });

--- a/lib/payment.spec.js
+++ b/lib/payment.spec.js
@@ -4,12 +4,16 @@ const chai = require('chai');
 const sinon = require('sinon');
 const sinonChai = require('sinon-chai');
 const proxyquire = require('proxyquire').noPreserveCache().noCallThru();
-const expect = chai.expect;
 chai.use(sinonChai);
 
 const {ApiPayloadFactory} = require('../test-utils');
 
 const MonetaryAmount = require('./monetary-amount');
+const uuidv4 = require('uuid/v4');
+
+const expect = chai.expect;
+const given = describe;
+const when = describe;
 
 const Wallet = proxyquire('./wallet/wallet', {
     './client-fund-contract': function() {
@@ -693,6 +697,46 @@ describe('Payment', () => {
 
         it('does not have a valid signature', () => {
             expect(payment.isSigned()).to.be.false;
+        });
+    });
+
+    given('a Payment constructor that optionally accepts a senderRef', () => {
+        let amount, sender, recipient, wallet;
+
+        beforeEach(() => {
+            amount = MonetaryAmount.from(fixture.amount, fixture.currency.ct, fixture.currency.id);
+            sender = fixture.sender;
+            recipient = fixture.recipient;
+            wallet = new Wallet(fixture.senderPrivateKey, stubbedProvider);
+        });
+
+        when('constructing Payments', () => {
+            it ('creates Payments with random senderRef property if input senderRef is undefined', () => {
+                const refSet = new Set();
+
+                for (let i = 0; i < 10; ++i) {
+                    const payment = new Payment(amount, sender, recipient, wallet);
+                    expect(refSet.has(payment.senderRef)).to.equal(false);
+                    refSet.add(payment.senderRef);
+                }
+            });
+
+            it ('creates Payments with senderRef property equal to input senderRef if defined', () => {
+                for (let i = 0; i < 10; ++i) {
+                    const inputSenderRef = uuidv4();
+                    const payment = new Payment(amount, sender, recipient, wallet, inputSenderRef);
+                    expect(payment.senderRef).to.equal(inputSenderRef);
+                }
+            });
+
+            it ('creates Payments regardless of senderRef character case', () => {
+                expect(new Payment(amount, sender, recipient, wallet, uuidv4().toLowerCase())).to.be.instanceof(Payment);
+                expect(new Payment(amount, sender, recipient, wallet, uuidv4().toUpperCase())).to.be.instanceof(Payment);
+            });
+
+            it ('throws if input input senderRef is not valid', () => {
+                expect(() => new Payment(amount, sender, recipient, wallet, 'something weird')).to.throw(/senderRef is not an uuid string/);
+            });
         });
     });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nahmii-sdk",
-  "version": "4.1.4",
+  "version": "4.2.4",
   "description": "Javascript SDK for using hubii nahmii APIs",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nahmii-sdk",
-  "version": "4.2.4",
+  "version": "4.2.0",
   "description": "Javascript SDK for using hubii nahmii APIs",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Description
Extended Payment constructor to allow for  semantic Payment.senderRef.
* Extended Payment constructor
* Added tests

### Issues
https://github.com/hubiinetwork/nahmii-sdk/issues/147

### Pull request checklist
- [x] The [Contribution Guidelines][1] has been followed
- [x] Tests for the changes have been added and all test pass (`npm test`)
- [x] JSDoc comments have been reviewed and added / updated as needed
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures
- [x] Package version number was updated according to semantic rules
- [x] Any changes to upstream dependencies have already been published
