### PR TITLE
Token holder revenue fund contracts ensemble

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,9 +60,10 @@ typings/
 # next.js build output
 .next
 
-# WebStorm
+# WebStorm/IntelliJ
 .idea
 package-lock.json
+*.iml
 
 # VSCode
 .vscode

--- a/.nycrc
+++ b/.nycrc
@@ -19,7 +19,7 @@
   "check-coverage": true,
   "per-file": false,
   "statements": 97,
-  "branches": 93,
+  "branches": 92,
   "functions": 96,
   "lines": 97
 }

--- a/Docs/fees-claimant.md
+++ b/Docs/fees-claimant.md
@@ -51,7 +51,7 @@ Get claimable amount of fees for a span of accruals
 Claim fees for a span of accruals
 
 **Kind**: instance method of [<code>FeesClaimant</code>](#module_nahmii-sdk)  
-**Returns**: <code>Promise</code> - A promise that resolves into a record that contains the transaction hash.  
+**Returns**: <code>Promise</code> - A promise that resolves into an array of transaction hashes.  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -82,7 +82,7 @@ Get claimable amount of fees for a span of block numbers
 Claim fees for a span of block numbers
 
 **Kind**: instance method of [<code>FeesClaimant</code>](#module_nahmii-sdk)  
-**Returns**: <code>Promise</code> - A promise that resolves into a record that contains the transaction hash.  
+**Returns**: <code>Promise</code> - A promise that resolves into an array of transaction hashes.  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -111,7 +111,7 @@ Get the withdrawable amount of fees
 Withdraw the given amount of fees
 
 **Kind**: instance method of [<code>FeesClaimant</code>](#module_nahmii-sdk)  
-**Returns**: <code>Promise</code> - A promise that resolves into a record that contains the transaction hash.  
+**Returns**: <code>Promise</code> - A promise that resolves into an array of transaction hashes.  
 
 | Param | Type | Description |
 | --- | --- | --- |

--- a/lib/claim/fees-claimant.js
+++ b/lib/claim/fees-claimant.js
@@ -108,7 +108,7 @@ class FeesClaimant {
      * @param {number} startBlock - The lower block number boundary
      * @param {number} endBlock - The upper block number boundary
      * @param [options] - An optional object containing the parameters for gasLimit and gasPrice
-     * @returns {Promise} A promise that resolves into a record that contains the transaction hash.
+     * @returns {Promise} A promise that resolves into an array of transaction hashes.
      */
     async claimFeesForBlocks(wallet, currency, startBlock, endBlock, options) {
         try {
@@ -139,7 +139,7 @@ class FeesClaimant {
      * @param {Wallet} wallet - The claimer nahmii wallet
      * @param {MonetaryAmount} monetaryAmount - The monetary amount
      * @param [options] - An optional object containing the parameters for gasLimit and gasPrice
-     * @returns {Promise} A promise that resolves into a record that contains the transaction hash.
+     * @returns {Promise} A promise that resolves into an array of transaction hashes.
      */
     async withdrawFees(wallet, monetaryAmount, options) {
         try {

--- a/lib/claim/fees-claimant.js
+++ b/lib/claim/fees-claimant.js
@@ -1,9 +1,9 @@
 'use strict';
 
-const TokenHolderRevenueFundContract = require('./token-holder-revenue-fund-contract');
+const TokenHolderRevenueFundContractsEnsemble = require('./token-holder-revenue-fund-contracts-ensemble');
 const NestedError = require('../nested-error');
 
-const _tokenHolderRevenueFund = new WeakMap();
+const _tokenHolderRevenueFundContractEnsemble = new WeakMap();
 
 /**
  * @class FeesClaimant
@@ -11,8 +11,10 @@ const _tokenHolderRevenueFund = new WeakMap();
  * @alias module:nahmii-sdk
  */
 class FeesClaimant {
-    constructor(provider) {
-        _tokenHolderRevenueFund.set(this, new TokenHolderRevenueFundContract(provider));
+    constructor(provider, ensembleNames) {
+        _tokenHolderRevenueFundContractEnsemble.set(
+            this, new TokenHolderRevenueFundContractsEnsemble(provider, ensembleNames)
+        );
     }
 
     /**
@@ -24,22 +26,21 @@ class FeesClaimant {
      * @returns {Promise} A promise that resolves into an array of claimable accruals.
      */
     async claimableAccruals(wallet, currency, startAccrual, endAccrual) {
-        const tokenHolderRevenueFund = _tokenHolderRevenueFund.get(this);
+        const ensemble = _tokenHolderRevenueFundContractEnsemble.get(this);
 
         startAccrual = startAccrual || 0;
-        endAccrual = endAccrual || (await tokenHolderRevenueFund.closedAccrualsCount(currency.ct, currency.id)) - 1;
+        endAccrual = endAccrual || (await ensemble.closedAccrualsCount(currency)) - 1;
 
         const accruals = [...Array(endAccrual - startAccrual + 1).keys()]
             .map(o => startAccrual + o);
 
         const accrualClaimableStats = (await Promise.all(
-            accruals.map(accrual => tokenHolderRevenueFund.fullyClaimed(
-                wallet.address, currency.ct.toString(), currency.id, accrual
-            ))
-        )).map((fullyClaimed, index) => ({
-            accrual: accruals[index],
-            claimable: !fullyClaimed
-        }));
+            accruals.map(accrual => ensemble.fullyClaimed(wallet, currency, accrual))
+        ))
+            .map((fullyClaimed, index) => ({
+                accrual: accruals[index],
+                claimable: !fullyClaimed
+            }));
 
         const claimableAccruals = accrualClaimableStats
             .filter(s => s.claimable)
@@ -57,9 +58,9 @@ class FeesClaimant {
      * @returns {Promise} A promise that resolves into a BigNumber value representing the claimable amount of fees.
      */
     async claimableFeesForAccruals(wallet, currency, startAccrual, endAccrual) {
-        const tokenHolderRevenueFund = _tokenHolderRevenueFund.get(this);
-        return tokenHolderRevenueFund.claimableAmountByAccruals(
-            wallet.address, currency.ct.toString(), currency.id, startAccrual, endAccrual
+        const ensemble = _tokenHolderRevenueFundContractEnsemble.get(this);
+        return ensemble.claimableAmountByAccruals(
+            wallet, currency, startAccrual, endAccrual
         );
     }
 
@@ -70,15 +71,15 @@ class FeesClaimant {
      * @param {number} startAccrual - The lower accrual index boundary
      * @param {number} endAccrual - The upper accrual index boundary
      * @param [options] - An optional object containing the parameters for gasLimit and gasPrice
-     * @returns {Promise} A promise that resolves into a record that contains the transaction hash.
+     * @returns {Promise} A promise that resolves into an array of transaction hashes.
      */
     async claimFeesForAccruals(wallet, currency, startAccrual, endAccrual, options) {
         try {
-            const tokenHolderRevenueFund = _tokenHolderRevenueFund.get(this).connect(wallet);
-            const tx = tokenHolderRevenueFund.claimAndStageByAccruals(
-                currency.ct.toString(), currency.id, startAccrual, endAccrual, options
+            const ensemble = _tokenHolderRevenueFundContractEnsemble.get(this);
+            const txs = ensemble.claimAndStageByAccruals(
+                wallet, currency, startAccrual, endAccrual, options
             );
-            return tx;
+            return txs;
         }
         catch (error) {
             throw new NestedError(error, 'Unable to claim fees for accruals.');
@@ -94,9 +95,9 @@ class FeesClaimant {
      * @returns {Promise} A promise that resolves into a BigNumber value representing the claimable amount of fees.
      */
     async claimableFeesForBlocks(wallet, currency, startBlock, endBlock) {
-        const tokenHolderRevenueFund = _tokenHolderRevenueFund.get(this);
-        return tokenHolderRevenueFund.claimableAmountByBlockNumbers(
-            wallet.address, currency.ct.toString(), currency.id, startBlock, endBlock
+        const ensemble = _tokenHolderRevenueFundContractEnsemble.get(this);
+        return ensemble.claimableAmountByBlockNumbers(
+            wallet, currency, startBlock, endBlock
         );
     }
 
@@ -111,11 +112,11 @@ class FeesClaimant {
      */
     async claimFeesForBlocks(wallet, currency, startBlock, endBlock, options) {
         try {
-            const tokenHolderRevenueFund = _tokenHolderRevenueFund.get(this).connect(wallet);
-            const tx = tokenHolderRevenueFund.claimAndStageByBlockNumbers(
-                currency.ct.toString(), currency.id, startBlock, endBlock, options
+            const ensemble = _tokenHolderRevenueFundContractEnsemble.get(this);
+            const txs = ensemble.claimAndStageByBlockNumbers(
+                wallet, currency, startBlock, endBlock, options
             );
-            return tx;
+            return txs;
         }
         catch (error) {
             throw new NestedError(error, 'Unable to claim fees for blocks.');
@@ -129,10 +130,8 @@ class FeesClaimant {
      * @returns {Promise} A promise that resolves into a BigNumber value representing the withdrawable amount of fees.
      */
     async withdrawableFees(wallet, currency) {
-        const tokenHolderRevenueFund = _tokenHolderRevenueFund.get(this);
-        return tokenHolderRevenueFund.stagedBalance(
-            wallet.address, currency.ct.toString(), currency.id
-        );
+        const ensemble = _tokenHolderRevenueFundContractEnsemble.get(this);
+        return ensemble.stagedBalance(wallet, currency);
     }
 
     /**
@@ -144,11 +143,11 @@ class FeesClaimant {
      */
     async withdrawFees(wallet, monetaryAmount, options) {
         try {
-            const tokenHolderRevenueFund = _tokenHolderRevenueFund.get(this).connect(wallet);
-            const tx = tokenHolderRevenueFund.withdraw(
-                monetaryAmount.amount, monetaryAmount.currency.ct.toString(), monetaryAmount.currency.id, 'ERC20', options
+            const ensemble = _tokenHolderRevenueFundContractEnsemble.get(this);
+            const txs = ensemble.withdraw(
+                wallet, monetaryAmount, 'ERC20', options
             );
-            return tx;
+            return txs;
         }
         catch (error) {
             throw new NestedError(error, 'Unable to withdraw fees.');

--- a/lib/claim/fees-claimant.js
+++ b/lib/claim/fees-claimant.js
@@ -11,9 +11,9 @@ const _tokenHolderRevenueFundContractEnsemble = new WeakMap();
  * @alias module:nahmii-sdk
  */
 class FeesClaimant {
-    constructor(provider, ensembleNames) {
+    constructor(provider, abstractionNames) {
         _tokenHolderRevenueFundContractEnsemble.set(
-            this, new TokenHolderRevenueFundContractsEnsemble(provider, ensembleNames)
+            this, new TokenHolderRevenueFundContractsEnsemble(provider, abstractionNames)
         );
     }
 

--- a/lib/claim/fees-claimant.js
+++ b/lib/claim/fees-claimant.js
@@ -21,18 +21,18 @@ class FeesClaimant {
      * Get claimable accruals
      * @param {Wallet} wallet - The claimer nahmii wallet
      * @param {Currency} currency - The currency
-     * @param {number} [startAccrual] - An optional lower accrual index boundary
-     * @param {number} [endAccrual] - An optional upper accrual index boundary
+     * @param {number} [firstAccrual] - An optional lower accrual index boundary
+     * @param {number} [lastAccrual] - An optional upper accrual index boundary
      * @returns {Promise} A promise that resolves into an array of claimable accruals.
      */
-    async claimableAccruals(wallet, currency, startAccrual, endAccrual) {
+    async claimableAccruals(wallet, currency, firstAccrual, lastAccrual) {
         const ensemble = _tokenHolderRevenueFundContractEnsemble.get(this);
 
-        startAccrual = startAccrual || 0;
-        endAccrual = endAccrual || (await ensemble.closedAccrualsCount(currency)) - 1;
+        firstAccrual = firstAccrual || 0;
+        lastAccrual = lastAccrual || (await ensemble.closedAccrualsCount(currency)) - 1;
 
-        const accruals = [...Array(endAccrual - startAccrual + 1).keys()]
-            .map(o => startAccrual + o);
+        const accruals = [...Array(lastAccrual - firstAccrual + 1).keys()]
+            .map(o => firstAccrual + o);
 
         const accrualClaimableStats = (await Promise.all(
             accruals.map(accrual => ensemble.fullyClaimed(wallet, currency, accrual))
@@ -53,14 +53,14 @@ class FeesClaimant {
      * Get claimable amount of fees for a span of accruals
      * @param {Wallet} wallet - The claimer nahmii wallet
      * @param {Currency} currency - The currency
-     * @param {number} startAccrual - The lower accrual index boundary
-     * @param {number} endAccrual - The upper accrual index boundary
+     * @param {number} firstAccrual - The lower accrual index boundary
+     * @param {number} lastAccrual - The upper accrual index boundary
      * @returns {Promise} A promise that resolves into a BigNumber value representing the claimable amount of fees.
      */
-    async claimableFeesForAccruals(wallet, currency, startAccrual, endAccrual) {
+    async claimableFeesForAccruals(wallet, currency, firstAccrual, lastAccrual) {
         const ensemble = _tokenHolderRevenueFundContractEnsemble.get(this);
         return ensemble.claimableAmountByAccruals(
-            wallet, currency, startAccrual, endAccrual
+            wallet, currency, firstAccrual, lastAccrual
         );
     }
 
@@ -68,16 +68,16 @@ class FeesClaimant {
      * Claim fees for a span of accruals
      * @param {Wallet} wallet - The claimer nahmii wallet
      * @param {Currency} currency - The currency
-     * @param {number} startAccrual - The lower accrual index boundary
-     * @param {number} endAccrual - The upper accrual index boundary
+     * @param {number} firstAccrual - The lower accrual index boundary
+     * @param {number} lastAccrual - The upper accrual index boundary
      * @param [options] - An optional object containing the parameters for gasLimit and gasPrice
      * @returns {Promise} A promise that resolves into an array of transaction hashes.
      */
-    async claimFeesForAccruals(wallet, currency, startAccrual, endAccrual, options) {
+    async claimFeesForAccruals(wallet, currency, firstAccrual, lastAccrual, options) {
         try {
             const ensemble = _tokenHolderRevenueFundContractEnsemble.get(this);
             const txs = ensemble.claimAndStageByAccruals(
-                wallet, currency, startAccrual, endAccrual, options
+                wallet, currency, firstAccrual, lastAccrual, options
             );
             return txs;
         }
@@ -90,14 +90,14 @@ class FeesClaimant {
      * Get claimable amount of fees for a span of block numbers
      * @param {Wallet} wallet - The claimer nahmii wallet
      * @param {Currency} currency - The currency
-     * @param {number} startBlock - The lower block number boundary
-     * @param {number} endBlock - The upper block number boundary
+     * @param {number} firstBlock - The lower block number boundary
+     * @param {number} lastBlock - The upper block number boundary
      * @returns {Promise} A promise that resolves into a BigNumber value representing the claimable amount of fees.
      */
-    async claimableFeesForBlocks(wallet, currency, startBlock, endBlock) {
+    async claimableFeesForBlocks(wallet, currency, firstBlock, lastBlock) {
         const ensemble = _tokenHolderRevenueFundContractEnsemble.get(this);
         return ensemble.claimableAmountByBlockNumbers(
-            wallet, currency, startBlock, endBlock
+            wallet, currency, firstBlock, lastBlock
         );
     }
 
@@ -105,16 +105,16 @@ class FeesClaimant {
      * Claim fees for a span of block numbers
      * @param {Wallet} wallet - The claimer nahmii wallet
      * @param {Currency} currency - The currency
-     * @param {number} startBlock - The lower block number boundary
-     * @param {number} endBlock - The upper block number boundary
+     * @param {number} firstBlock - The lower block number boundary
+     * @param {number} lastBlock - The upper block number boundary
      * @param [options] - An optional object containing the parameters for gasLimit and gasPrice
      * @returns {Promise} A promise that resolves into an array of transaction hashes.
      */
-    async claimFeesForBlocks(wallet, currency, startBlock, endBlock, options) {
+    async claimFeesForBlocks(wallet, currency, firstBlock, lastBlock, options) {
         try {
             const ensemble = _tokenHolderRevenueFundContractEnsemble.get(this);
             const txs = ensemble.claimAndStageByBlockNumbers(
-                wallet, currency, startBlock, endBlock, options
+                wallet, currency, firstBlock, lastBlock, options
             );
             return txs;
         }

--- a/lib/claim/fees-claimant.spec.js
+++ b/lib/claim/fees-claimant.spec.js
@@ -3,26 +3,23 @@
 const proxyquire = require('proxyquire').noPreserveCache().noCallThru();
 const sinon = require('sinon');
 const chai = require('chai');
-chai.use(require('sinon-chai'));
-chai.use(require('chai-as-promised'));
 const ethers = require('ethers');
 const {EthereumAddress} = require('nahmii-ethereum-address');
 const MonetaryAmount = require('../monetary-amount');
 const Currency = require('../currency');
 const NestedError = require('../nested-error');
 
-const stubbedProvider = {};
-const stubbedTokenHolderRevenueFund = {};
-const stubbedTokenHolderRevenueFundContract = sinon.stub()
-    .withArgs(stubbedProvider)
-    .returns(stubbedTokenHolderRevenueFund);
-
-const FeesClaimant = proxyquire('./fees-claimant', {
-    './token-holder-revenue-fund-contract': stubbedTokenHolderRevenueFundContract
-});
+chai.use(require('sinon-chai'));
+chai.use(require('chai-as-promised'));
+chai.should();
 
 describe('Fees claimant', () => {
     let wallet, currency;
+    let stubbedProvider;
+    let stubbedTokenHolderRevenueFundContractEnsembleConstructor;
+    let stubbedTokenHolderRevenueFundContractEnsemble;
+    let FeesClaimant;
+    let feesClaimant;
 
     before(() => {
         wallet = EthereumAddress.from('0x0000000000000000000000000000000000000001');
@@ -32,32 +29,63 @@ describe('Fees claimant', () => {
         });
     });
 
+    beforeEach(() => {
+        stubbedProvider = {};
+        stubbedTokenHolderRevenueFundContractEnsemble = {
+            closedAccrualsCount: sinon.stub(),
+            fullyClaimed: sinon.stub(),
+            claimableAmountByAccruals: sinon.stub(),
+            claimAndStageByAccruals: sinon.stub(),
+            claimableAmountByBlockNumbers: sinon.stub(),
+            claimAndStageByBlockNumbers: sinon.stub(),
+            stagedBalance: sinon.stub(),
+            withdraw: sinon.stub()
+        };
+        stubbedTokenHolderRevenueFundContractEnsembleConstructor = sinon.stub()
+            .withArgs(stubbedProvider)
+            .returns(stubbedTokenHolderRevenueFundContractEnsemble)
+            .withArgs(stubbedProvider, ['abstraction1', 'abstraction2'])
+            .returns(stubbedTokenHolderRevenueFundContractEnsemble);
+
+        FeesClaimant = proxyquire('./fees-claimant', {
+            './token-holder-revenue-fund-contracts-ensemble': stubbedTokenHolderRevenueFundContractEnsembleConstructor
+        });
+    });
+
     describe('when instantiating', () => {
-        it('succeeds', () => {
-            new FeesClaimant(stubbedProvider);
+        describe('if called without abstraction names', () => {
+            it('succeeds', () => {
+                new FeesClaimant(stubbedProvider);
+                stubbedTokenHolderRevenueFundContractEnsembleConstructor
+                    .should.have.been.calledWithExactly(stubbedProvider, undefined);
+            });
+        });
+
+        describe('if called with abstraction names', () => {
+            it('succeeds', () => {
+                new FeesClaimant(stubbedProvider, ['abstraction1', 'abstraction2']);
+                stubbedTokenHolderRevenueFundContractEnsembleConstructor
+                    .should.have.been.calledWithExactly(stubbedProvider, ['abstraction1', 'abstraction2']);
+            });
         });
     });
 
     describe('claimableAccruals()', () => {
-        let feesClaimant, startAccrual;
+        let startAccrual;
 
         beforeEach(() => {
             feesClaimant = new FeesClaimant(stubbedProvider);
             startAccrual = 0;
-            stubbedTokenHolderRevenueFund.closedAccrualsCount = sinon.stub()
+            stubbedTokenHolderRevenueFundContractEnsemble.closedAccrualsCount
                 .resolves(4);
-            stubbedTokenHolderRevenueFund.fullyClaimed = sinon.stub();
-            stubbedTokenHolderRevenueFund.fullyClaimed
-                .withArgs(wallet.address, currency.ct.toString(), currency.id, startAccrual)
-                .resolves(false);
-            stubbedTokenHolderRevenueFund.fullyClaimed
-                .withArgs(wallet.address, currency.ct.toString(), currency.id, startAccrual + 1)
-                .resolves(true);
-            stubbedTokenHolderRevenueFund.fullyClaimed
-                .withArgs(wallet.address, currency.ct.toString(), currency.id, startAccrual + 2)
-                .resolves(false);
-            stubbedTokenHolderRevenueFund.fullyClaimed
-                .withArgs(wallet.address, currency.ct.toString(), currency.id, startAccrual + 3)
+            stubbedTokenHolderRevenueFundContractEnsemble.fullyClaimed
+                .withArgs(wallet, currency, startAccrual)
+                .resolves(false)
+                .withArgs(wallet, currency, startAccrual + 1)
+                .resolves(true)
+                .withArgs(wallet, currency, startAccrual + 2)
+                .resolves(false)
+                .withArgs(wallet, currency, startAccrual + 3)
                 .resolves(true);
         });
 
@@ -77,14 +105,14 @@ describe('Fees claimant', () => {
     });
 
     describe('claimableFeesForAccruals()', () => {
-        let feesClaimant, startAccrual, endAccrual;
+        let startAccrual, endAccrual;
 
         beforeEach(() => {
             feesClaimant = new FeesClaimant(stubbedProvider);
             startAccrual = 1;
             endAccrual = 2;
-            stubbedTokenHolderRevenueFund.claimableAmountByAccruals = sinon.stub()
-                .withArgs(wallet.address, currency.ct.toString(), currency.id, startAccrual, endAccrual)
+            stubbedTokenHolderRevenueFundContractEnsemble.claimableAmountByAccruals
+                .withArgs(wallet, currency, startAccrual, endAccrual)
                 .resolves(1000);
         });
 
@@ -95,7 +123,7 @@ describe('Fees claimant', () => {
     });
 
     describe('claimFeesForAccruals()', () => {
-        let feesClaimant, startAccrual, endAccrual, options;
+        let startAccrual, endAccrual, options;
 
         beforeEach(() => {
             feesClaimant = new FeesClaimant(stubbedProvider);
@@ -104,13 +132,10 @@ describe('Fees claimant', () => {
             options = {};
         });
 
-        describe('when claim and stage succeeds', () => {
+        describe('when ensemble claim and stage succeeds', () => {
             beforeEach(() => {
-                stubbedTokenHolderRevenueFund.connect = sinon.stub()
-                    .withArgs(wallet)
-                    .returns(stubbedTokenHolderRevenueFund);
-                stubbedTokenHolderRevenueFund.claimAndStageByAccruals = sinon.stub()
-                    .withArgs(currency.ct.toString(), currency.id, startAccrual, endAccrual, options)
+                stubbedTokenHolderRevenueFundContractEnsemble.claimAndStageByAccruals
+                    .withArgs(wallet, currency, startAccrual, endAccrual, options)
                     .returns(ethers.constants.HashZero);
             });
 
@@ -120,30 +145,11 @@ describe('Fees claimant', () => {
             });
         });
 
-        describe('when connect throws', () => {
+        describe('when ensemble claim and stage throws', () => {
             beforeEach(() => {
-                stubbedTokenHolderRevenueFund.connect = sinon.stub()
-                    .withArgs(wallet)
-                    .throws(new Error('Unable to connect'));
-                stubbedTokenHolderRevenueFund.claimAndStageByAccruals = sinon.stub()
-                    .withArgs(currency.ct.toString(), currency.id, startAccrual, endAccrual, options)
-                    .returns(ethers.constants.HashZero);
-            });
-
-            it('should reject', async () => {
-                await feesClaimant.claimFeesForAccruals(wallet, currency, startAccrual, endAccrual, options)
-                    .should.be.rejectedWith(NestedError, 'Unable to claim fees for accruals.');
-            });
-        });
-
-        describe('when claim and stage throws', () => {
-            beforeEach(() => {
-                stubbedTokenHolderRevenueFund.connect = sinon.stub()
-                    .withArgs(wallet)
-                    .returns(stubbedTokenHolderRevenueFund);
-                stubbedTokenHolderRevenueFund.claimAndStageByAccruals = sinon.stub()
-                    .withArgs(currency.ct.toString(), currency.id, startAccrual, endAccrual, options)
-                    .throws(new Error('Unable to claim and stage for accruals'));
+                stubbedTokenHolderRevenueFundContractEnsemble.claimAndStageByAccruals
+                    .withArgs(wallet, currency, startAccrual, endAccrual, options)
+                    .throws();
             });
 
             it('should reject', async () => {
@@ -154,14 +160,14 @@ describe('Fees claimant', () => {
     });
 
     describe('claimableFeesForBlocks()', () => {
-        let feesClaimant, startBlock, endBlock;
+        let startBlock, endBlock;
 
         beforeEach(() => {
             feesClaimant = new FeesClaimant(stubbedProvider);
             startBlock = 1000000;
             endBlock = 2000000;
-            stubbedTokenHolderRevenueFund.claimableAmountByBlockNumbers = sinon.stub()
-                .withArgs(wallet.address, currency.ct.toString(), currency.id, startBlock, endBlock)
+            stubbedTokenHolderRevenueFundContractEnsemble.claimableAmountByBlockNumbers
+                .withArgs(wallet, currency, startBlock, endBlock)
                 .resolves(1000);
         });
 
@@ -172,7 +178,7 @@ describe('Fees claimant', () => {
     });
 
     describe('claimFeesForBlocks()', () => {
-        let feesClaimant, startBlock, endBlock, options;
+        let startBlock, endBlock, options;
 
         beforeEach(() => {
             feesClaimant = new FeesClaimant(stubbedProvider);
@@ -181,13 +187,10 @@ describe('Fees claimant', () => {
             options = {};
         });
 
-        describe('when claim and stage succeeds', () => {
+        describe('when ensemble claim and stage succeeds', () => {
             beforeEach(() => {
-                stubbedTokenHolderRevenueFund.connect = sinon.stub()
-                    .withArgs(wallet)
-                    .returns(stubbedTokenHolderRevenueFund);
-                stubbedTokenHolderRevenueFund.claimAndStageByBlockNumbers = sinon.stub()
-                    .withArgs(currency.ct.toString(), currency.id, startBlock, endBlock, options)
+                stubbedTokenHolderRevenueFundContractEnsemble.claimAndStageByBlockNumbers
+                    .withArgs(wallet, currency, startBlock, endBlock, options)
                     .returns(ethers.constants.HashZero);
             });
 
@@ -197,29 +200,10 @@ describe('Fees claimant', () => {
             });
         });
 
-        describe('when connect throws', () => {
+        describe('when ensemble claim and stage throws', () => {
             beforeEach(() => {
-                stubbedTokenHolderRevenueFund.connect = sinon.stub()
-                    .withArgs(wallet)
-                    .throws(new Error('Unable to connect'));
-                stubbedTokenHolderRevenueFund.claimAndStageByBlockNumbers = sinon.stub()
-                    .withArgs(currency.ct.toString(), currency.id, startBlock, endBlock, options)
-                    .returns(ethers.constants.HashZero);
-            });
-
-            it('should reject', async () => {
-                await feesClaimant.claimFeesForBlocks(wallet, currency, startBlock, endBlock, options)
-                    .should.be.rejectedWith(NestedError, 'Unable to claim fees for blocks.');
-            });
-        });
-
-        describe('when claim and stage throws', () => {
-            beforeEach(() => {
-                stubbedTokenHolderRevenueFund.connect = sinon.stub()
-                    .withArgs(wallet)
-                    .returns(stubbedTokenHolderRevenueFund);
-                stubbedTokenHolderRevenueFund.claimAndStageByBlockNumbers = sinon.stub()
-                    .withArgs(currency.ct.toString(), currency.id, startBlock, endBlock, options)
+                stubbedTokenHolderRevenueFundContractEnsemble.claimAndStageByBlockNumbers
+                    .withArgs(wallet, currency, startBlock, endBlock, options)
                     .throws(new Error('Unable to claim and stage for blocks numbers'));
             });
 
@@ -235,8 +219,8 @@ describe('Fees claimant', () => {
 
         beforeEach(() => {
             feesClaimant = new FeesClaimant(stubbedProvider);
-            stubbedTokenHolderRevenueFund.stagedBalance = sinon.stub()
-                .withArgs(wallet.address, currency.ct.toString(), currency.id)
+            stubbedTokenHolderRevenueFundContractEnsemble.stagedBalance
+                .withArgs(wallet, currency)
                 .resolves(1000);
         });
 
@@ -247,7 +231,7 @@ describe('Fees claimant', () => {
     });
 
     describe('withdrawFees()', () => {
-        let feesClaimant, monetaryAmount, options;
+        let monetaryAmount, options;
 
         beforeEach(() => {
             feesClaimant = new FeesClaimant(stubbedProvider);
@@ -263,11 +247,8 @@ describe('Fees claimant', () => {
 
         describe('when withdraw succeeds', () => {
             beforeEach(() => {
-                stubbedTokenHolderRevenueFund.connect = sinon.stub()
-                    .withArgs(wallet)
-                    .returns(stubbedTokenHolderRevenueFund);
-                stubbedTokenHolderRevenueFund.withdraw = sinon.stub()
-                    .withArgs(monetaryAmount.currency.ct.toString(), monetaryAmount.currency.id, options)
+                stubbedTokenHolderRevenueFundContractEnsemble.withdraw
+                    .withArgs(wallet, monetaryAmount, 'ERC20', options)
                     .returns(ethers.constants.HashZero);
             });
 
@@ -277,29 +258,10 @@ describe('Fees claimant', () => {
             });
         });
 
-        describe('when connect throws', () => {
-            beforeEach(() => {
-                stubbedTokenHolderRevenueFund.connect = sinon.stub()
-                    .withArgs(wallet)
-                    .throws(new Error('Unable to connect'));
-                stubbedTokenHolderRevenueFund.withdraw = sinon.stub()
-                    .withArgs(monetaryAmount.currency.ct.toString(), monetaryAmount.currency.id, options)
-                    .returns(ethers.constants.HashZero);
-            });
-
-            it('should reject', async () => {
-                await feesClaimant.withdrawFees(wallet, monetaryAmount, options)
-                    .should.be.rejectedWith(NestedError, 'Unable to withdraw fees.');
-            });
-        });
-
         describe('when withdraw throws', () => {
             beforeEach(() => {
-                stubbedTokenHolderRevenueFund.connect = sinon.stub()
-                    .withArgs(wallet)
-                    .returns(stubbedTokenHolderRevenueFund);
-                stubbedTokenHolderRevenueFund.withdraw = sinon.stub()
-                    .withArgs(monetaryAmount.currency.ct.toString(), monetaryAmount.currency.id, options)
+                stubbedTokenHolderRevenueFundContractEnsemble.withdraw
+                    .withArgs(wallet, monetaryAmount, 'ERC20', options)
                     .throws(new Error('Unable to withdraw'));
             });
 

--- a/lib/claim/fees-claimant.spec.js
+++ b/lib/claim/fees-claimant.spec.js
@@ -71,21 +71,21 @@ describe('Fees claimant', () => {
     });
 
     describe('claimableAccruals()', () => {
-        let startAccrual;
+        let firstAccrual;
 
         beforeEach(() => {
             feesClaimant = new FeesClaimant(stubbedProvider);
-            startAccrual = 0;
+            firstAccrual = 0;
             stubbedTokenHolderRevenueFundContractEnsemble.closedAccrualsCount
                 .resolves(4);
             stubbedTokenHolderRevenueFundContractEnsemble.fullyClaimed
-                .withArgs(wallet, currency, startAccrual)
+                .withArgs(wallet, currency, firstAccrual)
                 .resolves(false)
-                .withArgs(wallet, currency, startAccrual + 1)
+                .withArgs(wallet, currency, firstAccrual + 1)
                 .resolves(true)
-                .withArgs(wallet, currency, startAccrual + 2)
+                .withArgs(wallet, currency, firstAccrual + 2)
                 .resolves(false)
-                .withArgs(wallet, currency, startAccrual + 3)
+                .withArgs(wallet, currency, firstAccrual + 3)
                 .resolves(true);
         });
 
@@ -105,42 +105,42 @@ describe('Fees claimant', () => {
     });
 
     describe('claimableFeesForAccruals()', () => {
-        let startAccrual, endAccrual;
+        let firstAccrual, lastAccrual;
 
         beforeEach(() => {
             feesClaimant = new FeesClaimant(stubbedProvider);
-            startAccrual = 1;
-            endAccrual = 2;
+            firstAccrual = 1;
+            lastAccrual = 2;
             stubbedTokenHolderRevenueFundContractEnsemble.claimableAmountByAccruals
-                .withArgs(wallet, currency, startAccrual, endAccrual)
+                .withArgs(wallet, currency, firstAccrual, lastAccrual)
                 .resolves(1000);
         });
 
         it('should return the fees claimable by accruals', async () => {
-            (await feesClaimant.claimableFeesForAccruals(wallet, currency, startAccrual, endAccrual))
+            (await feesClaimant.claimableFeesForAccruals(wallet, currency, firstAccrual, lastAccrual))
                 .should.equal(1000);
         });
     });
 
     describe('claimFeesForAccruals()', () => {
-        let startAccrual, endAccrual, options;
+        let firstAccrual, lastAccrual, options;
 
         beforeEach(() => {
             feesClaimant = new FeesClaimant(stubbedProvider);
-            startAccrual = 1;
-            endAccrual = 2;
+            firstAccrual = 1;
+            lastAccrual = 2;
             options = {};
         });
 
         describe('when ensemble claim and stage succeeds', () => {
             beforeEach(() => {
                 stubbedTokenHolderRevenueFundContractEnsemble.claimAndStageByAccruals
-                    .withArgs(wallet, currency, startAccrual, endAccrual, options)
+                    .withArgs(wallet, currency, firstAccrual, lastAccrual, options)
                     .returns(ethers.constants.HashZero);
             });
 
             it('should return the fees claimable by accruals', async () => {
-                (await feesClaimant.claimFeesForAccruals(wallet, currency, startAccrual, endAccrual, options))
+                (await feesClaimant.claimFeesForAccruals(wallet, currency, firstAccrual, lastAccrual, options))
                     .should.equal(ethers.constants.HashZero);
             });
         });
@@ -148,54 +148,54 @@ describe('Fees claimant', () => {
         describe('when ensemble claim and stage throws', () => {
             beforeEach(() => {
                 stubbedTokenHolderRevenueFundContractEnsemble.claimAndStageByAccruals
-                    .withArgs(wallet, currency, startAccrual, endAccrual, options)
+                    .withArgs(wallet, currency, firstAccrual, lastAccrual, options)
                     .throws();
             });
 
             it('should reject', async () => {
-                await feesClaimant.claimFeesForAccruals(wallet, currency, startAccrual, endAccrual, options)
+                await feesClaimant.claimFeesForAccruals(wallet, currency, firstAccrual, lastAccrual, options)
                     .should.be.rejectedWith(NestedError, 'Unable to claim fees for accruals.');
             });
         });
     });
 
     describe('claimableFeesForBlocks()', () => {
-        let startBlock, endBlock;
+        let firstBlock, lastBlock;
 
         beforeEach(() => {
             feesClaimant = new FeesClaimant(stubbedProvider);
-            startBlock = 1000000;
-            endBlock = 2000000;
+            firstBlock = 1000000;
+            lastBlock = 2000000;
             stubbedTokenHolderRevenueFundContractEnsemble.claimableAmountByBlockNumbers
-                .withArgs(wallet, currency, startBlock, endBlock)
+                .withArgs(wallet, currency, firstBlock, lastBlock)
                 .resolves(1000);
         });
 
         it('should return the fees claimable by blocks', async () => {
-            (await feesClaimant.claimableFeesForBlocks(wallet, currency, startBlock, endBlock))
+            (await feesClaimant.claimableFeesForBlocks(wallet, currency, firstBlock, lastBlock))
                 .should.equal(1000);
         });
     });
 
     describe('claimFeesForBlocks()', () => {
-        let startBlock, endBlock, options;
+        let firstBlock, lastBlock, options;
 
         beforeEach(() => {
             feesClaimant = new FeesClaimant(stubbedProvider);
-            startBlock = 1000000;
-            endBlock = 2000000;
+            firstBlock = 1000000;
+            lastBlock = 2000000;
             options = {};
         });
 
         describe('when ensemble claim and stage succeeds', () => {
             beforeEach(() => {
                 stubbedTokenHolderRevenueFundContractEnsemble.claimAndStageByBlockNumbers
-                    .withArgs(wallet, currency, startBlock, endBlock, options)
+                    .withArgs(wallet, currency, firstBlock, lastBlock, options)
                     .returns(ethers.constants.HashZero);
             });
 
             it('should return the fees claimable by blocks', async () => {
-                (await feesClaimant.claimFeesForBlocks(wallet, currency, startBlock, endBlock, options))
+                (await feesClaimant.claimFeesForBlocks(wallet, currency, firstBlock, lastBlock, options))
                     .should.equal(ethers.constants.HashZero);
             });
         });
@@ -203,12 +203,12 @@ describe('Fees claimant', () => {
         describe('when ensemble claim and stage throws', () => {
             beforeEach(() => {
                 stubbedTokenHolderRevenueFundContractEnsemble.claimAndStageByBlockNumbers
-                    .withArgs(wallet, currency, startBlock, endBlock, options)
+                    .withArgs(wallet, currency, firstBlock, lastBlock, options)
                     .throws(new Error('Unable to claim and stage for blocks numbers'));
             });
 
             it('should reject', async () => {
-                await feesClaimant.claimFeesForBlocks(wallet, currency, startBlock, endBlock, options)
+                await feesClaimant.claimFeesForBlocks(wallet, currency, firstBlock, lastBlock, options)
                     .should.be.rejectedWith(NestedError, 'Unable to claim fees for blocks.');
             });
         });

--- a/lib/claim/token-holder-revenue-fund-contract.js
+++ b/lib/claim/token-holder-revenue-fund-contract.js
@@ -3,8 +3,8 @@
 const NahmiiContract = require('../contract');
 
 class TokenHolderRevenueFundContract extends NahmiiContract {
-    constructor(walletOrProvider, legacyName) {
-        super(legacyName || 'TokenHolderRevenueFund', walletOrProvider);
+    constructor(walletOrProvider, abstractionName) {
+        super(abstractionName || 'TokenHolderRevenueFund', walletOrProvider);
     }
 }
 

--- a/lib/claim/token-holder-revenue-fund-contract.js
+++ b/lib/claim/token-holder-revenue-fund-contract.js
@@ -3,8 +3,8 @@
 const NahmiiContract = require('../contract');
 
 class TokenHolderRevenueFundContract extends NahmiiContract {
-    constructor(walletOrProvider) {
-        super('TokenHolderRevenueFund', walletOrProvider);
+    constructor(walletOrProvider, legacyName) {
+        super(legacyName || 'TokenHolderRevenueFund', walletOrProvider);
     }
 }
 

--- a/lib/claim/token-holder-revenue-fund-contract.spec.js
+++ b/lib/claim/token-holder-revenue-fund-contract.spec.js
@@ -2,6 +2,7 @@
 
 const CONTRACT_NAME = 'TokenHolderRevenueFund';
 const CONTRACT_FILE = 'token-holder-revenue-fund-contract';
+const LEGACY_CONTRACT_NAME = CONTRACT_NAME + '-123-456';
 
 const chai = require('chai');
 const sinon = require('sinon');
@@ -13,14 +14,20 @@ const proxyquire = require('proxyquire').noPreserveCache().noCallThru();
 
 const stubbedNahmiiContractConstructor = sinon.stub();
 
-function createContract(walletOrProvider) {
+function createContract(walletOrProvider, legacyContractName) {
     const ConfigurationContract = proxyquire('./' + CONTRACT_FILE, {
         '../contract': stubbedNahmiiContractConstructor
     });
+
     stubbedNahmiiContractConstructor
         .withArgs(CONTRACT_NAME, walletOrProvider)
         .returns(stubbedNahmiiContractConstructor);
-    return new ConfigurationContract(walletOrProvider);
+    if (legacyContractName) {
+        stubbedNahmiiContractConstructor
+            .withArgs(legacyContractName, walletOrProvider)
+            .returns(stubbedNahmiiContractConstructor);
+    }
+    return new ConfigurationContract(walletOrProvider, legacyContractName);
 }
 
 describe(CONTRACT_NAME, () => {
@@ -38,9 +45,20 @@ describe(CONTRACT_NAME, () => {
         ['wallet', fakeWallet],
         ['provider', fakeProvider]
     ].forEach(([description, walletOrProvider]) => {
-        context('with ' + description, () => {
+        context('with ' + description + ' and no legacy contract name', () => {
             it('is an instance of NahmiiContract', () => {
                 expect(createContract(walletOrProvider)).to.be.instanceOf(stubbedNahmiiContractConstructor);
+            });
+        });
+    });
+
+    [
+        ['wallet', fakeWallet],
+        ['provider', fakeProvider]
+    ].forEach(([description, walletOrProvider]) => {
+        context('with ' + description + ' and legacy contract name', () => {
+            it('is an instance of NahmiiContract', () => {
+                expect(createContract(walletOrProvider, LEGACY_CONTRACT_NAME)).to.be.instanceOf(stubbedNahmiiContractConstructor);
             });
         });
     });

--- a/lib/claim/token-holder-revenue-fund-contracts-ensemble.js
+++ b/lib/claim/token-holder-revenue-fund-contracts-ensemble.js
@@ -5,14 +5,60 @@ const TokenHolderRevenueFundContract = require('./token-holder-revenue-fund-cont
 const NestedError = require('../nested-error');
 
 const _ensemble = new WeakMap();
-const _spannedByCurrency = new WeakMap();
 const _firstAccrualOffset = new WeakMap();
 
 const currencyToKey = (currency) => `${currency.ct.toString()}-${currency.id}`;
 
-const minBigNumber = function (n1, n2) {
-    return n1.lt(n2) ? n1 : n2;
-};
+const minBigNumber = (n1, n2) => n1.lt(n2) ? n1 : n2;
+
+/**
+ * Span (temporally) in accruals and block numbers for the given currency. I.e. infer the
+ * accrual and block number boundaries of the given currency for each contract
+ * instance in the ensemble
+ * @param {Currency} currency - The currency
+ */
+async function span(currency) {
+    const ensemble = _ensemble.get(this);
+    let globalAccrualOffset = _firstAccrualOffset.get(this);
+    const currencyKey = currencyToKey(currency);
+
+    for (const configuration of ensemble) {
+        const closedAccrualsCount = (await configuration.contract.closedAccrualsCount(
+            currency.ct.toString(), currency.id
+        )).toNumber();
+
+        const span = {};
+        span.firstAccrual = globalAccrualOffset || 0;
+        span.lastAccrual = span.firstAccrual + closedAccrualsCount - 1;
+        span.firstBlock =
+            (await configuration.contract.closedAccrualsByCurrency(
+                currency.ct.toString(), currency.id, span.firstAccrual
+            )).startBlock.toNumber();
+        span.lastBlock =
+            (await configuration.contract.closedAccrualsByCurrency(
+                currency.ct.toString(), currency.id, span.lastAccrual
+            )).endBlock.toNumber();
+
+        if (!configuration.spansByCurrency)
+            configuration.spansByCurrency = new Map();
+
+        configuration.spansByCurrency.set(currencyKey, span);
+
+        globalAccrualOffset = span.lastAccrual + 1;
+    }
+}
+
+/**
+ * Return status of whether contract instance span has been executed
+ * for the given currency
+ * @param {Currency} currency - The currency
+ * @returns {boolean} True if span has been executed, else false
+ */
+function isSpanned(currency) {
+    return _ensemble.get(this).every(
+        conf => conf.spansByCurrency && conf.spansByCurrency.has(currencyToKey(currency))
+    );
+}
 
 /**
  * @class TokenHolderRevenueFundContractsEnsemble
@@ -20,10 +66,20 @@ const minBigNumber = function (n1, n2) {
  * @alias module:nahmii-sdk
  */
 class TokenHolderRevenueFundContractsEnsemble {
+    /**
+     * Construct a new ensemble of TokenHolderRevenueFund contracts
+     * @param {Wallet|NahmiiProvider} walletOrProvider - A nahmii wallet or provider
+     * @param {string[]} abstractionNames - The names of abstractions to be included in the example, defaults
+     * to the ['TokenHolderRevenueFund'] which uses the latest contract instance only
+     */
     constructor(walletOrProvider, abstractionNames = ['TokenHolderRevenueFund'], firstAccrualOffset = 0) {
-        _ensemble.set(this, abstractionNames.map(n => ({contract: new TokenHolderRevenueFundContract(walletOrProvider, n)})));
-        _spannedByCurrency.set(this, new Map());
-        _firstAccrualOffset.set(this, firstAccrualOffset > 0 ? firstAccrualOffset : 0);
+        _ensemble.set(this, abstractionNames.map(
+            abstractionName => ({contract: new TokenHolderRevenueFundContract(walletOrProvider, abstractionName)})
+        ));
+
+        if (firstAccrualOffset < 0)
+            throw new Error(`Unexpected value of firstAccrualOffset: ${firstAccrualOffset}`);
+        _firstAccrualOffset.set(this, firstAccrualOffset);
     }
 
     /**
@@ -35,71 +91,21 @@ class TokenHolderRevenueFundContractsEnsemble {
     }
 
     /**
-     * Return status of whether contract instance span has been executed
-     * for the given currency
-     * @param {Currency} currency - The currency
-     * @returns {boolean} True if span has been executed, else false
-     */
-    isSpanned(currency) {
-        const spannedByCurrency = _spannedByCurrency.get(this);
-        return spannedByCurrency.get(currencyToKey(currency)) || false;
-    }
-
-    /**
-     * Span (temporally) in accruals and block numbers for the given currency. I.e. infer the
-     * accrual and block number boundaries of the given currency for each contract
-     * instance in the ensemble
-     * @param {Currency} currency - The currency
-     */
-    async span(currency) {
-        const ensemble = _ensemble.get(this);
-        let globalAccrualOffset = _firstAccrualOffset.get(this);
-        const currencyKey = currencyToKey(currency);
-
-        for (const configuration of ensemble) {
-            const closedAccrualsCount = (await configuration.contract.closedAccrualsCount(
-                currency.ct.toString(), currency.id
-            )).toNumber();
-
-            const span = {};
-            span.startAccrual = globalAccrualOffset || 0;
-            span.endAccrual = span.startAccrual + closedAccrualsCount - 1;
-            span.startBlock =
-                (await configuration.contract.closedAccrualsByCurrency(
-                    currency.ct.toString(), currency.id, span.startAccrual
-                )).startBlock.toNumber();
-            span.endBlock =
-                (await configuration.contract.closedAccrualsByCurrency(
-                    currency.ct.toString(), currency.id, span.endAccrual
-                )).endBlock.toNumber();
-
-            if (!configuration.spansByCurrency)
-                configuration.spansByCurrency = new Map();
-
-            configuration.spansByCurrency.set(currencyKey, span);
-
-            globalAccrualOffset = span.endAccrual + 1;
-        }
-
-        _spannedByCurrency.get(this).set(currencyKey, true);
-    }
-
-    /**
      * Return status of whether the given accrual has been fully claimed
      * @param {Wallet} wallet - The claimer nahmii wallet
      * @param {Currency} currency - The currency
      * @returns {boolean} True if fully claimed, else false
      */
     async fullyClaimed(wallet, currency, accrual) {
-        if (!this.isSpanned(currency))
-            await this.span(currency);
+        if (!isSpanned.call(this, currency))
+            await span.call(this, currency);
 
         const ensemble = _ensemble.get(this);
         const currencyKey = currencyToKey(currency);
 
         for (const configuration of ensemble) {
             const span = configuration.spansByCurrency.get(currencyKey);
-            if (span.startAccrual <= accrual && accrual <= span.endAccrual) {
+            if (span.firstAccrual <= accrual && accrual <= span.lastAccrual) {
                 return configuration.contract.fullyClaimed(
                     wallet.address, currency.ct.toString(), currency.id, accrual
                 );
@@ -129,16 +135,16 @@ class TokenHolderRevenueFundContractsEnsemble {
      * Get claimable amount for the given span of accruals
      * @param {Wallet} wallet - The claimer nahmii wallet
      * @param {Currency} currency - The currency
-     * @param {number} startAccrual - The lower accrual index boundary
-     * @param {number} endAccrual - The upper accrual index boundary
+     * @param {number} firstAccrual - The lower accrual index boundary
+     * @param {number} lastAccrual - The upper accrual index boundary
      * @returns {Promise} A promise that resolves into a BigNumber value representing the claimable amount.
      */
-    async claimableAmountByAccruals(wallet, currency, startAccrual, endAccrual) {
-        if (startAccrual > endAccrual)
-            throw new Error(`Ordinality mismatch of startAccrual > endAccrual (${startAccrual} > ${endAccrual})`);
+    async claimableAmountByAccruals(wallet, currency, firstAccrual, lastAccrual) {
+        if (firstAccrual > lastAccrual)
+            throw new Error(`Ordinality mismatch of firstAccrual > lastAccrual (${firstAccrual} > ${lastAccrual})`);
 
-        if (!this.isSpanned(currency))
-            await this.span(currency);
+        if (!isSpanned.call(this, currency))
+            await span.call(this, currency);
 
         const ensemble = _ensemble.get(this);
         const currencyKey = currencyToKey(currency);
@@ -148,14 +154,14 @@ class TokenHolderRevenueFundContractsEnsemble {
         for (const configuration of ensemble) {
             const span = configuration.spansByCurrency.get(currencyKey);
 
-            if (endAccrual < span.startAccrual || startAccrual > span.endAccrual)
+            if (lastAccrual < span.firstAccrual || firstAccrual > span.lastAccrual)
                 continue;
 
             claimableFees = claimableFees.add(
                 await configuration.contract.claimableAmountByAccruals(
                     wallet.address, currency.ct.toString(), currency.id,
-                    Math.max(startAccrual, span.startAccrual),
-                    Math.min(endAccrual, span.endAccrual)
+                    Math.max(firstAccrual, span.firstAccrual),
+                    Math.min(lastAccrual, span.lastAccrual)
                 )
             );
         }
@@ -167,17 +173,17 @@ class TokenHolderRevenueFundContractsEnsemble {
      * Claim and stage for the given span of accruals
      * @param {Wallet} wallet - The claimer nahmii wallet
      * @param {Currency} currency - The currency
-     * @param {number} startAccrual - The lower accrual index boundary
-     * @param {number} endAccrual - The upper accrual index boundary
+     * @param {number} firstAccrual - The lower accrual index boundary
+     * @param {number} lastAccrual - The upper accrual index boundary
      * @param [options] - An optional object containing the parameters for gasLimit and gasPrice
      * @returns {Promise} A promise that resolves into an array of transaction hashes.
      */
-    async claimAndStageByAccruals(wallet, currency, startAccrual, endAccrual, options) {
-        if (startAccrual > endAccrual)
-            throw new Error(`Ordinality mismatch of startAccrual > endAccrual (${startAccrual} > ${endAccrual})`);
+    async claimAndStageByAccruals(wallet, currency, firstAccrual, lastAccrual, options) {
+        if (firstAccrual > lastAccrual)
+            throw new Error(`Ordinality mismatch of firstAccrual > lastAccrual (${firstAccrual} > ${lastAccrual})`);
 
-        if (!this.isSpanned(currency))
-            await this.span(currency);
+        if (!isSpanned.call(this, currency))
+            await span.call(this, currency);
 
         const ensemble = _ensemble.get(this);
         const currencyKey = currencyToKey(currency);
@@ -188,15 +194,15 @@ class TokenHolderRevenueFundContractsEnsemble {
             for (const configuration of ensemble) {
                 const span = configuration.spansByCurrency.get(currencyKey);
 
-                if (endAccrual < span.startAccrual || startAccrual > span.endAccrual)
+                if (lastAccrual < span.firstAccrual || firstAccrual > span.lastAccrual)
                     continue;
 
                 const contract = configuration.contract.connect(wallet);
                 txs.push(
                     await contract.claimAndStageByAccruals(
                         currency.ct.toString(), currency.id,
-                        Math.max(startAccrual, span.startAccrual),
-                        Math.min(endAccrual, span.endAccrual),
+                        Math.max(firstAccrual, span.firstAccrual),
+                        Math.min(lastAccrual, span.lastAccrual),
                         options
                     )
                 );
@@ -213,16 +219,16 @@ class TokenHolderRevenueFundContractsEnsemble {
      * Get claimable amount for the given span of block numbers
      * @param {Wallet} wallet - The claimer nahmii wallet
      * @param {Currency} currency - The currency
-     * @param {number} startBlock - The lower block number boundary
-     * @param {number} endBlock - The upper block number boundary
+     * @param {number} firstBlock - The lower block number boundary
+     * @param {number} lastBlock - The upper block number boundary
      * @returns {Promise} A promise that resolves into a BigNumber value representing the claimable amount.
      */
-    async claimableAmountByBlockNumbers(wallet, currency, startBlock, endBlock) {
-        if (startBlock > endBlock)
-            throw new Error(`Ordinality mismatch of startBlock > endBlock (${startBlock} > ${endBlock})`);
+    async claimableAmountByBlockNumbers(wallet, currency, firstBlock, lastBlock) {
+        if (firstBlock > lastBlock)
+            throw new Error(`Ordinality mismatch of firstBlock > lastBlock (${firstBlock} > ${lastBlock})`);
 
-        if (!this.isSpanned(currency))
-            await this.span(currency);
+        if (!isSpanned.call(this, currency))
+            await span.call(this, currency);
 
         const ensemble = _ensemble.get(this);
         const currencyKey = currencyToKey(currency);
@@ -232,14 +238,14 @@ class TokenHolderRevenueFundContractsEnsemble {
         for (const configuration of ensemble) {
             const span = configuration.spansByCurrency.get(currencyKey);
 
-            if (endBlock < span.startBlock || startBlock > span.endBlock)
+            if (lastBlock < span.firstBlock || firstBlock > span.lastBlock)
                 continue;
 
             claimableFees = claimableFees.add(
                 await configuration.contract.claimableAmountByBlockNumbers(
                     wallet.address, currency.ct.toString(), currency.id,
-                    Math.max(startBlock, span.startBlock),
-                    Math.min(endBlock, span.endBlock)
+                    Math.max(firstBlock, span.firstBlock),
+                    Math.min(lastBlock, span.lastBlock)
                 )
             );
         }
@@ -251,17 +257,17 @@ class TokenHolderRevenueFundContractsEnsemble {
      * Claim and stage for the given span of block numbers
      * @param {Wallet} wallet - The claimer nahmii wallet
      * @param {Currency} currency - The currency
-     * @param {number} startBlock - The lower block number boundary
-     * @param {number} endBlock - The upper block number boundary
+     * @param {number} firstBlock - The lower block number boundary
+     * @param {number} lastBlock - The upper block number boundary
      * @param [options] - An optional object containing the parameters for gasLimit and gasPrice
      * @returns {Promise} A promise that resolves into an array of transaction hashes.
      */
-    async claimAndStageByBlockNumbers(wallet, currency, startBlock, endBlock, options) {
-        if (startBlock > endBlock)
-            throw new Error(`Ordinality mismatch of startBlock > endBlock (${startBlock} > ${endBlock})`);
+    async claimAndStageByBlockNumbers(wallet, currency, firstBlock, lastBlock, options) {
+        if (firstBlock > lastBlock)
+            throw new Error(`Ordinality mismatch of firstBlock > lastBlock (${firstBlock} > ${lastBlock})`);
 
-        if (!this.isSpanned(currency))
-            await this.span(currency);
+        if (!isSpanned.call(this, currency))
+            await span.call(this, currency);
 
         const ensemble = _ensemble.get(this);
         const currencyKey = currencyToKey(currency);
@@ -272,15 +278,15 @@ class TokenHolderRevenueFundContractsEnsemble {
             for (const configuration of ensemble) {
                 const span = configuration.spansByCurrency.get(currencyKey);
 
-                if (endBlock < span.startBlock || startBlock > span.endBlock)
+                if (lastBlock < span.firstBlock || firstBlock > span.lastBlock)
                     continue;
 
                 const contract = configuration.contract.connect(wallet);
                 txs.push(
                     await contract.claimAndStageByBlockNumbers(
                         currency.ct.toString(), currency.id,
-                        Math.max(startBlock, span.startBlock),
-                        Math.min(endBlock, span.endBlock),
+                        Math.max(firstBlock, span.firstBlock),
+                        Math.min(lastBlock, span.lastBlock),
                         options
                     )
                 );
@@ -317,8 +323,8 @@ class TokenHolderRevenueFundContractsEnsemble {
      * @returns {Promise} A promise that resolves into an array of transaction hashes.
      */
     async withdraw(wallet, monetaryAmount, standard = 'ERC20', options = undefined) {
-        if (!this.isSpanned(monetaryAmount.currency))
-            await this.span(monetaryAmount.currency);
+        if (!isSpanned.call(this, monetaryAmount.currency))
+            await span.call(this, monetaryAmount.currency);
 
         const stagedBalance = await this.stagedBalance(wallet, monetaryAmount.currency);
         if (stagedBalance.lt(monetaryAmount.amount))

--- a/lib/claim/token-holder-revenue-fund-contracts-ensemble.js
+++ b/lib/claim/token-holder-revenue-fund-contracts-ensemble.js
@@ -1,0 +1,334 @@
+'use strict';
+
+const {utils: {bigNumberify}} = require('ethers');
+const TokenHolderRevenueFundContract = require('./token-holder-revenue-fund-contract');
+const NestedError = require('../nested-error');
+
+const _ensemble = new WeakMap();
+const _brokenDown = new WeakMap();
+
+const currencyKey = (currency) => `${currency.ct.toString()}-${currency.id}`;
+
+const minBigNumber = function (n1, n2) {
+    return n1.lt(n2) ? n1 : n2;
+};
+
+/**
+ * @class TokenHolderRevenueFundContractsEnsemble
+ * An ensemble of instances of TokenHolderRevenueFundContract
+ * @alias module:nahmii-sdk
+ */
+class TokenHolderRevenueFundContractsEnsemble {
+    constructor(walletOrProvider, ensembleNames = ['TokenHolderRevenueFund']) {
+        _ensemble.set(this, ensembleNames.map(n => ({contract: new TokenHolderRevenueFundContract(walletOrProvider, n)})));
+        _brokenDown.set(this, new Map());
+    }
+
+    /**
+     * Execute contract instance break-down for the given currency
+     * @param {Currency} currency - The currency
+     */
+    async breakDown(currency) {
+        const brokenDown = _brokenDown.get(this);
+
+        const currencyKey = currencyKey(currency);
+
+        if (brokenDown.get(currencyKey))
+            return;
+
+        const ensemble = _ensemble.get(this);
+
+        let globalAccrualOffset = 0;
+        for (const configuration of ensemble) {
+            const closedAccrualsCount = (await configuration.contract.closedAccrualsCount(
+                currency.ct.toString(), currency.id
+            )).toNumber();
+
+            if (!configuration.breakDowns)
+                configuration.breakDowns = new Map();
+
+            const currencyBreakDown = {};
+            currencyBreakDown.startAccrual = globalAccrualOffset || 0;
+            currencyBreakDown.endAccrual = currencyBreakDown.startAccrual + closedAccrualsCount;
+            currencyBreakDown.startBlock =
+                (await configuration.contract.closedAccrualsByCurrency(
+                    currency.ct.toString(), currency.id, configuration.startAccrual
+                )).startBlock.toNumber();
+            currencyBreakDown.endBlock =
+                (await configuration.contract.closedAccrualsByCurrency(
+                    currency.ct.toString(), currency.id, configuration.endAccrual
+                )).endBlock.toNumber();
+
+            configuration.breakDowns.set(currencyKey, currencyBreakDown);
+
+            globalAccrualOffset = currencyBreakDown.endAccrual + 1;
+        }
+
+        brokenDown.set(currencyKey, true);
+    }
+
+    /**
+     * Return status of whether contract instance break-down has been executed for the given currency
+     * @param {Currency} currency - The currency
+     * @returns {boolean} True if break-down has been executed, else false
+     */
+    isBrokenDown(currency) {
+        const brokenDown = _brokenDown.get(this);
+        return brokenDown.get(currencyKey(currency));
+    }
+
+    /**
+     * Return status of whether the given accrual has been fully claimed
+     * @param {Wallet} wallet - The claimer nahmii wallet
+     * @param {Currency} currency - The currency
+     * @returns {boolean} True if fully claimed, else false
+     */
+    async fullyClaimed(wallet, currency, accrual) {
+        if (!this.isBrokenDown(currency))
+            await this.breakDown(currency);
+
+        const ensemble = _ensemble.get(this);
+
+        for (const configuration of ensemble) {
+            if (configuration.startAccrual <= accrual && accrual <= configuration.endAccrual) {
+                return configuration.contract.fullyClaimed(
+                    wallet.address, currency.ct.toString(), currency.id, accrual
+                );
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Get the count of closed accruals for the given currency
+     * @param {Currency} currency - The currency
+     * @returns {Promise} A promise that resolves into the count of closed accruals
+     */
+    async closedAccrualsCount(currency) {
+        const ensemble = _ensemble.get(this);
+
+        const count = (await Promise.all(ensemble.map(c => c.contract.closedAccrualsCount(
+            currency.ct.toString(), currency.id
+        ))))
+            .reduce((a, c) => a.add(c), bigNumberify(0));
+
+        return count.toNumber();
+    }
+
+    /**
+     * Get claimable amount for the given span of accruals
+     * @param {Wallet} wallet - The claimer nahmii wallet
+     * @param {Currency} currency - The currency
+     * @param {number} startAccrual - The lower accrual index boundary
+     * @param {number} endAccrual - The upper accrual index boundary
+     * @returns {Promise} A promise that resolves into a BigNumber value representing the claimable amount.
+     */
+    async claimableAmountByAccruals(wallet, currency, startAccrual, endAccrual) {
+        if (startAccrual > endAccrual)
+            throw new Error(`Ordinality mismatch of startAccrual > endAccrual (${startAccrual} > ${endAccrual})`);
+
+        if (!this.isBrokenDown(currency))
+            await this.breakDown(currency);
+
+        const ensemble = _ensemble.get(this);
+
+        let claimableFees = bigNumberify(0);
+
+        for (const configuration of ensemble) {
+            if (endAccrual < configuration.startAccrual || startAccrual > configuration.endAccrual)
+                continue;
+
+            claimableFees = claimableFees.add(
+                await configuration.contract.claimableAmountByAccruals(
+                    wallet.address, currency.ct.toString(), currency.id,
+                    Math.max(startAccrual, configuration.startAccrual),
+                    Math.min(endAccrual, configuration.endAccrual)
+                )
+            );
+        }
+
+        return claimableFees;
+    }
+
+    /**
+     * Claim and stage for the given span of accruals
+     * @param {Wallet} wallet - The claimer nahmii wallet
+     * @param {Currency} currency - The currency
+     * @param {number} startAccrual - The lower accrual index boundary
+     * @param {number} endAccrual - The upper accrual index boundary
+     * @param [options] - An optional object containing the parameters for gasLimit and gasPrice
+     * @returns {Promise} A promise that resolves into an array of transaction hashes.
+     */
+    async claimAndStageByAccruals(wallet, currency, startAccrual, endAccrual, options) {
+        if (startAccrual > endAccrual)
+            throw new Error(`Ordinality mismatch of startAccrual > endAccrual (${startAccrual} > ${endAccrual})`);
+
+        if (!this.isBrokenDown(currency))
+            await this.breakDown(currency);
+
+        const ensemble = _ensemble.get(this);
+
+        try {
+            const txs = [];
+
+            for (const configuration of ensemble) {
+                if (endAccrual < configuration.startAccrual || startAccrual > configuration.endAccrual)
+                    continue;
+
+                const contract = configuration.contract.connect(wallet);
+                txs.push(
+                    contract.claimAndStageByAccruals(
+                        currency.ct.toString(), currency.id,
+                        Math.max(startAccrual, configuration.startAccrual),
+                        Math.min(endAccrual, configuration.endAccrual),
+                        options
+                    )
+                );
+            }
+
+            return txs;
+        }
+        catch (error) {
+            throw new NestedError(error, 'Unable to claim and stage by accruals.');
+        }
+    }
+
+    /**
+     * Get claimable amount for the given span of block numbers
+     * @param {Wallet} wallet - The claimer nahmii wallet
+     * @param {Currency} currency - The currency
+     * @param {number} startBlock - The lower block number boundary
+     * @param {number} endBlock - The upper block number boundary
+     * @returns {Promise} A promise that resolves into a BigNumber value representing the claimable amount.
+     */
+    async claimableAmountByBlockNumbers(wallet, currency, startBlock, endBlock) {
+        if (startBlock > endBlock)
+            throw new Error(`Ordinality mismatch of startBlock > endBlock (${startBlock} > ${endBlock})`);
+
+        if (!this.isBrokenDown(currency))
+            await this.breakDown(currency);
+
+        const ensemble = _ensemble.get(this);
+
+        let claimableFees = bigNumberify(0);
+
+        for (const configuration of ensemble) {
+            if (endBlock < configuration.startBlock || startBlock > configuration.endBlock)
+                continue;
+
+            claimableFees = claimableFees.add(
+                await configuration.contract.claimableAmountByBlockNumbers(
+                    wallet.address, currency.ct.toString(), currency.id,
+                    Math.max(startBlock, configuration.startBlock),
+                    Math.min(endBlock, configuration.endBlock)
+                )
+            );
+        }
+
+        return claimableFees;
+    }
+
+    /**
+     * Claim and stage for the given span of block numbers
+     * @param {Wallet} wallet - The claimer nahmii wallet
+     * @param {Currency} currency - The currency
+     * @param {number} startBlock - The lower block number boundary
+     * @param {number} endBlock - The upper block number boundary
+     * @param [options] - An optional object containing the parameters for gasLimit and gasPrice
+     * @returns {Promise} A promise that resolves into an array of transaction hashes.
+     */
+    async claimAndStageByBlockNumbers(wallet, currency, startBlock, endBlock, options) {
+        if (startBlock > endBlock)
+            throw new Error(`Ordinality mismatch of startBlock > endBlock (${startBlock} > ${endBlock})`);
+
+        if (!this.isBrokenDown(currency))
+            await this.breakDown(currency);
+
+        const ensemble = _ensemble.get(this);
+
+        try {
+            const txs = [];
+
+            for (const configuration of ensemble) {
+                if (endBlock < configuration.startBlock || startBlock > configuration.endBlock)
+                    continue;
+
+                const contract = configuration.contract.connect(wallet);
+                txs.push(
+                    contract.claimAndStageByBlockNumbers(
+                        currency.ct.toString(), currency.id,
+                        Math.max(startBlock, configuration.startBlock),
+                        Math.min(endBlock, configuration.endBlock),
+                        options
+                    )
+                );
+            }
+
+            return txs;
+        }
+        catch (error) {
+            throw new NestedError(error, 'Unable to claim and stage by blocks.');
+        }
+    }
+
+    /**
+     * Get the staged balance
+     * @param {Wallet} wallet - The claimer nahmii wallet
+     * @param {Currency} currency - The currency
+     * @returns {Promise} A promise that resolves into a BigNumber value representing the staged balance
+     */
+    async stagedBalance(wallet, currency) {
+        const ensemble = _ensemble.get(this);
+
+        return (await Promise.all(ensemble.map(
+            c => c.contract.stagedBalance(wallet.address, currency.ct.toString(), currency.id)
+        )))
+            .reduce((a, c) => a.add(c), bigNumberify(0));
+    }
+
+    /**
+     * Withdraw the given amount
+     * @param {Wallet} wallet - The claimer nahmii wallet
+     * @param {MonetaryAmount} monetaryAmount - The monetary amount
+     * @param {string} [standard] - The currency standard
+     * @param [options] - An optional object containing the parameters for gasLimit and gasPrice
+     * @returns {Promise} A promise that resolves into an array of transaction hashes.
+     */
+    async withdraw(wallet, monetaryAmount, standard = 'ERC20', options = undefined) {
+        if (!this.isBrokenDown(monetaryAmount.currency))
+            await this.breakDown(monetaryAmount.currency);
+
+        const ensemble = _ensemble.get(this);
+
+        let amountDue = monetaryAmount.amount;
+
+        try {
+            const txs = [];
+
+            for (const configuration of ensemble) {
+                const withdrawableFees = await configuration.contract.stagedBalance(
+                    wallet.address, monetaryAmount.currency.ct.toString(), monetaryAmount.currency.id
+                );
+
+                const amountToWithdraw = minBigNumber(amountDue, withdrawableFees);
+                txs.push(
+                    configuration.contract.connect(wallet).withdraw(
+                        amountToWithdraw, monetaryAmount.currency.ct.toString(), monetaryAmount.currency.id, standard, options
+                    )
+                );
+
+                amountDue = amountDue.sub(amountToWithdraw);
+                if (amountDue.eq(0))
+                    break;
+            }
+
+            return txs;
+        }
+        catch (error) {
+            throw new NestedError(error, 'Unable to withdraw.');
+        }
+    }
+}
+
+module.exports = TokenHolderRevenueFundContractsEnsemble;

--- a/lib/claim/token-holder-revenue-fund-contracts-ensemble.js
+++ b/lib/claim/token-holder-revenue-fund-contracts-ensemble.js
@@ -5,9 +5,10 @@ const TokenHolderRevenueFundContract = require('./token-holder-revenue-fund-cont
 const NestedError = require('../nested-error');
 
 const _ensemble = new WeakMap();
-const _brokenDown = new WeakMap();
+const _decomposedByCurrency = new WeakMap();
+const _firstAccrualOffset = new WeakMap();
 
-const currencyKey = (currency) => `${currency.ct.toString()}-${currency.id}`;
+const currencyToKey = (currency) => `${currency.ct.toString()}-${currency.id}`;
 
 const minBigNumber = function (n1, n2) {
     return n1.lt(n2) ? n1 : n2;
@@ -19,62 +20,66 @@ const minBigNumber = function (n1, n2) {
  * @alias module:nahmii-sdk
  */
 class TokenHolderRevenueFundContractsEnsemble {
-    constructor(walletOrProvider, ensembleNames = ['TokenHolderRevenueFund']) {
-        _ensemble.set(this, ensembleNames.map(n => ({contract: new TokenHolderRevenueFundContract(walletOrProvider, n)})));
-        _brokenDown.set(this, new Map());
+    constructor(walletOrProvider, abstractionNames = ['TokenHolderRevenueFund'], firstAccrualOffset = 0) {
+        _ensemble.set(this, abstractionNames.map(n => ({contract: new TokenHolderRevenueFundContract(walletOrProvider, n)})));
+        _decomposedByCurrency.set(this, new Map());
+        _firstAccrualOffset.set(this, firstAccrualOffset > 0 ? firstAccrualOffset : 0);
     }
 
     /**
-     * Execute contract instance break-down for the given currency
+     * Returns the first accrual's offset index used in decomposition
+     * @returns {number} - First accrual's offset
+     */
+    get firstAccrualOffset() {
+        return _firstAccrualOffset.get(this);
+    }
+
+    /**
+     * Return status of whether contract instance decomposition has been executed
+     * for the given currency
+     * @param {Currency} currency - The currency
+     * @returns {boolean} True if decomposition has been executed, else false
+     */
+    isDecomposed(currency) {
+        const decomposedByCurrency = _decomposedByCurrency.get(this);
+        return decomposedByCurrency.get(currencyToKey(currency)) || false;
+    }
+
+    /**
+     * Execute contract instance decomposition for the given currency
      * @param {Currency} currency - The currency
      */
-    async breakDown(currency) {
-        const brokenDown = _brokenDown.get(this);
-
-        const currencyKey = currencyKey(currency);
-
-        if (brokenDown.get(currencyKey))
-            return;
-
+    async decompose(currency) {
         const ensemble = _ensemble.get(this);
+        let globalAccrualOffset = _firstAccrualOffset.get(this);
+        const currencyKey = currencyToKey(currency);
 
-        let globalAccrualOffset = 0;
         for (const configuration of ensemble) {
             const closedAccrualsCount = (await configuration.contract.closedAccrualsCount(
                 currency.ct.toString(), currency.id
             )).toNumber();
 
-            if (!configuration.breakDowns)
-                configuration.breakDowns = new Map();
-
-            const currencyBreakDown = {};
-            currencyBreakDown.startAccrual = globalAccrualOffset || 0;
-            currencyBreakDown.endAccrual = currencyBreakDown.startAccrual + closedAccrualsCount;
-            currencyBreakDown.startBlock =
+            const currencyDecomposition = {};
+            currencyDecomposition.startAccrual = globalAccrualOffset || 0;
+            currencyDecomposition.endAccrual = currencyDecomposition.startAccrual + closedAccrualsCount - 1;
+            currencyDecomposition.startBlock =
                 (await configuration.contract.closedAccrualsByCurrency(
-                    currency.ct.toString(), currency.id, configuration.startAccrual
+                    currency.ct.toString(), currency.id, currencyDecomposition.startAccrual
                 )).startBlock.toNumber();
-            currencyBreakDown.endBlock =
+            currencyDecomposition.endBlock =
                 (await configuration.contract.closedAccrualsByCurrency(
-                    currency.ct.toString(), currency.id, configuration.endAccrual
+                    currency.ct.toString(), currency.id, currencyDecomposition.endAccrual
                 )).endBlock.toNumber();
 
-            configuration.breakDowns.set(currencyKey, currencyBreakDown);
+            if (!configuration.decompositionsByCurrency)
+                configuration.decompositionsByCurrency = new Map();
 
-            globalAccrualOffset = currencyBreakDown.endAccrual + 1;
+            configuration.decompositionsByCurrency.set(currencyKey, currencyDecomposition);
+
+            globalAccrualOffset = currencyDecomposition.endAccrual + 1;
         }
 
-        brokenDown.set(currencyKey, true);
-    }
-
-    /**
-     * Return status of whether contract instance break-down has been executed for the given currency
-     * @param {Currency} currency - The currency
-     * @returns {boolean} True if break-down has been executed, else false
-     */
-    isBrokenDown(currency) {
-        const brokenDown = _brokenDown.get(this);
-        return brokenDown.get(currencyKey(currency));
+        _decomposedByCurrency.get(this).set(currencyKey, true);
     }
 
     /**
@@ -84,13 +89,15 @@ class TokenHolderRevenueFundContractsEnsemble {
      * @returns {boolean} True if fully claimed, else false
      */
     async fullyClaimed(wallet, currency, accrual) {
-        if (!this.isBrokenDown(currency))
-            await this.breakDown(currency);
+        if (!this.isDecomposed(currency))
+            await this.decompose(currency);
 
         const ensemble = _ensemble.get(this);
+        const currencyKey = currencyToKey(currency);
 
         for (const configuration of ensemble) {
-            if (configuration.startAccrual <= accrual && accrual <= configuration.endAccrual) {
+            const decomposition = configuration.decompositionsByCurrency.get(currencyKey);
+            if (decomposition.startAccrual <= accrual && accrual <= decomposition.endAccrual) {
                 return configuration.contract.fullyClaimed(
                     wallet.address, currency.ct.toString(), currency.id, accrual
                 );
@@ -113,7 +120,7 @@ class TokenHolderRevenueFundContractsEnsemble {
         ))))
             .reduce((a, c) => a.add(c), bigNumberify(0));
 
-        return count.toNumber();
+        return count;
     }
 
     /**
@@ -128,22 +135,25 @@ class TokenHolderRevenueFundContractsEnsemble {
         if (startAccrual > endAccrual)
             throw new Error(`Ordinality mismatch of startAccrual > endAccrual (${startAccrual} > ${endAccrual})`);
 
-        if (!this.isBrokenDown(currency))
-            await this.breakDown(currency);
+        if (!this.isDecomposed(currency))
+            await this.decompose(currency);
 
         const ensemble = _ensemble.get(this);
+        const currencyKey = currencyToKey(currency);
 
         let claimableFees = bigNumberify(0);
 
         for (const configuration of ensemble) {
-            if (endAccrual < configuration.startAccrual || startAccrual > configuration.endAccrual)
+            const decomposition = configuration.decompositionsByCurrency.get(currencyKey);
+
+            if (endAccrual < decomposition.startAccrual || startAccrual > decomposition.endAccrual)
                 continue;
 
             claimableFees = claimableFees.add(
                 await configuration.contract.claimableAmountByAccruals(
                     wallet.address, currency.ct.toString(), currency.id,
-                    Math.max(startAccrual, configuration.startAccrual),
-                    Math.min(endAccrual, configuration.endAccrual)
+                    Math.max(startAccrual, decomposition.startAccrual),
+                    Math.min(endAccrual, decomposition.endAccrual)
                 )
             );
         }
@@ -164,24 +174,27 @@ class TokenHolderRevenueFundContractsEnsemble {
         if (startAccrual > endAccrual)
             throw new Error(`Ordinality mismatch of startAccrual > endAccrual (${startAccrual} > ${endAccrual})`);
 
-        if (!this.isBrokenDown(currency))
-            await this.breakDown(currency);
+        if (!this.isDecomposed(currency))
+            await this.decompose(currency);
 
         const ensemble = _ensemble.get(this);
+        const currencyKey = currencyToKey(currency);
 
         try {
             const txs = [];
 
             for (const configuration of ensemble) {
-                if (endAccrual < configuration.startAccrual || startAccrual > configuration.endAccrual)
+                const decomposition = configuration.decompositionsByCurrency.get(currencyKey);
+
+                if (endAccrual < decomposition.startAccrual || startAccrual > decomposition.endAccrual)
                     continue;
 
                 const contract = configuration.contract.connect(wallet);
                 txs.push(
-                    contract.claimAndStageByAccruals(
+                    await contract.claimAndStageByAccruals(
                         currency.ct.toString(), currency.id,
-                        Math.max(startAccrual, configuration.startAccrual),
-                        Math.min(endAccrual, configuration.endAccrual),
+                        Math.max(startAccrual, decomposition.startAccrual),
+                        Math.min(endAccrual, decomposition.endAccrual),
                         options
                     )
                 );
@@ -206,22 +219,25 @@ class TokenHolderRevenueFundContractsEnsemble {
         if (startBlock > endBlock)
             throw new Error(`Ordinality mismatch of startBlock > endBlock (${startBlock} > ${endBlock})`);
 
-        if (!this.isBrokenDown(currency))
-            await this.breakDown(currency);
+        if (!this.isDecomposed(currency))
+            await this.decompose(currency);
 
         const ensemble = _ensemble.get(this);
+        const currencyKey = currencyToKey(currency);
 
         let claimableFees = bigNumberify(0);
 
         for (const configuration of ensemble) {
-            if (endBlock < configuration.startBlock || startBlock > configuration.endBlock)
+            const decomposition = configuration.decompositionsByCurrency.get(currencyKey);
+
+            if (endBlock < decomposition.startBlock || startBlock > decomposition.endBlock)
                 continue;
 
             claimableFees = claimableFees.add(
                 await configuration.contract.claimableAmountByBlockNumbers(
                     wallet.address, currency.ct.toString(), currency.id,
-                    Math.max(startBlock, configuration.startBlock),
-                    Math.min(endBlock, configuration.endBlock)
+                    Math.max(startBlock, decomposition.startBlock),
+                    Math.min(endBlock, decomposition.endBlock)
                 )
             );
         }
@@ -242,24 +258,27 @@ class TokenHolderRevenueFundContractsEnsemble {
         if (startBlock > endBlock)
             throw new Error(`Ordinality mismatch of startBlock > endBlock (${startBlock} > ${endBlock})`);
 
-        if (!this.isBrokenDown(currency))
-            await this.breakDown(currency);
+        if (!this.isDecomposed(currency))
+            await this.decompose(currency);
 
         const ensemble = _ensemble.get(this);
+        const currencyKey = currencyToKey(currency);
 
         try {
             const txs = [];
 
             for (const configuration of ensemble) {
-                if (endBlock < configuration.startBlock || startBlock > configuration.endBlock)
+                const decomposition = configuration.decompositionsByCurrency.get(currencyKey);
+
+                if (endBlock < decomposition.startBlock || startBlock > decomposition.endBlock)
                     continue;
 
                 const contract = configuration.contract.connect(wallet);
                 txs.push(
-                    contract.claimAndStageByBlockNumbers(
+                    await contract.claimAndStageByBlockNumbers(
                         currency.ct.toString(), currency.id,
-                        Math.max(startBlock, configuration.startBlock),
-                        Math.min(endBlock, configuration.endBlock),
+                        Math.max(startBlock, decomposition.startBlock),
+                        Math.min(endBlock, decomposition.endBlock),
                         options
                     )
                 );
@@ -268,7 +287,7 @@ class TokenHolderRevenueFundContractsEnsemble {
             return txs;
         }
         catch (error) {
-            throw new NestedError(error, 'Unable to claim and stage by blocks.');
+            throw new NestedError(error, 'Unable to claim and stage by blocks numbers.');
         }
     }
 
@@ -296,8 +315,12 @@ class TokenHolderRevenueFundContractsEnsemble {
      * @returns {Promise} A promise that resolves into an array of transaction hashes.
      */
     async withdraw(wallet, monetaryAmount, standard = 'ERC20', options = undefined) {
-        if (!this.isBrokenDown(monetaryAmount.currency))
-            await this.breakDown(monetaryAmount.currency);
+        if (!this.isDecomposed(monetaryAmount.currency))
+            await this.decompose(monetaryAmount.currency);
+
+        const stagedBalance = await this.stagedBalance(wallet, monetaryAmount.currency);
+        if (stagedBalance.lt(monetaryAmount.amount))
+            throw new Error(`Unable to withdraw more than ${stagedBalance.toString()}`);
 
         const ensemble = _ensemble.get(this);
 

--- a/lib/claim/token-holder-revenue-fund-contracts-ensemble.js
+++ b/lib/claim/token-holder-revenue-fund-contracts-ensemble.js
@@ -5,7 +5,7 @@ const TokenHolderRevenueFundContract = require('./token-holder-revenue-fund-cont
 const NestedError = require('../nested-error');
 
 const _ensemble = new WeakMap();
-const _decomposedByCurrency = new WeakMap();
+const _spannedByCurrency = new WeakMap();
 const _firstAccrualOffset = new WeakMap();
 
 const currencyToKey = (currency) => `${currency.ct.toString()}-${currency.id}`;
@@ -22,12 +22,12 @@ const minBigNumber = function (n1, n2) {
 class TokenHolderRevenueFundContractsEnsemble {
     constructor(walletOrProvider, abstractionNames = ['TokenHolderRevenueFund'], firstAccrualOffset = 0) {
         _ensemble.set(this, abstractionNames.map(n => ({contract: new TokenHolderRevenueFundContract(walletOrProvider, n)})));
-        _decomposedByCurrency.set(this, new Map());
+        _spannedByCurrency.set(this, new Map());
         _firstAccrualOffset.set(this, firstAccrualOffset > 0 ? firstAccrualOffset : 0);
     }
 
     /**
-     * Returns the first accrual's offset index used in decomposition
+     * Returns the first accrual's offset index used in the (temporal) span
      * @returns {number} - First accrual's offset
      */
     get firstAccrualOffset() {
@@ -35,21 +35,23 @@ class TokenHolderRevenueFundContractsEnsemble {
     }
 
     /**
-     * Return status of whether contract instance decomposition has been executed
+     * Return status of whether contract instance span has been executed
      * for the given currency
      * @param {Currency} currency - The currency
-     * @returns {boolean} True if decomposition has been executed, else false
+     * @returns {boolean} True if span has been executed, else false
      */
-    isDecomposed(currency) {
-        const decomposedByCurrency = _decomposedByCurrency.get(this);
-        return decomposedByCurrency.get(currencyToKey(currency)) || false;
+    isSpanned(currency) {
+        const spannedByCurrency = _spannedByCurrency.get(this);
+        return spannedByCurrency.get(currencyToKey(currency)) || false;
     }
 
     /**
-     * Execute contract instance decomposition for the given currency
+     * Span (temporally) in accruals and block numbers for the given currency. I.e. infer the
+     * accrual and block number boundaries of the given currency for each contract
+     * instance in the ensemble
      * @param {Currency} currency - The currency
      */
-    async decompose(currency) {
+    async span(currency) {
         const ensemble = _ensemble.get(this);
         let globalAccrualOffset = _firstAccrualOffset.get(this);
         const currencyKey = currencyToKey(currency);
@@ -59,27 +61,27 @@ class TokenHolderRevenueFundContractsEnsemble {
                 currency.ct.toString(), currency.id
             )).toNumber();
 
-            const currencyDecomposition = {};
-            currencyDecomposition.startAccrual = globalAccrualOffset || 0;
-            currencyDecomposition.endAccrual = currencyDecomposition.startAccrual + closedAccrualsCount - 1;
-            currencyDecomposition.startBlock =
+            const span = {};
+            span.startAccrual = globalAccrualOffset || 0;
+            span.endAccrual = span.startAccrual + closedAccrualsCount - 1;
+            span.startBlock =
                 (await configuration.contract.closedAccrualsByCurrency(
-                    currency.ct.toString(), currency.id, currencyDecomposition.startAccrual
+                    currency.ct.toString(), currency.id, span.startAccrual
                 )).startBlock.toNumber();
-            currencyDecomposition.endBlock =
+            span.endBlock =
                 (await configuration.contract.closedAccrualsByCurrency(
-                    currency.ct.toString(), currency.id, currencyDecomposition.endAccrual
+                    currency.ct.toString(), currency.id, span.endAccrual
                 )).endBlock.toNumber();
 
-            if (!configuration.decompositionsByCurrency)
-                configuration.decompositionsByCurrency = new Map();
+            if (!configuration.spansByCurrency)
+                configuration.spansByCurrency = new Map();
 
-            configuration.decompositionsByCurrency.set(currencyKey, currencyDecomposition);
+            configuration.spansByCurrency.set(currencyKey, span);
 
-            globalAccrualOffset = currencyDecomposition.endAccrual + 1;
+            globalAccrualOffset = span.endAccrual + 1;
         }
 
-        _decomposedByCurrency.get(this).set(currencyKey, true);
+        _spannedByCurrency.get(this).set(currencyKey, true);
     }
 
     /**
@@ -89,15 +91,15 @@ class TokenHolderRevenueFundContractsEnsemble {
      * @returns {boolean} True if fully claimed, else false
      */
     async fullyClaimed(wallet, currency, accrual) {
-        if (!this.isDecomposed(currency))
-            await this.decompose(currency);
+        if (!this.isSpanned(currency))
+            await this.span(currency);
 
         const ensemble = _ensemble.get(this);
         const currencyKey = currencyToKey(currency);
 
         for (const configuration of ensemble) {
-            const decomposition = configuration.decompositionsByCurrency.get(currencyKey);
-            if (decomposition.startAccrual <= accrual && accrual <= decomposition.endAccrual) {
+            const span = configuration.spansByCurrency.get(currencyKey);
+            if (span.startAccrual <= accrual && accrual <= span.endAccrual) {
                 return configuration.contract.fullyClaimed(
                     wallet.address, currency.ct.toString(), currency.id, accrual
                 );
@@ -135,8 +137,8 @@ class TokenHolderRevenueFundContractsEnsemble {
         if (startAccrual > endAccrual)
             throw new Error(`Ordinality mismatch of startAccrual > endAccrual (${startAccrual} > ${endAccrual})`);
 
-        if (!this.isDecomposed(currency))
-            await this.decompose(currency);
+        if (!this.isSpanned(currency))
+            await this.span(currency);
 
         const ensemble = _ensemble.get(this);
         const currencyKey = currencyToKey(currency);
@@ -144,16 +146,16 @@ class TokenHolderRevenueFundContractsEnsemble {
         let claimableFees = bigNumberify(0);
 
         for (const configuration of ensemble) {
-            const decomposition = configuration.decompositionsByCurrency.get(currencyKey);
+            const span = configuration.spansByCurrency.get(currencyKey);
 
-            if (endAccrual < decomposition.startAccrual || startAccrual > decomposition.endAccrual)
+            if (endAccrual < span.startAccrual || startAccrual > span.endAccrual)
                 continue;
 
             claimableFees = claimableFees.add(
                 await configuration.contract.claimableAmountByAccruals(
                     wallet.address, currency.ct.toString(), currency.id,
-                    Math.max(startAccrual, decomposition.startAccrual),
-                    Math.min(endAccrual, decomposition.endAccrual)
+                    Math.max(startAccrual, span.startAccrual),
+                    Math.min(endAccrual, span.endAccrual)
                 )
             );
         }
@@ -174,8 +176,8 @@ class TokenHolderRevenueFundContractsEnsemble {
         if (startAccrual > endAccrual)
             throw new Error(`Ordinality mismatch of startAccrual > endAccrual (${startAccrual} > ${endAccrual})`);
 
-        if (!this.isDecomposed(currency))
-            await this.decompose(currency);
+        if (!this.isSpanned(currency))
+            await this.span(currency);
 
         const ensemble = _ensemble.get(this);
         const currencyKey = currencyToKey(currency);
@@ -184,17 +186,17 @@ class TokenHolderRevenueFundContractsEnsemble {
             const txs = [];
 
             for (const configuration of ensemble) {
-                const decomposition = configuration.decompositionsByCurrency.get(currencyKey);
+                const span = configuration.spansByCurrency.get(currencyKey);
 
-                if (endAccrual < decomposition.startAccrual || startAccrual > decomposition.endAccrual)
+                if (endAccrual < span.startAccrual || startAccrual > span.endAccrual)
                     continue;
 
                 const contract = configuration.contract.connect(wallet);
                 txs.push(
                     await contract.claimAndStageByAccruals(
                         currency.ct.toString(), currency.id,
-                        Math.max(startAccrual, decomposition.startAccrual),
-                        Math.min(endAccrual, decomposition.endAccrual),
+                        Math.max(startAccrual, span.startAccrual),
+                        Math.min(endAccrual, span.endAccrual),
                         options
                     )
                 );
@@ -219,8 +221,8 @@ class TokenHolderRevenueFundContractsEnsemble {
         if (startBlock > endBlock)
             throw new Error(`Ordinality mismatch of startBlock > endBlock (${startBlock} > ${endBlock})`);
 
-        if (!this.isDecomposed(currency))
-            await this.decompose(currency);
+        if (!this.isSpanned(currency))
+            await this.span(currency);
 
         const ensemble = _ensemble.get(this);
         const currencyKey = currencyToKey(currency);
@@ -228,16 +230,16 @@ class TokenHolderRevenueFundContractsEnsemble {
         let claimableFees = bigNumberify(0);
 
         for (const configuration of ensemble) {
-            const decomposition = configuration.decompositionsByCurrency.get(currencyKey);
+            const span = configuration.spansByCurrency.get(currencyKey);
 
-            if (endBlock < decomposition.startBlock || startBlock > decomposition.endBlock)
+            if (endBlock < span.startBlock || startBlock > span.endBlock)
                 continue;
 
             claimableFees = claimableFees.add(
                 await configuration.contract.claimableAmountByBlockNumbers(
                     wallet.address, currency.ct.toString(), currency.id,
-                    Math.max(startBlock, decomposition.startBlock),
-                    Math.min(endBlock, decomposition.endBlock)
+                    Math.max(startBlock, span.startBlock),
+                    Math.min(endBlock, span.endBlock)
                 )
             );
         }
@@ -258,8 +260,8 @@ class TokenHolderRevenueFundContractsEnsemble {
         if (startBlock > endBlock)
             throw new Error(`Ordinality mismatch of startBlock > endBlock (${startBlock} > ${endBlock})`);
 
-        if (!this.isDecomposed(currency))
-            await this.decompose(currency);
+        if (!this.isSpanned(currency))
+            await this.span(currency);
 
         const ensemble = _ensemble.get(this);
         const currencyKey = currencyToKey(currency);
@@ -268,17 +270,17 @@ class TokenHolderRevenueFundContractsEnsemble {
             const txs = [];
 
             for (const configuration of ensemble) {
-                const decomposition = configuration.decompositionsByCurrency.get(currencyKey);
+                const span = configuration.spansByCurrency.get(currencyKey);
 
-                if (endBlock < decomposition.startBlock || startBlock > decomposition.endBlock)
+                if (endBlock < span.startBlock || startBlock > span.endBlock)
                     continue;
 
                 const contract = configuration.contract.connect(wallet);
                 txs.push(
                     await contract.claimAndStageByBlockNumbers(
                         currency.ct.toString(), currency.id,
-                        Math.max(startBlock, decomposition.startBlock),
-                        Math.min(endBlock, decomposition.endBlock),
+                        Math.max(startBlock, span.startBlock),
+                        Math.min(endBlock, span.endBlock),
                         options
                     )
                 );
@@ -315,8 +317,8 @@ class TokenHolderRevenueFundContractsEnsemble {
      * @returns {Promise} A promise that resolves into an array of transaction hashes.
      */
     async withdraw(wallet, monetaryAmount, standard = 'ERC20', options = undefined) {
-        if (!this.isDecomposed(monetaryAmount.currency))
-            await this.decompose(monetaryAmount.currency);
+        if (!this.isSpanned(monetaryAmount.currency))
+            await this.span(monetaryAmount.currency);
 
         const stagedBalance = await this.stagedBalance(wallet, monetaryAmount.currency);
         if (stagedBalance.lt(monetaryAmount.amount))

--- a/lib/claim/token-holder-revenue-fund-contracts-ensemble.spec.js
+++ b/lib/claim/token-holder-revenue-fund-contracts-ensemble.spec.js
@@ -136,78 +136,6 @@ describe('TokenHolderRevenueFundContractsEnsemble', () => {
                 expect(ensemble.firstAccrualOffset).to.be.eq(10);
             });
         });
-
-        describe('when constructed with negative first accrual offset parameter', () => {
-            beforeEach(() => {
-                ensemble = new TokenHolderRevenueFundContractsEnsemble(fakeProvider, ['abstraction1', 'abstraction2'], -10);
-            });
-
-            it('should return 0', () => {
-                expect(ensemble.firstAccrualOffset).to.be.eq(0);
-            });
-        });
-    });
-
-    describe('isSpanned()', () => {
-        let ensemble;
-
-        beforeEach(() => {
-            ensemble = new TokenHolderRevenueFundContractsEnsemble(fakeProvider, ['abstraction1', 'abstraction2']);
-        });
-
-        describe('when called before span', () => {
-            it('should return false', () => {
-                expect(ensemble.isSpanned(currency)).to.be.false;
-            });
-        });
-    });
-
-    describe('span()', () => {
-        let ensemble;
-
-        describe('if first accrual offset is 0', () => {
-            beforeEach(() => {
-                stubbedTokenHolderRevenueFundContract.closedAccrualsByCurrency
-                    .withArgs(currency.ct.toString(), currency.id, 0)
-                    .returns(stubbedAccruals[0])
-                    .withArgs(currency.ct.toString(), currency.id, 9)
-                    .returns(stubbedAccruals[1])
-                    .withArgs(currency.ct.toString(), currency.id, 10)
-                    .returns(stubbedAccruals[2])
-                    .withArgs(currency.ct.toString(), currency.id, 29)
-                    .returns(stubbedAccruals[3]);
-
-                ensemble = new TokenHolderRevenueFundContractsEnsemble(fakeProvider, ['abstraction1', 'abstraction2']);
-            });
-
-            it('should successfully span', async () => {
-                await ensemble.span(currency);
-
-                expect(ensemble.isSpanned(currency)).to.be.true;
-            });
-        });
-
-        describe('if first accrual offset is non-zero', () => {
-            beforeEach(() => {
-                stubbedTokenHolderRevenueFundContract.closedAccrualsByCurrency
-                    .withArgs(currency.ct.toString(), currency.id, 10)
-                    .returns(stubbedAccruals[0])
-                    .withArgs(currency.ct.toString(), currency.id, 19)
-                    .returns(stubbedAccruals[1])
-                    .withArgs(currency.ct.toString(), currency.id, 20)
-                    .returns(stubbedAccruals[2])
-                    .withArgs(currency.ct.toString(), currency.id, 39)
-                    .returns(stubbedAccruals[3]);
-
-                ensemble = new TokenHolderRevenueFundContractsEnsemble(fakeProvider, ['abstraction1', 'abstraction2'], 10);
-            });
-
-            it('should successfully span', async () => {
-                await ensemble.span(currency);
-
-                expect(ensemble.isSpanned(currency)).to.be.true;
-            });
-        });
     });
 
     describe('closedAccrualsCount', () => {
@@ -247,8 +175,6 @@ describe('TokenHolderRevenueFundContractsEnsemble', () => {
 
             it('should return false', async () => {
                 expect(await ensemble.fullyClaimed(wallet, currency, 15)).to.be.false;
-
-                expect(ensemble.isSpanned(currency)).to.be.true;
             });
         });
 
@@ -259,8 +185,6 @@ describe('TokenHolderRevenueFundContractsEnsemble', () => {
 
             it('should return true', async () => {
                 expect(await ensemble.fullyClaimed(wallet, currency, 15)).to.be.true;
-
-                expect(ensemble.isSpanned(currency)).to.be.true;
             });
         });
 
@@ -272,8 +196,6 @@ describe('TokenHolderRevenueFundContractsEnsemble', () => {
 
             it('should return false', async () => {
                 expect(await ensemble.fullyClaimed(wallet, currency, 50)).to.be.false;
-
-                expect(ensemble.isSpanned(currency)).to.be.true;
             });
         });
     });
@@ -297,21 +219,21 @@ describe('TokenHolderRevenueFundContractsEnsemble', () => {
             );
         });
 
-        describe('if start accrual is greater than end accrual', () => {
+        describe('if first accrual is greater than last accrual', () => {
             it('should throw', async () => {
                 expect(ensemble.claimableAmountByAccruals(wallet, currency, 15, 5))
                     .to.be.rejected;
             });
         });
 
-        describe('if start accrual is greater than end accrual of last span', () => {
+        describe('if first accrual is greater than last accrual of last span', () => {
             it('should return 0', async () => {
                 expect((await ensemble.claimableAmountByAccruals(wallet, currency, 50, 60)).toNumber())
                     .to.be.eq(0);
             });
         });
 
-        describe('if end accrual is less than start accrual of first span', () => {
+        describe('if last accrual is less than first accrual of first span', () => {
             it('should return 0', async () => {
                 expect((await ensemble.claimableAmountByAccruals(wallet, currency, 5, 8)).toNumber())
                     .to.be.eq(0);
@@ -383,20 +305,20 @@ describe('TokenHolderRevenueFundContractsEnsemble', () => {
             );
         });
 
-        describe('if start accrual is greater than end accrual', () => {
+        describe('if first accrual is greater than last accrual', () => {
             it('should throw', async () => {
                 expect(ensemble.claimAndStageByAccruals(wallet, currency, 15, 5)).to.be.rejected;
             });
         });
 
-        describe('if start accrual is greater than end accrual of last span', () => {
+        describe('if first accrual is greater than last accrual of last span', () => {
             it('should return an empty array', async () => {
                 expect(await ensemble.claimAndStageByAccruals(wallet, currency, 50, 60))
                     .to.be.an('array').that.is.empty;
             });
         });
 
-        describe('if end accrual is less than start accrual of first span', () => {
+        describe('if last accrual is less than first accrual of first span', () => {
             it('should return an empty array', async () => {
                 expect(await ensemble.claimAndStageByAccruals(wallet, currency, 5, 8))
                     .to.be.an('array').that.is.empty;
@@ -502,21 +424,21 @@ describe('TokenHolderRevenueFundContractsEnsemble', () => {
             );
         });
 
-        describe('if start block is greater than end block', () => {
+        describe('if first block is greater than last block', () => {
             it('should throw', async () => {
                 expect(ensemble.claimableAmountByBlockNumbers(wallet, currency, 1500000, 500000))
                     .to.be.rejected;
             });
         });
 
-        describe('if start block is greater than end block of last span', () => {
+        describe('if first block is greater than last block of last span', () => {
             it('should return 0', async () => {
                 expect((await ensemble.claimableAmountByBlockNumbers(wallet, currency, 10000000, 11000000)).toNumber())
                     .to.be.eq(0);
             });
         });
 
-        describe('if end block is less than start block of first span', () => {
+        describe('if last block is less than first block of first span', () => {
             it('should return 0', async () => {
                 expect((await ensemble.claimableAmountByBlockNumbers(wallet, currency, 500000, 800000)).toNumber())
                     .to.be.eq(0);
@@ -588,21 +510,21 @@ describe('TokenHolderRevenueFundContractsEnsemble', () => {
             );
         });
 
-        describe('if start block is greater than end block', () => {
+        describe('if first block is greater than last block', () => {
             it('should throw', async () => {
                 expect(ensemble.claimAndStageByBlockNumbers(wallet, currency, 1500000, 500000))
                     .to.be.rejected;
             });
         });
 
-        describe('if start block is greater than end block of last span', () => {
+        describe('if first block is greater than last block of last span', () => {
             it('should return an empty array', async () => {
                 expect(await ensemble.claimAndStageByBlockNumbers(wallet, currency, 10000000, 11000000))
                     .to.be.an('array').that.is.empty;
             });
         });
 
-        describe('if end block is less than start block of first span', () => {
+        describe('if last block is less than first block of first span', () => {
             it('should return an empty array', async () => {
                 expect(await ensemble.claimAndStageByBlockNumbers(wallet, currency, 500000, 800000))
                     .to.be.an('array').that.is.empty;

--- a/lib/claim/token-holder-revenue-fund-contracts-ensemble.spec.js
+++ b/lib/claim/token-holder-revenue-fund-contracts-ensemble.spec.js
@@ -148,21 +148,21 @@ describe('TokenHolderRevenueFundContractsEnsemble', () => {
         });
     });
 
-    describe('isDecomposed()', () => {
+    describe('isSpanned()', () => {
         let ensemble;
 
         beforeEach(() => {
             ensemble = new TokenHolderRevenueFundContractsEnsemble(fakeProvider, ['abstraction1', 'abstraction2']);
         });
 
-        describe('when called before decomposition', () => {
+        describe('when called before span', () => {
             it('should return false', () => {
-                expect(ensemble.isDecomposed(currency)).to.be.false;
+                expect(ensemble.isSpanned(currency)).to.be.false;
             });
         });
     });
 
-    describe('decompose()', () => {
+    describe('span()', () => {
         let ensemble;
 
         describe('if first accrual offset is 0', () => {
@@ -180,10 +180,10 @@ describe('TokenHolderRevenueFundContractsEnsemble', () => {
                 ensemble = new TokenHolderRevenueFundContractsEnsemble(fakeProvider, ['abstraction1', 'abstraction2']);
             });
 
-            it('should successfully decompose', async () => {
-                await ensemble.decompose(currency);
+            it('should successfully span', async () => {
+                await ensemble.span(currency);
 
-                expect(ensemble.isDecomposed(currency)).to.be.true;
+                expect(ensemble.isSpanned(currency)).to.be.true;
             });
         });
 
@@ -202,10 +202,10 @@ describe('TokenHolderRevenueFundContractsEnsemble', () => {
                 ensemble = new TokenHolderRevenueFundContractsEnsemble(fakeProvider, ['abstraction1', 'abstraction2'], 10);
             });
 
-            it('should successfully decompose', async () => {
-                await ensemble.decompose(currency);
+            it('should successfully span', async () => {
+                await ensemble.span(currency);
 
-                expect(ensemble.isDecomposed(currency)).to.be.true;
+                expect(ensemble.isSpanned(currency)).to.be.true;
             });
         });
     });
@@ -217,7 +217,7 @@ describe('TokenHolderRevenueFundContractsEnsemble', () => {
             ensemble = new TokenHolderRevenueFundContractsEnsemble(fakeProvider, ['abstraction1', 'abstraction2']);
         });
 
-        it('should return the value obtained from the decompositions combined', async () => {
+        it('should return the value obtained from the spans combined', async () => {
             expect((await ensemble.closedAccrualsCount(currency)).toNumber())
                 .to.be.eq(30);
         });
@@ -248,7 +248,7 @@ describe('TokenHolderRevenueFundContractsEnsemble', () => {
             it('should return false', async () => {
                 expect(await ensemble.fullyClaimed(wallet, currency, 15)).to.be.false;
 
-                expect(ensemble.isDecomposed(currency)).to.be.true;
+                expect(ensemble.isSpanned(currency)).to.be.true;
             });
         });
 
@@ -260,7 +260,7 @@ describe('TokenHolderRevenueFundContractsEnsemble', () => {
             it('should return true', async () => {
                 expect(await ensemble.fullyClaimed(wallet, currency, 15)).to.be.true;
 
-                expect(ensemble.isDecomposed(currency)).to.be.true;
+                expect(ensemble.isSpanned(currency)).to.be.true;
             });
         });
 
@@ -273,7 +273,7 @@ describe('TokenHolderRevenueFundContractsEnsemble', () => {
             it('should return false', async () => {
                 expect(await ensemble.fullyClaimed(wallet, currency, 50)).to.be.false;
 
-                expect(ensemble.isDecomposed(currency)).to.be.true;
+                expect(ensemble.isSpanned(currency)).to.be.true;
             });
         });
     });
@@ -304,34 +304,34 @@ describe('TokenHolderRevenueFundContractsEnsemble', () => {
             });
         });
 
-        describe('if start accrual is greater than end accrual of last decomposition', () => {
+        describe('if start accrual is greater than end accrual of last span', () => {
             it('should return 0', async () => {
                 expect((await ensemble.claimableAmountByAccruals(wallet, currency, 50, 60)).toNumber())
                     .to.be.eq(0);
             });
         });
 
-        describe('if end accrual is less than start accrual of first decomposition', () => {
+        describe('if end accrual is less than start accrual of first span', () => {
             it('should return 0', async () => {
                 expect((await ensemble.claimableAmountByAccruals(wallet, currency, 5, 8)).toNumber())
                     .to.be.eq(0);
             });
         });
 
-        describe('if accrual arguments entirely fall within the span of one decomposition', () => {
+        describe('if accrual arguments entirely fall within the span of one span', () => {
             beforeEach(() => {
                 stubbedTokenHolderRevenueFundContract.claimableAmountByAccruals
                     .withArgs(wallet.address, currency.ct.toString(), currency.id, 12, 17)
                     .returns(utils.bigNumberify(10));
             });
 
-            it('should return the value obtained from the decomposition', async () => {
+            it('should return the value obtained from the span', async () => {
                 expect((await ensemble.claimableAmountByAccruals(wallet, currency, 12, 17)).toNumber())
                     .to.be.eq(10);
             });
         });
 
-        describe('if accrual arguments fall within the span of two decompositions', () => {
+        describe('if accrual arguments fall within the span of two spans', () => {
             beforeEach(() => {
                 stubbedTokenHolderRevenueFundContract.claimableAmountByAccruals
                     .withArgs(wallet.address, currency.ct.toString(), currency.id, 12, 19)
@@ -341,13 +341,13 @@ describe('TokenHolderRevenueFundContractsEnsemble', () => {
                     .returns(utils.bigNumberify(20));
             });
 
-            it('should return the value obtained from the decompositions combined', async () => {
+            it('should return the value obtained from the spans combined', async () => {
                 expect((await ensemble.claimableAmountByAccruals(wallet, currency, 12, 27)).toNumber())
                     .to.be.eq(30);
             });
         });
 
-        describe('if accrual arguments wrap the span of two decompositions', () => {
+        describe('if accrual arguments wrap the span of two spans', () => {
             beforeEach(() => {
                 stubbedTokenHolderRevenueFundContract.claimableAmountByAccruals
                     .withArgs(wallet.address, currency.ct.toString(), currency.id, 10, 19)
@@ -357,7 +357,7 @@ describe('TokenHolderRevenueFundContractsEnsemble', () => {
                     .returns(utils.bigNumberify(20));
             });
 
-            it('should return the value obtained from the decompositions combined', async () => {
+            it('should return the value obtained from the spans combined', async () => {
                 expect((await ensemble.claimableAmountByAccruals(wallet, currency, 5, 45)).toNumber())
                     .to.be.eq(30);
             });
@@ -389,21 +389,21 @@ describe('TokenHolderRevenueFundContractsEnsemble', () => {
             });
         });
 
-        describe('if start accrual is greater than end accrual of last decomposition', () => {
+        describe('if start accrual is greater than end accrual of last span', () => {
             it('should return an empty array', async () => {
                 expect(await ensemble.claimAndStageByAccruals(wallet, currency, 50, 60))
                     .to.be.an('array').that.is.empty;
             });
         });
 
-        describe('if end accrual is less than start accrual of first decomposition', () => {
+        describe('if end accrual is less than start accrual of first span', () => {
             it('should return an empty array', async () => {
                 expect(await ensemble.claimAndStageByAccruals(wallet, currency, 5, 8))
                     .to.be.an('array').that.is.empty;
             });
         });
 
-        describe('if accrual arguments entirely fall within the span of one decomposition', () => {
+        describe('if accrual arguments entirely fall within the span of one span', () => {
             beforeEach(() => {
                 stubbedTokenHolderRevenueFundContract.claimAndStageByAccruals
                     .withArgs(currency.ct.toString(), currency.id, 12, 17)
@@ -416,7 +416,7 @@ describe('TokenHolderRevenueFundContractsEnsemble', () => {
             });
         });
 
-        describe('if accrual arguments fall within the span of two decompositions', () => {
+        describe('if accrual arguments fall within the span of two spans', () => {
             beforeEach(() => {
                 stubbedTokenHolderRevenueFundContract.claimAndStageByAccruals
                     .withArgs(currency.ct.toString(), currency.id, 12, 19)
@@ -432,7 +432,7 @@ describe('TokenHolderRevenueFundContractsEnsemble', () => {
             });
         });
 
-        describe('if accrual arguments wrap the span of two decompositions', () => {
+        describe('if accrual arguments wrap the span of two spans', () => {
             beforeEach(() => {
                 stubbedTokenHolderRevenueFundContract.claimAndStageByAccruals
                     .withArgs(currency.ct.toString(), currency.id, 10, 19)
@@ -509,34 +509,34 @@ describe('TokenHolderRevenueFundContractsEnsemble', () => {
             });
         });
 
-        describe('if start block is greater than end block of last decomposition', () => {
+        describe('if start block is greater than end block of last span', () => {
             it('should return 0', async () => {
                 expect((await ensemble.claimableAmountByBlockNumbers(wallet, currency, 10000000, 11000000)).toNumber())
                     .to.be.eq(0);
             });
         });
 
-        describe('if end block is less than start block of first decomposition', () => {
+        describe('if end block is less than start block of first span', () => {
             it('should return 0', async () => {
                 expect((await ensemble.claimableAmountByBlockNumbers(wallet, currency, 500000, 800000)).toNumber())
                     .to.be.eq(0);
             });
         });
 
-        describe('if block arguments entirely fall within the span of one decomposition', () => {
+        describe('if block arguments entirely fall within the span of one span', () => {
             beforeEach(() => {
                 stubbedTokenHolderRevenueFundContract.claimableAmountByBlockNumbers
                     .withArgs(wallet.address, currency.ct.toString(), currency.id, 1200000, 1700000)
                     .returns(utils.bigNumberify(10));
             });
 
-            it('should return the value obtained from the decomposition', async () => {
+            it('should return the value obtained from the span', async () => {
                 expect((await ensemble.claimableAmountByBlockNumbers(wallet, currency, 1200000, 1700000)).toNumber())
                     .to.be.eq(10);
             });
         });
 
-        describe('if block arguments fall within the span of two decompositions', () => {
+        describe('if block arguments fall within the span of two spans', () => {
             beforeEach(() => {
                 stubbedTokenHolderRevenueFundContract.claimableAmountByBlockNumbers
                     .withArgs(wallet.address, currency.ct.toString(), currency.id, 1200000, 2000000)
@@ -546,13 +546,13 @@ describe('TokenHolderRevenueFundContractsEnsemble', () => {
                     .returns(utils.bigNumberify(20));
             });
 
-            it('should return the value obtained from the decompositions combined', async () => {
+            it('should return the value obtained from the spans combined', async () => {
                 expect((await ensemble.claimableAmountByBlockNumbers(wallet, currency, 1200000, 2700000)).toNumber())
                     .to.be.eq(30);
             });
         });
 
-        describe('if block arguments wrap the span of two decompositions', () => {
+        describe('if block arguments wrap the span of two spans', () => {
             beforeEach(() => {
                 stubbedTokenHolderRevenueFundContract.claimableAmountByBlockNumbers
                     .withArgs(wallet.address, currency.ct.toString(), currency.id, 900001, 2000000)
@@ -562,7 +562,7 @@ describe('TokenHolderRevenueFundContractsEnsemble', () => {
                     .returns(utils.bigNumberify(20));
             });
 
-            it('should return the value obtained from the decompositions combined', async () => {
+            it('should return the value obtained from the spans combined', async () => {
                 expect((await ensemble.claimableAmountByBlockNumbers(wallet, currency, 500000, 7000000)).toNumber())
                     .to.be.eq(30);
             });
@@ -595,21 +595,21 @@ describe('TokenHolderRevenueFundContractsEnsemble', () => {
             });
         });
 
-        describe('if start block is greater than end block of last decomposition', () => {
+        describe('if start block is greater than end block of last span', () => {
             it('should return an empty array', async () => {
                 expect(await ensemble.claimAndStageByBlockNumbers(wallet, currency, 10000000, 11000000))
                     .to.be.an('array').that.is.empty;
             });
         });
 
-        describe('if end block is less than start block of first decomposition', () => {
+        describe('if end block is less than start block of first span', () => {
             it('should return an empty array', async () => {
                 expect(await ensemble.claimAndStageByBlockNumbers(wallet, currency, 500000, 800000))
                     .to.be.an('array').that.is.empty;
             });
         });
 
-        describe('if block arguments entirely fall within the span of one decomposition', () => {
+        describe('if block arguments entirely fall within the span of one span', () => {
             beforeEach(() => {
                 stubbedTokenHolderRevenueFundContract.claimAndStageByBlockNumbers
                     .withArgs(currency.ct.toString(), currency.id, 1200000, 1700000)
@@ -622,7 +622,7 @@ describe('TokenHolderRevenueFundContractsEnsemble', () => {
             });
         });
 
-        describe('if block arguments fall within the span of two decompositions', () => {
+        describe('if block arguments fall within the span of two spans', () => {
             beforeEach(() => {
                 stubbedTokenHolderRevenueFundContract.claimAndStageByBlockNumbers
                     .withArgs(currency.ct.toString(), currency.id, 1200000, 2000000)
@@ -638,7 +638,7 @@ describe('TokenHolderRevenueFundContractsEnsemble', () => {
             });
         });
 
-        describe('if block arguments wrap the span of two decompositions', () => {
+        describe('if block arguments wrap the span of two spans', () => {
             beforeEach(() => {
                 stubbedTokenHolderRevenueFundContract.claimAndStageByBlockNumbers
                     .withArgs(currency.ct.toString(), currency.id, 900001, 2000000)
@@ -648,7 +648,7 @@ describe('TokenHolderRevenueFundContractsEnsemble', () => {
                     .returns(hashOne);
             });
 
-            it('should return the value obtained from the decompositions combined', async () => {
+            it('should return the value obtained from the spans combined', async () => {
                 expect(await ensemble.claimAndStageByBlockNumbers(wallet, currency, 500000, 7000000))
                     .to.be.an('array').that.deep.equals([hashZero, hashOne]);
             });
@@ -714,7 +714,7 @@ describe('TokenHolderRevenueFundContractsEnsemble', () => {
             );
         });
 
-        it('should return the value obtained from the decompositions combined', async () => {
+        it('should return the value obtained from the spans combined', async () => {
             expect((await ensemble.stagedBalance(wallet, currency)).toNumber())
                 .to.be.eq(30);
         });
@@ -760,7 +760,7 @@ describe('TokenHolderRevenueFundContractsEnsemble', () => {
             });
         });
 
-        describe('if called with amount less than the stageable amount of the first decomposition', () => {
+        describe('if called with amount less than the stageable amount of the first span', () => {
             beforeEach(() => {
                 stubbedTokenHolderRevenueFundContract.withdraw
                     .withArgs(utils.bigNumberify(5), currency.ct.toString(), currency.id, 'ERC20')
@@ -772,13 +772,13 @@ describe('TokenHolderRevenueFundContractsEnsemble', () => {
                 monetaryAmount = MonetaryAmount.from(5, currency.ct, currency.id);
             });
 
-            it('should return the value obtained from the decompositions combined', async () => {
+            it('should return the value obtained from the spans combined', async () => {
                 expect(await ensemble.withdraw(wallet, monetaryAmount))
                     .to.be.an('array').that.deep.equals([hashZero]);
             });
         });
 
-        describe('if called with amount less than the stageable amount of the decompositions combined', () => {
+        describe('if called with amount less than the stageable amount of the spans combined', () => {
             beforeEach(() => {
                 stubbedTokenHolderRevenueFundContract.withdraw
                     .withArgs(utils.bigNumberify(10), currency.ct.toString(), currency.id, 'ERC20')
@@ -789,7 +789,7 @@ describe('TokenHolderRevenueFundContractsEnsemble', () => {
                 monetaryAmount = MonetaryAmount.from(25, currency.ct, currency.id);
             });
 
-            it('should return the value obtained from the decompositions combined', async () => {
+            it('should return the value obtained from the spans combined', async () => {
                 expect(await ensemble.withdraw(wallet, monetaryAmount))
                     .to.be.an('array').that.deep.equals([hashZero, hashOne]);
             });
@@ -806,7 +806,7 @@ describe('TokenHolderRevenueFundContractsEnsemble', () => {
                 monetaryAmount = MonetaryAmount.from(30, currency.ct, currency.id);
             });
 
-            it('should return the value obtained from the decompositions combined', async () => {
+            it('should return the value obtained from the spans combined', async () => {
                 expect(await ensemble.withdraw(wallet, monetaryAmount))
                     .to.be.an('array').that.deep.equals([hashZero, hashOne]);
             });

--- a/lib/claim/token-holder-revenue-fund-contracts-ensemble.spec.js
+++ b/lib/claim/token-holder-revenue-fund-contracts-ensemble.spec.js
@@ -1,0 +1,851 @@
+'use strict';
+
+const chai = require('chai');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+const expect = chai.expect;
+chai.use(sinonChai);
+const {constants, utils} = require('ethers');
+const MonetaryAmount = require('../monetary-amount');
+const Currency = require('../currency');
+const Wallet = require('../wallet');
+const NestedError = require('../nested-error');
+
+const proxyquire = require('proxyquire').noPreserveCache().noCallThru();
+
+const privateKey = '0x' + '0F'.repeat(32);
+const hashZero = constants.HashZero;
+const hashOne = hashZero.replace(/0$/, '1');
+
+describe('TokenHolderRevenueFundContractsEnsemble', () => {
+    const fakeProvider = {
+        network: {
+            chainId: '123456789',
+            name: 'some network'
+        }
+    };
+
+    let stubbedTokenHolderRevenueFundConstructor;
+    let stubbedTokenHolderRevenueFundContract;
+    let stubbedAccruals;
+    let TokenHolderRevenueFundContractsEnsemble;
+    let currency;
+    let wallet;
+
+    before(() => {
+        currency = Currency.from({ct: constants.AddressZero, id: 0});
+        wallet = new Wallet(privateKey);
+    });
+
+    beforeEach(() => {
+        stubbedTokenHolderRevenueFundConstructor = sinon.stub();
+
+        stubbedTokenHolderRevenueFundContract = {
+            closedAccrualsCount: sinon.stub(),
+            closedAccrualsByCurrency: sinon.stub(),
+            fullyClaimed: sinon.stub(),
+            claimableAmountByAccruals: sinon.stub(),
+            claimAndStageByAccruals: sinon.stub(),
+            claimableAmountByBlockNumbers: sinon.stub(),
+            claimAndStageByBlockNumbers: sinon.stub(),
+            stagedBalance: sinon.stub(),
+            withdraw: sinon.stub(),
+            connect: sinon.stub()
+        };
+
+        stubbedTokenHolderRevenueFundContract.connect.returns(stubbedTokenHolderRevenueFundContract);
+
+        stubbedAccruals = [
+            {
+                startBlock: utils.bigNumberify(900001),
+                endBlock: utils.bigNumberify(1000000)
+            },
+            {
+                startBlock: utils.bigNumberify(1900001),
+                endBlock: utils.bigNumberify(2000000)
+            },
+            {
+                startBlock: utils.bigNumberify(2000001),
+                endBlock: utils.bigNumberify(2100000)
+            },
+            {
+                startBlock: utils.bigNumberify(5900001),
+                endBlock: utils.bigNumberify(6000000)
+            }
+        ];
+
+        stubbedTokenHolderRevenueFundContract.closedAccrualsCount
+            .withArgs(currency.ct.toString(), currency.id)
+            .onFirstCall()
+            .returns(utils.bigNumberify(10))
+            .onSecondCall()
+            .returns(utils.bigNumberify(20));
+
+        stubbedTokenHolderRevenueFundConstructor
+            .withArgs(fakeProvider, 'TokenHolderRevenueFund')
+            .returns(stubbedTokenHolderRevenueFundContract)
+            .withArgs(fakeProvider, 'abstraction1')
+            .returns(stubbedTokenHolderRevenueFundContract)
+            .withArgs(fakeProvider, 'abstraction2')
+            .returns(stubbedTokenHolderRevenueFundContract);
+
+        TokenHolderRevenueFundContractsEnsemble = proxyquire('./token-holder-revenue-fund-contracts-ensemble', {
+            './token-holder-revenue-fund-contract': stubbedTokenHolderRevenueFundConstructor
+        });
+    });
+
+    describe('constructor', () => {
+        describe('without abstractions names', () => {
+            it('should successfully construct', () => {
+                new TokenHolderRevenueFundContractsEnsemble(fakeProvider);
+                expect(stubbedTokenHolderRevenueFundConstructor)
+                    .to.have.been.calledWithNew.and
+                    .to.have.been.calledOnce;
+            });
+        });
+
+        describe('with abstractions names', () => {
+            it('should successfully construct', () => {
+                new TokenHolderRevenueFundContractsEnsemble(fakeProvider, ['abstraction1', 'abstraction2']);
+                expect(stubbedTokenHolderRevenueFundConstructor)
+                    .to.have.been.calledWithNew.and
+                    .to.have.been.calledTwice;
+            });
+        });
+    });
+
+    describe('firstAccrualOffset', () => {
+        let ensemble;
+
+        describe('when constructed with default firstAccrualOffset parameter', () => {
+            beforeEach(() => {
+                ensemble = new TokenHolderRevenueFundContractsEnsemble(fakeProvider, ['abstraction1', 'abstraction2']);
+            });
+
+            it('should return 0', () => {
+                expect(ensemble.firstAccrualOffset).to.be.eq(0);
+            });
+        });
+
+        describe('when constructed with positive first accrual offset parameter', () => {
+            beforeEach(() => {
+                ensemble = new TokenHolderRevenueFundContractsEnsemble(fakeProvider, ['abstraction1', 'abstraction2'], 10);
+            });
+
+            it('should return the given parameter', () => {
+                expect(ensemble.firstAccrualOffset).to.be.eq(10);
+            });
+        });
+
+        describe('when constructed with negative first accrual offset parameter', () => {
+            beforeEach(() => {
+                ensemble = new TokenHolderRevenueFundContractsEnsemble(fakeProvider, ['abstraction1', 'abstraction2'], -10);
+            });
+
+            it('should return 0', () => {
+                expect(ensemble.firstAccrualOffset).to.be.eq(0);
+            });
+        });
+    });
+
+    describe('isDecomposed()', () => {
+        let ensemble;
+
+        beforeEach(() => {
+            ensemble = new TokenHolderRevenueFundContractsEnsemble(fakeProvider, ['abstraction1', 'abstraction2']);
+        });
+
+        describe('when called before decomposition', () => {
+            it('should return false', () => {
+                expect(ensemble.isDecomposed(currency)).to.be.false;
+            });
+        });
+    });
+
+    describe('decompose()', () => {
+        let ensemble;
+
+        describe('if first accrual offset is 0', () => {
+            beforeEach(() => {
+                stubbedTokenHolderRevenueFundContract.closedAccrualsByCurrency
+                    .withArgs(currency.ct.toString(), currency.id, 0)
+                    .returns(stubbedAccruals[0])
+                    .withArgs(currency.ct.toString(), currency.id, 9)
+                    .returns(stubbedAccruals[1])
+                    .withArgs(currency.ct.toString(), currency.id, 10)
+                    .returns(stubbedAccruals[2])
+                    .withArgs(currency.ct.toString(), currency.id, 29)
+                    .returns(stubbedAccruals[3]);
+
+                ensemble = new TokenHolderRevenueFundContractsEnsemble(fakeProvider, ['abstraction1', 'abstraction2']);
+            });
+
+            it('should successfully decompose', async () => {
+                await ensemble.decompose(currency);
+
+                expect(ensemble.isDecomposed(currency)).to.be.true;
+            });
+        });
+
+        describe('if first accrual offset is non-zero', () => {
+            beforeEach(() => {
+                stubbedTokenHolderRevenueFundContract.closedAccrualsByCurrency
+                    .withArgs(currency.ct.toString(), currency.id, 10)
+                    .returns(stubbedAccruals[0])
+                    .withArgs(currency.ct.toString(), currency.id, 19)
+                    .returns(stubbedAccruals[1])
+                    .withArgs(currency.ct.toString(), currency.id, 20)
+                    .returns(stubbedAccruals[2])
+                    .withArgs(currency.ct.toString(), currency.id, 39)
+                    .returns(stubbedAccruals[3]);
+
+                ensemble = new TokenHolderRevenueFundContractsEnsemble(fakeProvider, ['abstraction1', 'abstraction2'], 10);
+            });
+
+            it('should successfully decompose', async () => {
+                await ensemble.decompose(currency);
+
+                expect(ensemble.isDecomposed(currency)).to.be.true;
+            });
+        });
+    });
+
+    describe('closedAccrualsCount', () => {
+        let ensemble;
+
+        beforeEach(() => {
+            ensemble = new TokenHolderRevenueFundContractsEnsemble(fakeProvider, ['abstraction1', 'abstraction2']);
+        });
+
+        it('should return the value obtained from the decompositions combined', async () => {
+            expect((await ensemble.closedAccrualsCount(currency)).toNumber())
+                .to.be.eq(30);
+        });
+    });
+
+    describe('fullyClaimed()', () => {
+        let ensemble;
+
+        beforeEach(() => {
+            stubbedTokenHolderRevenueFundContract.closedAccrualsByCurrency
+                .withArgs(currency.ct.toString(), currency.id, 0)
+                .returns(stubbedAccruals[0])
+                .withArgs(currency.ct.toString(), currency.id, 9)
+                .returns(stubbedAccruals[1])
+                .withArgs(currency.ct.toString(), currency.id, 10)
+                .returns(stubbedAccruals[2])
+                .withArgs(currency.ct.toString(), currency.id, 29)
+                .returns(stubbedAccruals[3]);
+
+            ensemble = new TokenHolderRevenueFundContractsEnsemble(fakeProvider, ['abstraction1', 'abstraction2']);
+        });
+
+        describe('if the matching configuration contract not is fully claimed', () => {
+            beforeEach(() => {
+                stubbedTokenHolderRevenueFundContract.fullyClaimed.returns(false);
+            });
+
+            it('should return false', async () => {
+                expect(await ensemble.fullyClaimed(wallet, currency, 15)).to.be.false;
+
+                expect(ensemble.isDecomposed(currency)).to.be.true;
+            });
+        });
+
+        describe('if the matching configuration contract is fully claimed', () => {
+            beforeEach(() => {
+                stubbedTokenHolderRevenueFundContract.fullyClaimed.returns(true);
+            });
+
+            it('should return true', async () => {
+                expect(await ensemble.fullyClaimed(wallet, currency, 15)).to.be.true;
+
+                expect(ensemble.isDecomposed(currency)).to.be.true;
+            });
+        });
+
+        describe('if there is no matching configuration contract', () => {
+            beforeEach(() => {
+                stubbedTokenHolderRevenueFundContract.fullyClaimed.reset();
+                stubbedTokenHolderRevenueFundContract.fullyClaimed.throws();
+            });
+
+            it('should return false', async () => {
+                expect(await ensemble.fullyClaimed(wallet, currency, 50)).to.be.false;
+
+                expect(ensemble.isDecomposed(currency)).to.be.true;
+            });
+        });
+    });
+
+    describe('claimableAmountByAccruals()', () => {
+        let ensemble;
+
+        beforeEach(() => {
+            stubbedTokenHolderRevenueFundContract.closedAccrualsByCurrency
+                .withArgs(currency.ct.toString(), currency.id, 10)
+                .returns(stubbedAccruals[0])
+                .withArgs(currency.ct.toString(), currency.id, 19)
+                .returns(stubbedAccruals[1])
+                .withArgs(currency.ct.toString(), currency.id, 20)
+                .returns(stubbedAccruals[2])
+                .withArgs(currency.ct.toString(), currency.id, 39)
+                .returns(stubbedAccruals[3]);
+
+            ensemble = new TokenHolderRevenueFundContractsEnsemble(
+                fakeProvider, ['abstraction1', 'abstraction2'], 10
+            );
+        });
+
+        describe('if start accrual is greater than end accrual', () => {
+            it('should throw', async () => {
+                expect(ensemble.claimableAmountByAccruals(wallet, currency, 15, 5))
+                    .to.be.rejected;
+            });
+        });
+
+        describe('if start accrual is greater than end accrual of last decomposition', () => {
+            it('should return 0', async () => {
+                expect((await ensemble.claimableAmountByAccruals(wallet, currency, 50, 60)).toNumber())
+                    .to.be.eq(0);
+            });
+        });
+
+        describe('if end accrual is less than start accrual of first decomposition', () => {
+            it('should return 0', async () => {
+                expect((await ensemble.claimableAmountByAccruals(wallet, currency, 5, 8)).toNumber())
+                    .to.be.eq(0);
+            });
+        });
+
+        describe('if accrual arguments entirely fall within the span of one decomposition', () => {
+            beforeEach(() => {
+                stubbedTokenHolderRevenueFundContract.claimableAmountByAccruals
+                    .withArgs(wallet.address, currency.ct.toString(), currency.id, 12, 17)
+                    .returns(utils.bigNumberify(10));
+            });
+
+            it('should return the value obtained from the decomposition', async () => {
+                expect((await ensemble.claimableAmountByAccruals(wallet, currency, 12, 17)).toNumber())
+                    .to.be.eq(10);
+            });
+        });
+
+        describe('if accrual arguments fall within the span of two decompositions', () => {
+            beforeEach(() => {
+                stubbedTokenHolderRevenueFundContract.claimableAmountByAccruals
+                    .withArgs(wallet.address, currency.ct.toString(), currency.id, 12, 19)
+                    .returns(utils.bigNumberify(10));
+                stubbedTokenHolderRevenueFundContract.claimableAmountByAccruals
+                    .withArgs(wallet.address, currency.ct.toString(), currency.id, 20, 27)
+                    .returns(utils.bigNumberify(20));
+            });
+
+            it('should return the value obtained from the decompositions combined', async () => {
+                expect((await ensemble.claimableAmountByAccruals(wallet, currency, 12, 27)).toNumber())
+                    .to.be.eq(30);
+            });
+        });
+
+        describe('if accrual arguments wrap the span of two decompositions', () => {
+            beforeEach(() => {
+                stubbedTokenHolderRevenueFundContract.claimableAmountByAccruals
+                    .withArgs(wallet.address, currency.ct.toString(), currency.id, 10, 19)
+                    .returns(utils.bigNumberify(10));
+                stubbedTokenHolderRevenueFundContract.claimableAmountByAccruals
+                    .withArgs(wallet.address, currency.ct.toString(), currency.id, 20, 39)
+                    .returns(utils.bigNumberify(20));
+            });
+
+            it('should return the value obtained from the decompositions combined', async () => {
+                expect((await ensemble.claimableAmountByAccruals(wallet, currency, 5, 45)).toNumber())
+                    .to.be.eq(30);
+            });
+        });
+    });
+
+    describe('claimAndStageByAccruals()', () => {
+        let ensemble;
+
+        beforeEach(() => {
+            stubbedTokenHolderRevenueFundContract.closedAccrualsByCurrency
+                .withArgs(currency.ct.toString(), currency.id, 10)
+                .returns(stubbedAccruals[0])
+                .withArgs(currency.ct.toString(), currency.id, 19)
+                .returns(stubbedAccruals[1])
+                .withArgs(currency.ct.toString(), currency.id, 20)
+                .returns(stubbedAccruals[2])
+                .withArgs(currency.ct.toString(), currency.id, 39)
+                .returns(stubbedAccruals[3]);
+
+            ensemble = new TokenHolderRevenueFundContractsEnsemble(
+                fakeProvider, ['abstraction1', 'abstraction2'], 10
+            );
+        });
+
+        describe('if start accrual is greater than end accrual', () => {
+            it('should throw', async () => {
+                expect(ensemble.claimAndStageByAccruals(wallet, currency, 15, 5)).to.be.rejected;
+            });
+        });
+
+        describe('if start accrual is greater than end accrual of last decomposition', () => {
+            it('should return an empty array', async () => {
+                expect(await ensemble.claimAndStageByAccruals(wallet, currency, 50, 60))
+                    .to.be.an('array').that.is.empty;
+            });
+        });
+
+        describe('if end accrual is less than start accrual of first decomposition', () => {
+            it('should return an empty array', async () => {
+                expect(await ensemble.claimAndStageByAccruals(wallet, currency, 5, 8))
+                    .to.be.an('array').that.is.empty;
+            });
+        });
+
+        describe('if accrual arguments entirely fall within the span of one decomposition', () => {
+            beforeEach(() => {
+                stubbedTokenHolderRevenueFundContract.claimAndStageByAccruals
+                    .withArgs(currency.ct.toString(), currency.id, 12, 17)
+                    .returns(hashZero);
+            });
+
+            it('should return an array of 1 tx hash', async () => {
+                expect(await ensemble.claimAndStageByAccruals(wallet, currency, 12, 17))
+                    .to.be.an('array').that.deep.equals([hashZero]);
+            });
+        });
+
+        describe('if accrual arguments fall within the span of two decompositions', () => {
+            beforeEach(() => {
+                stubbedTokenHolderRevenueFundContract.claimAndStageByAccruals
+                    .withArgs(currency.ct.toString(), currency.id, 12, 19)
+                    .returns(hashZero);
+                stubbedTokenHolderRevenueFundContract.claimAndStageByAccruals
+                    .withArgs(currency.ct.toString(), currency.id, 20, 27)
+                    .returns(hashOne);
+            });
+
+            it('should return an array of 2 tx hashes', async () => {
+                expect(await ensemble.claimAndStageByAccruals(wallet, currency, 12, 27))
+                    .to.be.an('array').that.deep.equals([hashZero, hashOne]);
+            });
+        });
+
+        describe('if accrual arguments wrap the span of two decompositions', () => {
+            beforeEach(() => {
+                stubbedTokenHolderRevenueFundContract.claimAndStageByAccruals
+                    .withArgs(currency.ct.toString(), currency.id, 10, 19)
+                    .returns(hashZero);
+                stubbedTokenHolderRevenueFundContract.claimAndStageByAccruals
+                    .withArgs(currency.ct.toString(), currency.id, 20, 39)
+                    .returns(hashOne);
+            });
+
+            it('should return an array of 2 tx hashes', async () => {
+                expect(await ensemble.claimAndStageByAccruals(wallet, currency, 5, 45))
+                    .to.be.an('array').that.deep.equals([hashZero, hashOne]);
+            });
+        });
+
+        describe('if contract connect throws', () => {
+            beforeEach(() => {
+                stubbedTokenHolderRevenueFundContract.connect
+                    .throws(new Error('Unable to connect'));
+                stubbedTokenHolderRevenueFundContract.claimAndStageByAccruals
+                    .withArgs(currency.ct.toString(), currency.id, 10, 19)
+                    .returns(hashZero);
+                stubbedTokenHolderRevenueFundContract.claimAndStageByAccruals
+                    .withArgs(currency.ct.toString(), currency.id, 20, 39)
+                    .returns(hashOne);
+            });
+
+            it('should be rejected', async () => {
+                expect(ensemble.claimAndStageByAccruals(wallet, currency, 5, 45))
+                    .to.be.rejectedWith(NestedError, 'Unable to claim and stage by accruals.');
+            });
+        });
+
+        describe('if contract claim and stage throws', () => {
+            beforeEach(() => {
+                stubbedTokenHolderRevenueFundContract.claimAndStageByAccruals
+                    .withArgs(currency.ct.toString(), currency.id, 10, 19)
+                    .returns(hashZero);
+                stubbedTokenHolderRevenueFundContract.claimAndStageByAccruals
+                    .withArgs(currency.ct.toString(), currency.id, 20, 39)
+                    .throws(new Error('Unable to claim and stage'));
+            });
+
+            it('should be rejected', async () => {
+                expect(ensemble.claimAndStageByAccruals(wallet, currency, 5, 45))
+                    .to.be.rejectedWith(NestedError, 'Unable to claim and stage by accruals.');
+            });
+        });
+    });
+
+    describe('claimableAmountByBlockNumbers()', () => {
+        let ensemble;
+
+        beforeEach(() => {
+            stubbedTokenHolderRevenueFundContract.closedAccrualsByCurrency
+                .withArgs(currency.ct.toString(), currency.id, 10)
+                .returns(stubbedAccruals[0])
+                .withArgs(currency.ct.toString(), currency.id, 19)
+                .returns(stubbedAccruals[1])
+                .withArgs(currency.ct.toString(), currency.id, 20)
+                .returns(stubbedAccruals[2])
+                .withArgs(currency.ct.toString(), currency.id, 39)
+                .returns(stubbedAccruals[3]);
+
+            ensemble = new TokenHolderRevenueFundContractsEnsemble(
+                fakeProvider, ['abstraction1', 'abstraction2'], 10
+            );
+        });
+
+        describe('if start block is greater than end block', () => {
+            it('should throw', async () => {
+                expect(ensemble.claimableAmountByBlockNumbers(wallet, currency, 1500000, 500000))
+                    .to.be.rejected;
+            });
+        });
+
+        describe('if start block is greater than end block of last decomposition', () => {
+            it('should return 0', async () => {
+                expect((await ensemble.claimableAmountByBlockNumbers(wallet, currency, 10000000, 11000000)).toNumber())
+                    .to.be.eq(0);
+            });
+        });
+
+        describe('if end block is less than start block of first decomposition', () => {
+            it('should return 0', async () => {
+                expect((await ensemble.claimableAmountByBlockNumbers(wallet, currency, 500000, 800000)).toNumber())
+                    .to.be.eq(0);
+            });
+        });
+
+        describe('if block arguments entirely fall within the span of one decomposition', () => {
+            beforeEach(() => {
+                stubbedTokenHolderRevenueFundContract.claimableAmountByBlockNumbers
+                    .withArgs(wallet.address, currency.ct.toString(), currency.id, 1200000, 1700000)
+                    .returns(utils.bigNumberify(10));
+            });
+
+            it('should return the value obtained from the decomposition', async () => {
+                expect((await ensemble.claimableAmountByBlockNumbers(wallet, currency, 1200000, 1700000)).toNumber())
+                    .to.be.eq(10);
+            });
+        });
+
+        describe('if block arguments fall within the span of two decompositions', () => {
+            beforeEach(() => {
+                stubbedTokenHolderRevenueFundContract.claimableAmountByBlockNumbers
+                    .withArgs(wallet.address, currency.ct.toString(), currency.id, 1200000, 2000000)
+                    .returns(utils.bigNumberify(10));
+                stubbedTokenHolderRevenueFundContract.claimableAmountByBlockNumbers
+                    .withArgs(wallet.address, currency.ct.toString(), currency.id, 2000001, 2700000)
+                    .returns(utils.bigNumberify(20));
+            });
+
+            it('should return the value obtained from the decompositions combined', async () => {
+                expect((await ensemble.claimableAmountByBlockNumbers(wallet, currency, 1200000, 2700000)).toNumber())
+                    .to.be.eq(30);
+            });
+        });
+
+        describe('if block arguments wrap the span of two decompositions', () => {
+            beforeEach(() => {
+                stubbedTokenHolderRevenueFundContract.claimableAmountByBlockNumbers
+                    .withArgs(wallet.address, currency.ct.toString(), currency.id, 900001, 2000000)
+                    .returns(utils.bigNumberify(10));
+                stubbedTokenHolderRevenueFundContract.claimableAmountByBlockNumbers
+                    .withArgs(wallet.address, currency.ct.toString(), currency.id, 2000001, 6000000)
+                    .returns(utils.bigNumberify(20));
+            });
+
+            it('should return the value obtained from the decompositions combined', async () => {
+                expect((await ensemble.claimableAmountByBlockNumbers(wallet, currency, 500000, 7000000)).toNumber())
+                    .to.be.eq(30);
+            });
+        });
+    });
+
+    describe('claimAndStageByBlockNumbers()', () => {
+        let ensemble;
+
+        beforeEach(() => {
+            stubbedTokenHolderRevenueFundContract.closedAccrualsByCurrency
+                .withArgs(currency.ct.toString(), currency.id, 10)
+                .returns(stubbedAccruals[0])
+                .withArgs(currency.ct.toString(), currency.id, 19)
+                .returns(stubbedAccruals[1])
+                .withArgs(currency.ct.toString(), currency.id, 20)
+                .returns(stubbedAccruals[2])
+                .withArgs(currency.ct.toString(), currency.id, 39)
+                .returns(stubbedAccruals[3]);
+
+            ensemble = new TokenHolderRevenueFundContractsEnsemble(
+                fakeProvider, ['abstraction1', 'abstraction2'], 10
+            );
+        });
+
+        describe('if start block is greater than end block', () => {
+            it('should throw', async () => {
+                expect(ensemble.claimAndStageByBlockNumbers(wallet, currency, 1500000, 500000))
+                    .to.be.rejected;
+            });
+        });
+
+        describe('if start block is greater than end block of last decomposition', () => {
+            it('should return an empty array', async () => {
+                expect(await ensemble.claimAndStageByBlockNumbers(wallet, currency, 10000000, 11000000))
+                    .to.be.an('array').that.is.empty;
+            });
+        });
+
+        describe('if end block is less than start block of first decomposition', () => {
+            it('should return an empty array', async () => {
+                expect(await ensemble.claimAndStageByBlockNumbers(wallet, currency, 500000, 800000))
+                    .to.be.an('array').that.is.empty;
+            });
+        });
+
+        describe('if block arguments entirely fall within the span of one decomposition', () => {
+            beforeEach(() => {
+                stubbedTokenHolderRevenueFundContract.claimAndStageByBlockNumbers
+                    .withArgs(currency.ct.toString(), currency.id, 1200000, 1700000)
+                    .returns(hashZero);
+            });
+
+            it('should return an array of 1 tx hash', async () => {
+                expect(await ensemble.claimAndStageByBlockNumbers(wallet, currency, 1200000, 1700000))
+                    .to.be.an('array').that.deep.equals([hashZero]);
+            });
+        });
+
+        describe('if block arguments fall within the span of two decompositions', () => {
+            beforeEach(() => {
+                stubbedTokenHolderRevenueFundContract.claimAndStageByBlockNumbers
+                    .withArgs(currency.ct.toString(), currency.id, 1200000, 2000000)
+                    .returns(hashZero);
+                stubbedTokenHolderRevenueFundContract.claimAndStageByBlockNumbers
+                    .withArgs(currency.ct.toString(), currency.id, 2000001, 2700000)
+                    .returns(hashOne);
+            });
+
+            it('should return an array of 2 tx hashes', async () => {
+                expect(await ensemble.claimAndStageByBlockNumbers(wallet, currency, 1200000, 2700000))
+                    .to.be.an('array').that.deep.equals([hashZero, hashOne]);
+            });
+        });
+
+        describe('if block arguments wrap the span of two decompositions', () => {
+            beforeEach(() => {
+                stubbedTokenHolderRevenueFundContract.claimAndStageByBlockNumbers
+                    .withArgs(currency.ct.toString(), currency.id, 900001, 2000000)
+                    .returns(hashZero);
+                stubbedTokenHolderRevenueFundContract.claimAndStageByBlockNumbers
+                    .withArgs(currency.ct.toString(), currency.id, 2000001, 6000000)
+                    .returns(hashOne);
+            });
+
+            it('should return the value obtained from the decompositions combined', async () => {
+                expect(await ensemble.claimAndStageByBlockNumbers(wallet, currency, 500000, 7000000))
+                    .to.be.an('array').that.deep.equals([hashZero, hashOne]);
+            });
+        });
+
+        describe('if contract connect throws', () => {
+            beforeEach(() => {
+                stubbedTokenHolderRevenueFundContract.connect
+                    .throws(new Error('Unable to connect'));
+                stubbedTokenHolderRevenueFundContract.claimAndStageByBlockNumbers
+                    .withArgs(currency.ct.toString(), currency.id, 900001, 2000000)
+                    .returns(hashZero);
+                stubbedTokenHolderRevenueFundContract.claimAndStageByBlockNumbers
+                    .withArgs(currency.ct.toString(), currency.id, 2000001, 6000000)
+                    .returns(hashOne);
+            });
+
+            it('should be rejected', async () => {
+                expect(ensemble.claimAndStageByBlockNumbers(wallet, currency, 500000, 7000000))
+                    .to.be.rejectedWith(NestedError, 'Unable to claim and stage by blocks numbers.');
+            });
+        });
+
+        describe('if contract claim and stage throws', () => {
+            beforeEach(() => {
+                stubbedTokenHolderRevenueFundContract.claimAndStageByBlockNumbers
+                    .withArgs(currency.ct.toString(), currency.id, 900001, 2000000)
+                    .returns(hashZero);
+                stubbedTokenHolderRevenueFundContract.claimAndStageByBlockNumbers
+                    .withArgs(currency.ct.toString(), currency.id, 2000001, 6000000)
+                    .throws(new Error('Unable to claim and stage'));
+            });
+
+            it('should be rejected', async () => {
+                expect(ensemble.claimAndStageByBlockNumbers(wallet, currency, 500000, 7000000))
+                    .to.be.rejectedWith(NestedError, 'Unable to claim and stage by blocks numbers.');
+            });
+        });
+    });
+
+    describe('stagedBalance()', () => {
+        let ensemble;
+
+        beforeEach(() => {
+            stubbedTokenHolderRevenueFundContract.closedAccrualsByCurrency
+                .withArgs(currency.ct.toString(), currency.id, 10)
+                .returns(stubbedAccruals[0])
+                .withArgs(currency.ct.toString(), currency.id, 19)
+                .returns(stubbedAccruals[1])
+                .withArgs(currency.ct.toString(), currency.id, 20)
+                .returns(stubbedAccruals[2])
+                .withArgs(currency.ct.toString(), currency.id, 39)
+                .returns(stubbedAccruals[3]);
+            stubbedTokenHolderRevenueFundContract.stagedBalance
+                .withArgs(wallet.address, currency.ct.toString(), currency.id)
+                .onFirstCall()
+                .returns(10)
+                .onSecondCall()
+                .returns(20);
+
+            ensemble = new TokenHolderRevenueFundContractsEnsemble(
+                fakeProvider, ['abstraction1', 'abstraction2'], 10
+            );
+        });
+
+        it('should return the value obtained from the decompositions combined', async () => {
+            expect((await ensemble.stagedBalance(wallet, currency)).toNumber())
+                .to.be.eq(30);
+        });
+    });
+
+    describe('withdraw()', () => {
+        let ensemble, monetaryAmount;
+
+        beforeEach(() => {
+            stubbedTokenHolderRevenueFundContract.closedAccrualsByCurrency
+                .withArgs(currency.ct.toString(), currency.id, 10)
+                .returns(stubbedAccruals[0])
+                .withArgs(currency.ct.toString(), currency.id, 19)
+                .returns(stubbedAccruals[1])
+                .withArgs(currency.ct.toString(), currency.id, 20)
+                .returns(stubbedAccruals[2])
+                .withArgs(currency.ct.toString(), currency.id, 39)
+                .returns(stubbedAccruals[3]);
+            stubbedTokenHolderRevenueFundContract.stagedBalance
+                .withArgs(wallet.address, currency.ct.toString(), currency.id)
+                .onCall(0)
+                .returns(utils.bigNumberify(10))
+                .onCall(1)
+                .returns(utils.bigNumberify(20))
+                .onCall(2)
+                .returns(utils.bigNumberify(10))
+                .onCall(3)
+                .returns(utils.bigNumberify(20));
+
+            ensemble = new TokenHolderRevenueFundContractsEnsemble(
+                fakeProvider, ['abstraction1', 'abstraction2'], 10
+            );
+        });
+
+        describe('if called amount greater than the stageable amount', () => {
+            beforeEach(() => {
+                monetaryAmount = MonetaryAmount.from(40, currency.ct, currency.id);
+            });
+
+            it('should throw', async () => {
+                expect(ensemble.withdraw(wallet, monetaryAmount))
+                    .to.be.rejected;
+            });
+        });
+
+        describe('if called with amount less than the stageable amount of the first decomposition', () => {
+            beforeEach(() => {
+                stubbedTokenHolderRevenueFundContract.withdraw
+                    .withArgs(utils.bigNumberify(5), currency.ct.toString(), currency.id, 'ERC20')
+                    .returns(hashZero);
+                stubbedTokenHolderRevenueFundContract.withdraw
+                    .onSecondCall()
+                    .throws();
+
+                monetaryAmount = MonetaryAmount.from(5, currency.ct, currency.id);
+            });
+
+            it('should return the value obtained from the decompositions combined', async () => {
+                expect(await ensemble.withdraw(wallet, monetaryAmount))
+                    .to.be.an('array').that.deep.equals([hashZero]);
+            });
+        });
+
+        describe('if called with amount less than the stageable amount of the decompositions combined', () => {
+            beforeEach(() => {
+                stubbedTokenHolderRevenueFundContract.withdraw
+                    .withArgs(utils.bigNumberify(10), currency.ct.toString(), currency.id, 'ERC20')
+                    .returns(hashZero)
+                    .withArgs(utils.bigNumberify(15), currency.ct.toString(), currency.id, 'ERC20')
+                    .returns(hashOne);
+
+                monetaryAmount = MonetaryAmount.from(25, currency.ct, currency.id);
+            });
+
+            it('should return the value obtained from the decompositions combined', async () => {
+                expect(await ensemble.withdraw(wallet, monetaryAmount))
+                    .to.be.an('array').that.deep.equals([hashZero, hashOne]);
+            });
+        });
+
+        describe('if called with equal to the stageable amount', () => {
+            beforeEach(() => {
+                stubbedTokenHolderRevenueFundContract.withdraw
+                    .withArgs(utils.bigNumberify(10), currency.ct.toString(), currency.id, 'ERC20')
+                    .returns(hashZero)
+                    .withArgs(utils.bigNumberify(20), currency.ct.toString(), currency.id, 'ERC20')
+                    .returns(hashOne);
+
+                monetaryAmount = MonetaryAmount.from(30, currency.ct, currency.id);
+            });
+
+            it('should return the value obtained from the decompositions combined', async () => {
+                expect(await ensemble.withdraw(wallet, monetaryAmount))
+                    .to.be.an('array').that.deep.equals([hashZero, hashOne]);
+            });
+        });
+
+        describe('if contract connect throws', () => {
+            beforeEach(() => {
+                stubbedTokenHolderRevenueFundContract.connect
+                    .throws(new Error('Unable to connect'));
+                stubbedTokenHolderRevenueFundContract.withdraw
+                    .withArgs(utils.bigNumberify(10), currency.ct.toString(), currency.id, 'ERC20')
+                    .returns(hashZero)
+                    .withArgs(utils.bigNumberify(20), currency.ct.toString(), currency.id, 'ERC20')
+                    .returns(hashOne);
+
+                monetaryAmount = MonetaryAmount.from(30, currency.ct, currency.id);
+            });
+
+            it('should be rejected', async () => {
+                expect(ensemble.withdraw(wallet, monetaryAmount))
+                    .to.be.rejectedWith(NestedError, 'Unable to withdraw.');
+            });
+        });
+
+        describe('if contract withdraw throws', () => {
+            beforeEach(() => {
+                stubbedTokenHolderRevenueFundContract.withdraw
+                    .withArgs(utils.bigNumberify(10), currency.ct.toString(), currency.id, 'ERC20')
+                    .returns(hashZero)
+                    .withArgs(utils.bigNumberify(20), currency.ct.toString(), currency.id, 'ERC20')
+                    .throws(new Error('Unable to withdraw'));
+
+                monetaryAmount = MonetaryAmount.from(30, currency.ct, currency.id);
+            });
+
+            it('should be rejected', async () => {
+                expect(ensemble.withdraw(wallet, monetaryAmount))
+                    .to.be.rejectedWith(NestedError, 'Unable to withdraw.');
+            });
+        });
+    });
+});

--- a/lib/contract/index.js
+++ b/lib/contract/index.js
@@ -35,23 +35,23 @@ class NahmiiContract extends ethers.Contract {
      * (Deprecated) Constructs a new contract wrapper instance by loading the correct ABIs
      * based on the name of the contract and the network that the provider or
      * wallet is connected to.
-     * @param {string} contractName - Name of the nahmii contract to load
+     * @param {string} abstractionName - Name of the nahmii contract to load
      * @param {NahmiiProvider|Wallet} walletOrProvider - Wallet or provider connected to nahmii cluster
      */
-    constructor(contractName, walletOrProvider) {
+    constructor(abstractionName, walletOrProvider) {
         // if (!_isCalledFromFactory) {
         //     console.warn('WARNING: Calling NahmiiContract constructor directly is deprecated and will be removed.');
         //     console.warn('         Use factory function NahmiiContract.from() instead.');
         // }
 
         const provider = walletOrProvider.provider || walletOrProvider;
-        const deployment = contractAbstractions.get(provider.network.name, contractName);
+        const deployment = contractAbstractions.get(provider.network.name, abstractionName);
         const address = deployment.networks[provider.network.chainId].address;
 
         super(address, deployment.abi, walletOrProvider);
 
         _provider.set(this, provider);
-        _contractName.set(this, contractName);
+        _contractName.set(this, abstractionName);
     }
 
     async validate() {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "ethereumjs-util": "^6.1.0",
     "lodash.get": "^4.4.2",
     "nahmii-contract-abstractions": "2.2.0",
-    "nahmii-contract-abstractions-ropsten": "3.2.2",
+    "nahmii-contract-abstractions-ropsten": "3.2.3",
     "socket.io-client": "^2.2.0",
     "superagent": "^5.1.3",
     "uuid": "^3.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nahmii-sdk",
-  "version": "4.4.1",
+  "version": "4.5.0",
   "description": "Javascript SDK for using hubii nahmii APIs",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Description
<!-- Enter a description of what this PR changes -->
This PR enables the support of claiming fees from multiple instances of `TokenHolderRevenueFund` whose contract abstractions are all stored in one version of nahmii contract abstractions package.

### Issues
<!-- Enter references to relevant github issues -->
Issues: #157

### Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

### Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] The [Contribution Guidelines][1] has been followed
- [x] Tests for the changes have been added and all test pass (`npm test`)
- [x] JSDoc comments have been reviewed and added / updated as needed
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures
- [x] Package version number was updated according to semantic rules
- [x] Any changes to upstream dependencies have already been published

[1]: https://github.com/hubiinetwork/nahmii-sdk#contributing
