### PR TITLE
Logics of spanning configuration of TokenHolderRevenueFundContractEnsemble

### DIFF
--- a/Docs/fees-claimant.md
+++ b/Docs/fees-claimant.md
@@ -7,17 +7,17 @@ A class for the claiming and withdrawal of accrued fees
 **Kind**: global class  
 
 * [FeesClaimant](#module_nahmii-sdk)
-    * [.claimableAccruals(wallet, currency, [startAccrual], [endAccrual])](#module_nahmii-sdk+claimableAccruals) ⇒ <code>Promise</code>
-    * [.claimableFeesForAccruals(wallet, currency, startAccrual, endAccrual)](#module_nahmii-sdk+claimableFeesForAccruals) ⇒ <code>Promise</code>
-    * [.claimFeesForAccruals(wallet, currency, startAccrual, endAccrual, [options])](#module_nahmii-sdk+claimFeesForAccruals) ⇒ <code>Promise</code>
-    * [.claimableFeesForBlocks(wallet, currency, startBlock, endBlock)](#module_nahmii-sdk+claimableFeesForBlocks) ⇒ <code>Promise</code>
-    * [.claimFeesForBlocks(wallet, currency, startBlock, endBlock, [options])](#module_nahmii-sdk+claimFeesForBlocks) ⇒ <code>Promise</code>
+    * [.claimableAccruals(wallet, currency, [firstAccrual], [lastAccrual])](#module_nahmii-sdk+claimableAccruals) ⇒ <code>Promise</code>
+    * [.claimableFeesForAccruals(wallet, currency, firstAccrual, lastAccrual)](#module_nahmii-sdk+claimableFeesForAccruals) ⇒ <code>Promise</code>
+    * [.claimFeesForAccruals(wallet, currency, firstAccrual, lastAccrual, [options])](#module_nahmii-sdk+claimFeesForAccruals) ⇒ <code>Promise</code>
+    * [.claimableFeesForBlocks(wallet, currency, firstBlock, lastBlock)](#module_nahmii-sdk+claimableFeesForBlocks) ⇒ <code>Promise</code>
+    * [.claimFeesForBlocks(wallet, currency, firstBlock, lastBlock, [options])](#module_nahmii-sdk+claimFeesForBlocks) ⇒ <code>Promise</code>
     * [.withdrawableFees(wallet, currency)](#module_nahmii-sdk+withdrawableFees) ⇒ <code>Promise</code>
     * [.withdrawFees(wallet, monetaryAmount, [options])](#module_nahmii-sdk+withdrawFees) ⇒ <code>Promise</code>
 
 <a name="module_nahmii-sdk+claimableAccruals"></a>
 
-### feesClaimant.claimableAccruals(wallet, currency, [startAccrual], [endAccrual]) ⇒ <code>Promise</code>
+### feesClaimant.claimableAccruals(wallet, currency, [firstAccrual], [lastAccrual]) ⇒ <code>Promise</code>
 Get claimable accruals
 
 **Kind**: instance method of [<code>FeesClaimant</code>](#module_nahmii-sdk)  
@@ -27,27 +27,27 @@ Get claimable accruals
 | --- | --- | --- |
 | wallet | <code>Wallet</code> | The claimer nahmii wallet |
 | currency | <code>Currency</code> | The currency |
-| [startAccrual] | <code>number</code> | An optional lower accrual index boundary |
-| [endAccrual] | <code>number</code> | An optional upper accrual index boundary |
+| [firstAccrual] | <code>number</code> | An optional lower accrual index boundary |
+| [lastAccrual] | <code>number</code> | An optional upper accrual index boundary |
 
 <a name="module_nahmii-sdk+claimableFeesForAccruals"></a>
 
-### feesClaimant.claimableFeesForAccruals(wallet, currency, startAccrual, endAccrual) ⇒ <code>Promise</code>
+### feesClaimant.claimableFeesForAccruals(wallet, currency, firstAccrual, lastAccrual) ⇒ <code>Promise</code>
 Get claimable amount of fees for a span of accruals
 
 **Kind**: instance method of [<code>FeesClaimant</code>](#module_nahmii-sdk)  
-**Returns**: <code>Promise</code> - A promise that resolves into a BigNumber value representing the claimable amount of fees.  
+**Returns**: <code>Promise</code> - A promise that resolves into a string value representing the claimable amount of fees.  
 
 | Param | Type | Description |
 | --- | --- | --- |
 | wallet | <code>Wallet</code> | The claimer nahmii wallet |
 | currency | <code>Currency</code> | The currency |
-| startAccrual | <code>number</code> | The lower accrual index boundary |
-| endAccrual | <code>number</code> | The upper accrual index boundary |
+| firstAccrual | <code>number</code> | The lower accrual index boundary |
+| lastAccrual | <code>number</code> | The upper accrual index boundary |
 
 <a name="module_nahmii-sdk+claimFeesForAccruals"></a>
 
-### feesClaimant.claimFeesForAccruals(wallet, currency, startAccrual, endAccrual, [options]) ⇒ <code>Promise</code>
+### feesClaimant.claimFeesForAccruals(wallet, currency, firstAccrual, lastAccrual, [options]) ⇒ <code>Promise</code>
 Claim fees for a span of accruals
 
 **Kind**: instance method of [<code>FeesClaimant</code>](#module_nahmii-sdk)  
@@ -57,28 +57,28 @@ Claim fees for a span of accruals
 | --- | --- | --- |
 | wallet | <code>Wallet</code> | The claimer nahmii wallet |
 | currency | <code>Currency</code> | The currency |
-| startAccrual | <code>number</code> | The lower accrual index boundary |
-| endAccrual | <code>number</code> | The upper accrual index boundary |
+| firstAccrual | <code>number</code> | The lower accrual index boundary |
+| lastAccrual | <code>number</code> | The upper accrual index boundary |
 | [options] |  | An optional object containing the parameters for gasLimit and gasPrice |
 
 <a name="module_nahmii-sdk+claimableFeesForBlocks"></a>
 
-### feesClaimant.claimableFeesForBlocks(wallet, currency, startBlock, endBlock) ⇒ <code>Promise</code>
+### feesClaimant.claimableFeesForBlocks(wallet, currency, firstBlock, lastBlock) ⇒ <code>Promise</code>
 Get claimable amount of fees for a span of block numbers
 
 **Kind**: instance method of [<code>FeesClaimant</code>](#module_nahmii-sdk)  
-**Returns**: <code>Promise</code> - A promise that resolves into a BigNumber value representing the claimable amount of fees.  
+**Returns**: <code>Promise</code> - A promise that resolves into a string value representing the claimable amount of fees.  
 
 | Param | Type | Description |
 | --- | --- | --- |
 | wallet | <code>Wallet</code> | The claimer nahmii wallet |
 | currency | <code>Currency</code> | The currency |
-| startBlock | <code>number</code> | The lower block number boundary |
-| endBlock | <code>number</code> | The upper block number boundary |
+| firstBlock | <code>number</code> | The lower block number boundary |
+| lastBlock | <code>number</code> | The upper block number boundary |
 
 <a name="module_nahmii-sdk+claimFeesForBlocks"></a>
 
-### feesClaimant.claimFeesForBlocks(wallet, currency, startBlock, endBlock, [options]) ⇒ <code>Promise</code>
+### feesClaimant.claimFeesForBlocks(wallet, currency, firstBlock, lastBlock, [options]) ⇒ <code>Promise</code>
 Claim fees for a span of block numbers
 
 **Kind**: instance method of [<code>FeesClaimant</code>](#module_nahmii-sdk)  
@@ -88,8 +88,8 @@ Claim fees for a span of block numbers
 | --- | --- | --- |
 | wallet | <code>Wallet</code> | The claimer nahmii wallet |
 | currency | <code>Currency</code> | The currency |
-| startBlock | <code>number</code> | The lower block number boundary |
-| endBlock | <code>number</code> | The upper block number boundary |
+| firstBlock | <code>number</code> | The lower block number boundary |
+| lastBlock | <code>number</code> | The upper block number boundary |
 | [options] |  | An optional object containing the parameters for gasLimit and gasPrice |
 
 <a name="module_nahmii-sdk+withdrawableFees"></a>
@@ -98,7 +98,7 @@ Claim fees for a span of block numbers
 Get the withdrawable amount of fees
 
 **Kind**: instance method of [<code>FeesClaimant</code>](#module_nahmii-sdk)  
-**Returns**: <code>Promise</code> - A promise that resolves into a BigNumber value representing the withdrawable amount of fees.  
+**Returns**: <code>Promise</code> - A promise that resolves into a string value representing the withdrawable amount of fees.  
 
 | Param | Type | Description |
 | --- | --- | --- |

--- a/Docs/nahmii-contract.md
+++ b/Docs/nahmii-contract.md
@@ -4,7 +4,7 @@
 
 * [nahmii-sdk](#module_nahmii-sdk)
     * [NahmiiContract](#exp_module_nahmii-sdk--NahmiiContract) ⏏
-        * [new NahmiiContract(contractName, walletOrProvider)](#new_module_nahmii-sdk--NahmiiContract_new)
+        * [new NahmiiContract(abstractionName, walletOrProvider)](#new_module_nahmii-sdk--NahmiiContract_new)
         * [.from(contractName, walletOrProvider)](#module_nahmii-sdk--NahmiiContract.from) ⇒ <code>NahmiiContract</code> \| <code>null</code>
 
 <a name="exp_module_nahmii-sdk--NahmiiContract"></a>
@@ -18,7 +18,7 @@ officially in use by the nahmii cluster, use the `validate()` method.
 **Kind**: Exported class  
 <a name="new_module_nahmii-sdk--NahmiiContract_new"></a>
 
-#### new NahmiiContract(contractName, walletOrProvider)
+#### new NahmiiContract(abstractionName, walletOrProvider)
 (Deprecated) Constructs a new contract wrapper instance by loading the correct ABIs
 based on the name of the contract and the network that the provider or
 wallet is connected to.
@@ -26,7 +26,7 @@ wallet is connected to.
 
 | Param | Type | Description |
 | --- | --- | --- |
-| contractName | <code>string</code> | Name of the nahmii contract to load |
+| abstractionName | <code>string</code> | Name of the nahmii contract to load |
 | walletOrProvider | <code>NahmiiProvider</code> \| <code>Wallet</code> | Wallet or provider connected to nahmii cluster |
 
 **Example**  

--- a/lib/claim/fees-claimant.js
+++ b/lib/claim/fees-claimant.js
@@ -2,8 +2,10 @@
 
 const TokenHolderRevenueFundContractsEnsemble = require('./token-holder-revenue-fund-contracts-ensemble');
 const NestedError = require('../nested-error');
+const {ethers: {utils: {formatUnits}}} = require('ethers');
 
 const _tokenHolderRevenueFundContractEnsemble = new WeakMap();
+const _provider = new WeakMap();
 
 /**
  * @class FeesClaimant
@@ -15,6 +17,7 @@ class FeesClaimant {
         _tokenHolderRevenueFundContractEnsemble.set(
             this, new TokenHolderRevenueFundContractsEnsemble(provider, abstractionNames)
         );
+        _provider.set(this, provider);
     }
 
     /**
@@ -55,13 +58,19 @@ class FeesClaimant {
      * @param {Currency} currency - The currency
      * @param {number} firstAccrual - The lower accrual index boundary
      * @param {number} lastAccrual - The upper accrual index boundary
-     * @returns {Promise} A promise that resolves into a BigNumber value representing the claimable amount of fees.
+     * @returns {Promise} A promise that resolves into a string value representing the claimable amount of fees.
      */
     async claimableFeesForAccruals(wallet, currency, firstAccrual, lastAccrual) {
         const ensemble = _tokenHolderRevenueFundContractEnsemble.get(this);
-        return ensemble.claimableAmountByAccruals(
+        const provider = _provider.get(this);
+
+        const claimableAmount = await ensemble.claimableAmountByAccruals(
             wallet, currency, firstAccrual, lastAccrual
         );
+
+        const tokenInfo = await provider.getTokenInfo(currency.ct.toString(), true);
+
+        return tokenInfo ? formatUnits(claimableAmount, tokenInfo.decimals) : claimableAmount.toString();
     }
 
     /**
@@ -92,13 +101,19 @@ class FeesClaimant {
      * @param {Currency} currency - The currency
      * @param {number} firstBlock - The lower block number boundary
      * @param {number} lastBlock - The upper block number boundary
-     * @returns {Promise} A promise that resolves into a BigNumber value representing the claimable amount of fees.
+     * @returns {Promise} A promise that resolves into a string value representing the claimable amount of fees.
      */
     async claimableFeesForBlocks(wallet, currency, firstBlock, lastBlock) {
         const ensemble = _tokenHolderRevenueFundContractEnsemble.get(this);
-        return ensemble.claimableAmountByBlockNumbers(
+        const provider = _provider.get(this);
+
+        const claimableAmount = await ensemble.claimableAmountByBlockNumbers(
             wallet, currency, firstBlock, lastBlock
         );
+
+        const tokenInfo = await provider.getTokenInfo(currency.ct.toString(), true);
+
+        return tokenInfo ? formatUnits(claimableAmount, tokenInfo.decimals) : claimableAmount.toString();
     }
 
     /**
@@ -127,11 +142,17 @@ class FeesClaimant {
      * Get the withdrawable amount of fees
      * @param {Wallet} wallet - The claimer nahmii wallet
      * @param {Currency} currency - The currency
-     * @returns {Promise} A promise that resolves into a BigNumber value representing the withdrawable amount of fees.
+     * @returns {Promise} A promise that resolves into a string value representing the withdrawable amount of fees.
      */
     async withdrawableFees(wallet, currency) {
         const ensemble = _tokenHolderRevenueFundContractEnsemble.get(this);
-        return ensemble.stagedBalance(wallet, currency);
+        const provider = _provider.get(this);
+
+        const withdrawableFees = await ensemble.stagedBalance(wallet, currency);
+
+        const tokenInfo = await provider.getTokenInfo(currency.ct.toString(), true);
+
+        return tokenInfo ? formatUnits(withdrawableFees, tokenInfo.decimals) : withdrawableFees.toString();
     }
 
     /**

--- a/lib/claim/fees-claimant.js
+++ b/lib/claim/fees-claimant.js
@@ -7,6 +7,10 @@ const {ethers: {utils: {formatUnits}}} = require('ethers');
 const _tokenHolderRevenueFundContractEnsemble = new WeakMap();
 const _provider = new WeakMap();
 
+async function getTokenInfo(currency) {
+    return _provider.get(this).getTokenInfo(currency.ct.toString(), true);
+}
+
 /**
  * @class FeesClaimant
  * A class for the claiming and withdrawal of accrued fees
@@ -62,13 +66,12 @@ class FeesClaimant {
      */
     async claimableFeesForAccruals(wallet, currency, firstAccrual, lastAccrual) {
         const ensemble = _tokenHolderRevenueFundContractEnsemble.get(this);
-        const provider = _provider.get(this);
 
         const claimableAmount = await ensemble.claimableAmountByAccruals(
             wallet, currency, firstAccrual, lastAccrual
         );
 
-        const tokenInfo = await provider.getTokenInfo(currency.ct.toString(), true);
+        const tokenInfo = await getTokenInfo.call(this, currency);
 
         return tokenInfo ? formatUnits(claimableAmount, tokenInfo.decimals) : claimableAmount.toString();
     }
@@ -105,13 +108,12 @@ class FeesClaimant {
      */
     async claimableFeesForBlocks(wallet, currency, firstBlock, lastBlock) {
         const ensemble = _tokenHolderRevenueFundContractEnsemble.get(this);
-        const provider = _provider.get(this);
 
         const claimableAmount = await ensemble.claimableAmountByBlockNumbers(
             wallet, currency, firstBlock, lastBlock
         );
 
-        const tokenInfo = await provider.getTokenInfo(currency.ct.toString(), true);
+        const tokenInfo = await getTokenInfo.call(this, currency);
 
         return tokenInfo ? formatUnits(claimableAmount, tokenInfo.decimals) : claimableAmount.toString();
     }
@@ -146,11 +148,10 @@ class FeesClaimant {
      */
     async withdrawableFees(wallet, currency) {
         const ensemble = _tokenHolderRevenueFundContractEnsemble.get(this);
-        const provider = _provider.get(this);
 
         const withdrawableFees = await ensemble.stagedBalance(wallet, currency);
 
-        const tokenInfo = await provider.getTokenInfo(currency.ct.toString(), true);
+        const tokenInfo = await getTokenInfo.call(this, currency);
 
         return tokenInfo ? formatUnits(withdrawableFees, tokenInfo.decimals) : withdrawableFees.toString();
     }

--- a/lib/claim/fees-claimant.spec.js
+++ b/lib/claim/fees-claimant.spec.js
@@ -14,7 +14,7 @@ chai.use(require('chai-as-promised'));
 chai.should();
 
 describe('Fees claimant', () => {
-    let wallet, currency;
+    let wallet, currency, tokenInfo;
     let stubbedProvider;
     let stubbedTokenHolderRevenueFundContractEnsembleConstructor;
     let stubbedTokenHolderRevenueFundContractEnsemble;
@@ -27,10 +27,15 @@ describe('Fees claimant', () => {
             ct: EthereumAddress.from('0x0000000000000000000000000000000000000002'),
             id: 0
         });
+        tokenInfo = {
+            decimals: 15
+        };
     });
 
     beforeEach(() => {
-        stubbedProvider = {};
+        stubbedProvider = {
+            getTokenInfo: sinon.stub().returns(tokenInfo)
+        };
         stubbedTokenHolderRevenueFundContractEnsemble = {
             closedAccrualsCount: sinon.stub(),
             fullyClaimed: sinon.stub(),
@@ -113,12 +118,25 @@ describe('Fees claimant', () => {
             lastAccrual = 2;
             stubbedTokenHolderRevenueFundContractEnsemble.claimableAmountByAccruals
                 .withArgs(wallet, currency, firstAccrual, lastAccrual)
-                .resolves(1000);
+                .resolves(ethers.utils.parseUnits('1000', tokenInfo.decimals));
         });
 
-        it('should return the fees claimable by accruals', async () => {
-            (await feesClaimant.claimableFeesForAccruals(wallet, currency, firstAccrual, lastAccrual))
-                .should.equal(1000);
+        describe('when token info exists', () => {
+            it('should return the formatted fees claimable by accruals', async () => {
+                (await feesClaimant.claimableFeesForAccruals(wallet, currency, firstAccrual, lastAccrual))
+                    .should.equal('1000.0');
+            });
+        });
+
+        describe('when token info does not exist', () => {
+            beforeEach(() => {
+                stubbedProvider.getTokenInfo.reset();
+            });
+
+            it('should return the raw fees claimable by accruals', async () => {
+                (await feesClaimant.claimableFeesForAccruals(wallet, currency, firstAccrual, lastAccrual))
+                    .should.equal('1000000000000000000');
+            });
         });
     });
 
@@ -168,12 +186,25 @@ describe('Fees claimant', () => {
             lastBlock = 2000000;
             stubbedTokenHolderRevenueFundContractEnsemble.claimableAmountByBlockNumbers
                 .withArgs(wallet, currency, firstBlock, lastBlock)
-                .resolves(1000);
+                .resolves(ethers.utils.parseUnits('1000', tokenInfo.decimals));
         });
 
-        it('should return the fees claimable by blocks', async () => {
-            (await feesClaimant.claimableFeesForBlocks(wallet, currency, firstBlock, lastBlock))
-                .should.equal(1000);
+        describe('when token info exists', () => {
+            it('should return the formatted fees claimable by blocks', async () => {
+                (await feesClaimant.claimableFeesForBlocks(wallet, currency, firstBlock, lastBlock))
+                    .should.equal('1000.0');
+            });
+        });
+
+        describe('when token info does not exist', () => {
+            beforeEach(() => {
+                stubbedProvider.getTokenInfo.reset();
+            });
+
+            it('should return the raw fees claimable by blocks', async () => {
+                (await feesClaimant.claimableFeesForBlocks(wallet, currency, firstBlock, lastBlock))
+                    .should.equal('1000000000000000000');
+            });
         });
     });
 
@@ -221,12 +252,25 @@ describe('Fees claimant', () => {
             feesClaimant = new FeesClaimant(stubbedProvider);
             stubbedTokenHolderRevenueFundContractEnsemble.stagedBalance
                 .withArgs(wallet, currency)
-                .resolves(1000);
+                .resolves(ethers.utils.parseUnits('1000', tokenInfo.decimals));
         });
 
-        it('should return the claimable amount by accruals', async () => {
-            (await feesClaimant.withdrawableFees(wallet, currency))
-                .should.equal(1000);
+        describe('when token info exists', () => {
+            it('should return the formatted withdrawable amount', async () => {
+                (await feesClaimant.withdrawableFees(wallet, currency))
+                    .should.equal('1000.0');
+            });
+        });
+
+        describe('when token info does not exist', () => {
+            beforeEach(() => {
+                stubbedProvider.getTokenInfo.reset();
+            });
+
+            it('should return the raw fees claimable by blocks', async () => {
+                (await feesClaimant.withdrawableFees(wallet, currency))
+                    .should.equal('1000000000000000000');
+            });
         });
     });
 

--- a/lib/claim/token-holder-revenue-fund-contracts-ensemble.js
+++ b/lib/claim/token-holder-revenue-fund-contracts-ensemble.js
@@ -34,6 +34,7 @@ async function span(currency) {
         const firstBlock = (await configuration.contract.closedAccrualsByCurrency(
             currency.ct.toString(), currency.id, 0
         )).startBlock.toNumber();
+
         const lastBlock = (await configuration.contract.closedAccrualsByCurrency(
             currency.ct.toString(), currency.id, closedAccrualsCount - 1
         )).endBlock.toNumber();
@@ -160,9 +161,6 @@ class TokenHolderRevenueFundContractsEnsemble {
         let claimableFees = bigNumberify(0);
 
         for (const configuration of configurations) {
-            if (!configuration.spansByCurrency || !configuration.spansByCurrency.has(currencyKey))
-                continue;
-
             const span = configuration.spansByCurrency.get(currencyKey);
 
             if (lastAccrual < span.firstAccrual || firstAccrual > span.lastAccrual)
@@ -203,9 +201,6 @@ class TokenHolderRevenueFundContractsEnsemble {
             const txs = [];
 
             for (const configuration of configurations) {
-                if (!configuration.spansByCurrency || !configuration.spansByCurrency.has(currencyKey))
-                    continue;
-
                 const span = configuration.spansByCurrency.get(currencyKey);
 
                 if (lastAccrual < span.firstAccrual || firstAccrual > span.lastAccrual)
@@ -250,9 +245,6 @@ class TokenHolderRevenueFundContractsEnsemble {
         let claimableFees = bigNumberify(0);
 
         for (const configuration of configurations) {
-            if (!configuration.spansByCurrency || !configuration.spansByCurrency.has(currencyKey))
-                continue;
-
             const span = configuration.spansByCurrency.get(currencyKey);
 
             if (lastBlock < span.firstBlock || firstBlock > span.lastBlock)
@@ -293,9 +285,6 @@ class TokenHolderRevenueFundContractsEnsemble {
             const txs = [];
 
             for (const configuration of configurations) {
-                if (!configuration.spansByCurrency || !configuration.spansByCurrency.has(currencyKey))
-                    continue;
-
                 const span = configuration.spansByCurrency.get(currencyKey);
 
                 if (lastBlock < span.firstBlock || firstBlock > span.lastBlock)

--- a/lib/claim/token-holder-revenue-fund-contracts-ensemble.js
+++ b/lib/claim/token-holder-revenue-fund-contracts-ensemble.js
@@ -4,7 +4,7 @@ const {utils: {bigNumberify}} = require('ethers');
 const TokenHolderRevenueFundContract = require('./token-holder-revenue-fund-contract');
 const NestedError = require('../nested-error');
 
-const _ensemble = new WeakMap();
+const _configurations = new WeakMap();
 const _firstAccrualOffset = new WeakMap();
 
 const currencyToKey = (currency) => `${currency.ct.toString()}-${currency.id}`;
@@ -18,33 +18,41 @@ const minBigNumber = (n1, n2) => n1.lt(n2) ? n1 : n2;
  * @param {Currency} currency - The currency
  */
 async function span(currency) {
-    const ensemble = _ensemble.get(this);
-    let globalAccrualOffset = _firstAccrualOffset.get(this);
+    const configurations = _configurations.get(this);
+    let accrualOffset = _firstAccrualOffset.get(this);
+    let blockOffset = 0;
     const currencyKey = currencyToKey(currency);
 
-    for (const configuration of ensemble) {
+    for (const configuration of configurations) {
         const closedAccrualsCount = (await configuration.contract.closedAccrualsCount(
             currency.ct.toString(), currency.id
         )).toNumber();
 
-        const span = {};
-        span.firstAccrual = globalAccrualOffset || 0;
-        span.lastAccrual = span.firstAccrual + closedAccrualsCount - 1;
-        span.firstBlock =
-            (await configuration.contract.closedAccrualsByCurrency(
-                currency.ct.toString(), currency.id, span.firstAccrual
-            )).startBlock.toNumber();
-        span.lastBlock =
-            (await configuration.contract.closedAccrualsByCurrency(
-                currency.ct.toString(), currency.id, span.lastAccrual
-            )).endBlock.toNumber();
+        if (0 === closedAccrualsCount)
+            continue;
+
+        const firstBlock = (await configuration.contract.closedAccrualsByCurrency(
+            currency.ct.toString(), currency.id, 0
+        )).startBlock.toNumber();
+        const lastBlock = (await configuration.contract.closedAccrualsByCurrency(
+            currency.ct.toString(), currency.id, closedAccrualsCount - 1
+        )).endBlock.toNumber();
+
+        const span = {
+            closedAccrualsCount,
+            firstAccrual: accrualOffset,
+            lastAccrual: accrualOffset + closedAccrualsCount - 1,
+            firstBlock: Math.max(blockOffset, firstBlock),
+            lastBlock
+        };
 
         if (!configuration.spansByCurrency)
             configuration.spansByCurrency = new Map();
 
         configuration.spansByCurrency.set(currencyKey, span);
 
-        globalAccrualOffset = span.lastAccrual + 1;
+        accrualOffset = span.lastAccrual + 1;
+        blockOffset = span.lastBlock + 1;
     }
 }
 
@@ -55,8 +63,8 @@ async function span(currency) {
  * @returns {boolean} True if span has been executed, else false
  */
 function isSpanned(currency) {
-    return _ensemble.get(this).every(
-        conf => conf.spansByCurrency && conf.spansByCurrency.has(currencyToKey(currency))
+    return _configurations.get(this).every(
+        configuration => configuration.spansByCurrency && configuration.spansByCurrency.has(currencyToKey(currency))
     );
 }
 
@@ -73,7 +81,7 @@ class TokenHolderRevenueFundContractsEnsemble {
      * to the ['TokenHolderRevenueFund'] which uses the latest contract instance only
      */
     constructor(walletOrProvider, abstractionNames = ['TokenHolderRevenueFund'], firstAccrualOffset = 0) {
-        _ensemble.set(this, abstractionNames.map(
+        _configurations.set(this, abstractionNames.map(
             abstractionName => ({contract: new TokenHolderRevenueFundContract(walletOrProvider, abstractionName)})
         ));
 
@@ -100,10 +108,10 @@ class TokenHolderRevenueFundContractsEnsemble {
         if (!isSpanned.call(this, currency))
             await span.call(this, currency);
 
-        const ensemble = _ensemble.get(this);
+        const configurations = _configurations.get(this);
         const currencyKey = currencyToKey(currency);
 
-        for (const configuration of ensemble) {
+        for (const configuration of configurations) {
             const span = configuration.spansByCurrency.get(currencyKey);
             if (span.firstAccrual <= accrual && accrual <= span.lastAccrual) {
                 return configuration.contract.fullyClaimed(
@@ -121,9 +129,9 @@ class TokenHolderRevenueFundContractsEnsemble {
      * @returns {Promise} A promise that resolves into the count of closed accruals
      */
     async closedAccrualsCount(currency) {
-        const ensemble = _ensemble.get(this);
+        const configurations = _configurations.get(this);
 
-        const count = (await Promise.all(ensemble.map(c => c.contract.closedAccrualsCount(
+        const count = (await Promise.all(configurations.map(c => c.contract.closedAccrualsCount(
             currency.ct.toString(), currency.id
         ))))
             .reduce((a, c) => a.add(c), bigNumberify(0));
@@ -146,12 +154,15 @@ class TokenHolderRevenueFundContractsEnsemble {
         if (!isSpanned.call(this, currency))
             await span.call(this, currency);
 
-        const ensemble = _ensemble.get(this);
+        const configurations = _configurations.get(this);
         const currencyKey = currencyToKey(currency);
 
         let claimableFees = bigNumberify(0);
 
-        for (const configuration of ensemble) {
+        for (const configuration of configurations) {
+            if (!configuration.spansByCurrency || !configuration.spansByCurrency.has(currencyKey))
+                continue;
+
             const span = configuration.spansByCurrency.get(currencyKey);
 
             if (lastAccrual < span.firstAccrual || firstAccrual > span.lastAccrual)
@@ -160,8 +171,8 @@ class TokenHolderRevenueFundContractsEnsemble {
             claimableFees = claimableFees.add(
                 await configuration.contract.claimableAmountByAccruals(
                     wallet.address, currency.ct.toString(), currency.id,
-                    Math.max(firstAccrual, span.firstAccrual),
-                    Math.min(lastAccrual, span.lastAccrual)
+                    Math.max(firstAccrual - span.firstAccrual, 0),
+                    Math.min(lastAccrual - span.firstAccrual, span.closedAccrualsCount - 1)
                 )
             );
         }
@@ -185,13 +196,16 @@ class TokenHolderRevenueFundContractsEnsemble {
         if (!isSpanned.call(this, currency))
             await span.call(this, currency);
 
-        const ensemble = _ensemble.get(this);
+        const configurations = _configurations.get(this);
         const currencyKey = currencyToKey(currency);
 
         try {
             const txs = [];
 
-            for (const configuration of ensemble) {
+            for (const configuration of configurations) {
+                if (!configuration.spansByCurrency || !configuration.spansByCurrency.has(currencyKey))
+                    continue;
+
                 const span = configuration.spansByCurrency.get(currencyKey);
 
                 if (lastAccrual < span.firstAccrual || firstAccrual > span.lastAccrual)
@@ -201,8 +215,8 @@ class TokenHolderRevenueFundContractsEnsemble {
                 txs.push(
                     await contract.claimAndStageByAccruals(
                         currency.ct.toString(), currency.id,
-                        Math.max(firstAccrual, span.firstAccrual),
-                        Math.min(lastAccrual, span.lastAccrual),
+                        Math.max(firstAccrual - span.firstAccrual, 0),
+                        Math.min(lastAccrual - span.firstAccrual, span.closedAccrualsCount - 1),
                         options
                     )
                 );
@@ -230,12 +244,15 @@ class TokenHolderRevenueFundContractsEnsemble {
         if (!isSpanned.call(this, currency))
             await span.call(this, currency);
 
-        const ensemble = _ensemble.get(this);
+        const configurations = _configurations.get(this);
         const currencyKey = currencyToKey(currency);
 
         let claimableFees = bigNumberify(0);
 
-        for (const configuration of ensemble) {
+        for (const configuration of configurations) {
+            if (!configuration.spansByCurrency || !configuration.spansByCurrency.has(currencyKey))
+                continue;
+
             const span = configuration.spansByCurrency.get(currencyKey);
 
             if (lastBlock < span.firstBlock || firstBlock > span.lastBlock)
@@ -269,13 +286,16 @@ class TokenHolderRevenueFundContractsEnsemble {
         if (!isSpanned.call(this, currency))
             await span.call(this, currency);
 
-        const ensemble = _ensemble.get(this);
+        const configurations = _configurations.get(this);
         const currencyKey = currencyToKey(currency);
 
         try {
             const txs = [];
 
-            for (const configuration of ensemble) {
+            for (const configuration of configurations) {
+                if (!configuration.spansByCurrency || !configuration.spansByCurrency.has(currencyKey))
+                    continue;
+
                 const span = configuration.spansByCurrency.get(currencyKey);
 
                 if (lastBlock < span.firstBlock || firstBlock > span.lastBlock)
@@ -306,9 +326,9 @@ class TokenHolderRevenueFundContractsEnsemble {
      * @returns {Promise} A promise that resolves into a BigNumber value representing the staged balance
      */
     async stagedBalance(wallet, currency) {
-        const ensemble = _ensemble.get(this);
+        const configurations = _configurations.get(this);
 
-        return (await Promise.all(ensemble.map(
+        return (await Promise.all(configurations.map(
             c => c.contract.stagedBalance(wallet.address, currency.ct.toString(), currency.id)
         )))
             .reduce((a, c) => a.add(c), bigNumberify(0));
@@ -330,14 +350,14 @@ class TokenHolderRevenueFundContractsEnsemble {
         if (stagedBalance.lt(monetaryAmount.amount))
             throw new Error(`Unable to withdraw more than ${stagedBalance.toString()}`);
 
-        const ensemble = _ensemble.get(this);
+        const configurations = _configurations.get(this);
 
         let amountDue = monetaryAmount.amount;
 
         try {
             const txs = [];
 
-            for (const configuration of ensemble) {
+            for (const configuration of configurations) {
                 const withdrawableFees = await configuration.contract.stagedBalance(
                     wallet.address, monetaryAmount.currency.ct.toString(), monetaryAmount.currency.id
                 );

--- a/lib/claim/token-holder-revenue-fund-contracts-ensemble.spec.js
+++ b/lib/claim/token-holder-revenue-fund-contracts-ensemble.spec.js
@@ -138,31 +138,20 @@ describe('TokenHolderRevenueFundContractsEnsemble', () => {
         });
     });
 
-    describe('closedAccrualsCount', () => {
-        let ensemble;
-
-        beforeEach(() => {
-            ensemble = new TokenHolderRevenueFundContractsEnsemble(fakeProvider, ['abstraction1', 'abstraction2']);
-        });
-
-        it('should return the value obtained from the spans combined', async () => {
-            expect((await ensemble.closedAccrualsCount(currency)).toNumber())
-                .to.be.eq(30);
-        });
-    });
-
     describe('fullyClaimed()', () => {
         let ensemble;
 
         beforeEach(() => {
             stubbedTokenHolderRevenueFundContract.closedAccrualsByCurrency
                 .withArgs(currency.ct.toString(), currency.id, 0)
+                .onFirstCall()
                 .returns(stubbedAccruals[0])
                 .withArgs(currency.ct.toString(), currency.id, 9)
                 .returns(stubbedAccruals[1])
-                .withArgs(currency.ct.toString(), currency.id, 10)
+                .withArgs(currency.ct.toString(), currency.id, 0)
+                .onSecondCall()
                 .returns(stubbedAccruals[2])
-                .withArgs(currency.ct.toString(), currency.id, 29)
+                .withArgs(currency.ct.toString(), currency.id, 19)
                 .returns(stubbedAccruals[3]);
 
             ensemble = new TokenHolderRevenueFundContractsEnsemble(fakeProvider, ['abstraction1', 'abstraction2']);
@@ -190,7 +179,6 @@ describe('TokenHolderRevenueFundContractsEnsemble', () => {
 
         describe('if there is no matching configuration contract', () => {
             beforeEach(() => {
-                stubbedTokenHolderRevenueFundContract.fullyClaimed.reset();
                 stubbedTokenHolderRevenueFundContract.fullyClaimed.throws();
             });
 
@@ -200,18 +188,33 @@ describe('TokenHolderRevenueFundContractsEnsemble', () => {
         });
     });
 
+    describe('closedAccrualsCount', () => {
+        let ensemble;
+
+        beforeEach(() => {
+            ensemble = new TokenHolderRevenueFundContractsEnsemble(fakeProvider, ['abstraction1', 'abstraction2']);
+        });
+
+        it('should return the value obtained from the spans combined', async () => {
+            expect((await ensemble.closedAccrualsCount(currency)).toNumber())
+                .to.be.eq(30);
+        });
+    });
+
     describe('claimableAmountByAccruals()', () => {
         let ensemble;
 
         beforeEach(() => {
             stubbedTokenHolderRevenueFundContract.closedAccrualsByCurrency
-                .withArgs(currency.ct.toString(), currency.id, 10)
+                .withArgs(currency.ct.toString(), currency.id, 0)
+                .onFirstCall()
                 .returns(stubbedAccruals[0])
-                .withArgs(currency.ct.toString(), currency.id, 19)
+                .withArgs(currency.ct.toString(), currency.id, 9)
                 .returns(stubbedAccruals[1])
-                .withArgs(currency.ct.toString(), currency.id, 20)
+                .withArgs(currency.ct.toString(), currency.id, 0)
+                .onSecondCall()
                 .returns(stubbedAccruals[2])
-                .withArgs(currency.ct.toString(), currency.id, 39)
+                .withArgs(currency.ct.toString(), currency.id, 19)
                 .returns(stubbedAccruals[3]);
 
             ensemble = new TokenHolderRevenueFundContractsEnsemble(
@@ -240,10 +243,10 @@ describe('TokenHolderRevenueFundContractsEnsemble', () => {
             });
         });
 
-        describe('if accrual arguments entirely fall within the span of one span', () => {
+        describe('if accrual arguments entirely fall within the scope of one span', () => {
             beforeEach(() => {
                 stubbedTokenHolderRevenueFundContract.claimableAmountByAccruals
-                    .withArgs(wallet.address, currency.ct.toString(), currency.id, 12, 17)
+                    .withArgs(wallet.address, currency.ct.toString(), currency.id, 2, 7)
                     .returns(utils.bigNumberify(10));
             });
 
@@ -253,13 +256,13 @@ describe('TokenHolderRevenueFundContractsEnsemble', () => {
             });
         });
 
-        describe('if accrual arguments fall within the span of two spans', () => {
+        describe('if accrual arguments fall within the scope of two spans', () => {
             beforeEach(() => {
                 stubbedTokenHolderRevenueFundContract.claimableAmountByAccruals
-                    .withArgs(wallet.address, currency.ct.toString(), currency.id, 12, 19)
+                    .withArgs(wallet.address, currency.ct.toString(), currency.id, 2, 9)
                     .returns(utils.bigNumberify(10));
                 stubbedTokenHolderRevenueFundContract.claimableAmountByAccruals
-                    .withArgs(wallet.address, currency.ct.toString(), currency.id, 20, 27)
+                    .withArgs(wallet.address, currency.ct.toString(), currency.id, 0, 7)
                     .returns(utils.bigNumberify(20));
             });
 
@@ -272,10 +275,10 @@ describe('TokenHolderRevenueFundContractsEnsemble', () => {
         describe('if accrual arguments wrap the span of two spans', () => {
             beforeEach(() => {
                 stubbedTokenHolderRevenueFundContract.claimableAmountByAccruals
-                    .withArgs(wallet.address, currency.ct.toString(), currency.id, 10, 19)
+                    .withArgs(wallet.address, currency.ct.toString(), currency.id, 0, 9)
                     .returns(utils.bigNumberify(10));
                 stubbedTokenHolderRevenueFundContract.claimableAmountByAccruals
-                    .withArgs(wallet.address, currency.ct.toString(), currency.id, 20, 39)
+                    .withArgs(wallet.address, currency.ct.toString(), currency.id, 0, 19)
                     .returns(utils.bigNumberify(20));
             });
 
@@ -291,13 +294,15 @@ describe('TokenHolderRevenueFundContractsEnsemble', () => {
 
         beforeEach(() => {
             stubbedTokenHolderRevenueFundContract.closedAccrualsByCurrency
-                .withArgs(currency.ct.toString(), currency.id, 10)
+                .withArgs(currency.ct.toString(), currency.id, 0)
+                .onFirstCall()
                 .returns(stubbedAccruals[0])
-                .withArgs(currency.ct.toString(), currency.id, 19)
+                .withArgs(currency.ct.toString(), currency.id, 9)
                 .returns(stubbedAccruals[1])
-                .withArgs(currency.ct.toString(), currency.id, 20)
+                .withArgs(currency.ct.toString(), currency.id, 0)
+                .onSecondCall()
                 .returns(stubbedAccruals[2])
-                .withArgs(currency.ct.toString(), currency.id, 39)
+                .withArgs(currency.ct.toString(), currency.id, 19)
                 .returns(stubbedAccruals[3]);
 
             ensemble = new TokenHolderRevenueFundContractsEnsemble(
@@ -325,10 +330,10 @@ describe('TokenHolderRevenueFundContractsEnsemble', () => {
             });
         });
 
-        describe('if accrual arguments entirely fall within the span of one span', () => {
+        describe('if accrual arguments entirely fall within the scope of one span', () => {
             beforeEach(() => {
                 stubbedTokenHolderRevenueFundContract.claimAndStageByAccruals
-                    .withArgs(currency.ct.toString(), currency.id, 12, 17)
+                    .withArgs(currency.ct.toString(), currency.id, 2, 7)
                     .returns(hashZero);
             });
 
@@ -338,13 +343,13 @@ describe('TokenHolderRevenueFundContractsEnsemble', () => {
             });
         });
 
-        describe('if accrual arguments fall within the span of two spans', () => {
+        describe('if accrual arguments fall within the scope of two spans', () => {
             beforeEach(() => {
                 stubbedTokenHolderRevenueFundContract.claimAndStageByAccruals
-                    .withArgs(currency.ct.toString(), currency.id, 12, 19)
+                    .withArgs(currency.ct.toString(), currency.id, 2, 9)
                     .returns(hashZero);
                 stubbedTokenHolderRevenueFundContract.claimAndStageByAccruals
-                    .withArgs(currency.ct.toString(), currency.id, 20, 27)
+                    .withArgs(currency.ct.toString(), currency.id, 0, 7)
                     .returns(hashOne);
             });
 
@@ -357,10 +362,10 @@ describe('TokenHolderRevenueFundContractsEnsemble', () => {
         describe('if accrual arguments wrap the span of two spans', () => {
             beforeEach(() => {
                 stubbedTokenHolderRevenueFundContract.claimAndStageByAccruals
-                    .withArgs(currency.ct.toString(), currency.id, 10, 19)
+                    .withArgs(currency.ct.toString(), currency.id, 0, 9)
                     .returns(hashZero);
                 stubbedTokenHolderRevenueFundContract.claimAndStageByAccruals
-                    .withArgs(currency.ct.toString(), currency.id, 20, 39)
+                    .withArgs(currency.ct.toString(), currency.id, 0, 19)
                     .returns(hashOne);
             });
 
@@ -375,10 +380,10 @@ describe('TokenHolderRevenueFundContractsEnsemble', () => {
                 stubbedTokenHolderRevenueFundContract.connect
                     .throws(new Error('Unable to connect'));
                 stubbedTokenHolderRevenueFundContract.claimAndStageByAccruals
-                    .withArgs(currency.ct.toString(), currency.id, 10, 19)
+                    .withArgs(currency.ct.toString(), currency.id, 0, 9)
                     .returns(hashZero);
                 stubbedTokenHolderRevenueFundContract.claimAndStageByAccruals
-                    .withArgs(currency.ct.toString(), currency.id, 20, 39)
+                    .withArgs(currency.ct.toString(), currency.id, 0, 19)
                     .returns(hashOne);
             });
 
@@ -391,10 +396,10 @@ describe('TokenHolderRevenueFundContractsEnsemble', () => {
         describe('if contract claim and stage throws', () => {
             beforeEach(() => {
                 stubbedTokenHolderRevenueFundContract.claimAndStageByAccruals
-                    .withArgs(currency.ct.toString(), currency.id, 10, 19)
+                    .withArgs(currency.ct.toString(), currency.id, 0, 9)
                     .returns(hashZero);
                 stubbedTokenHolderRevenueFundContract.claimAndStageByAccruals
-                    .withArgs(currency.ct.toString(), currency.id, 20, 39)
+                    .withArgs(currency.ct.toString(), currency.id, 0, 19)
                     .throws(new Error('Unable to claim and stage'));
             });
 
@@ -410,13 +415,15 @@ describe('TokenHolderRevenueFundContractsEnsemble', () => {
 
         beforeEach(() => {
             stubbedTokenHolderRevenueFundContract.closedAccrualsByCurrency
-                .withArgs(currency.ct.toString(), currency.id, 10)
+                .withArgs(currency.ct.toString(), currency.id, 0)
+                .onFirstCall()
                 .returns(stubbedAccruals[0])
-                .withArgs(currency.ct.toString(), currency.id, 19)
+                .withArgs(currency.ct.toString(), currency.id, 9)
                 .returns(stubbedAccruals[1])
-                .withArgs(currency.ct.toString(), currency.id, 20)
+                .withArgs(currency.ct.toString(), currency.id, 0)
+                .onSecondCall()
                 .returns(stubbedAccruals[2])
-                .withArgs(currency.ct.toString(), currency.id, 39)
+                .withArgs(currency.ct.toString(), currency.id, 19)
                 .returns(stubbedAccruals[3]);
 
             ensemble = new TokenHolderRevenueFundContractsEnsemble(
@@ -445,7 +452,7 @@ describe('TokenHolderRevenueFundContractsEnsemble', () => {
             });
         });
 
-        describe('if block arguments entirely fall within the span of one span', () => {
+        describe('if block arguments entirely fall within the scope of one span', () => {
             beforeEach(() => {
                 stubbedTokenHolderRevenueFundContract.claimableAmountByBlockNumbers
                     .withArgs(wallet.address, currency.ct.toString(), currency.id, 1200000, 1700000)
@@ -458,7 +465,7 @@ describe('TokenHolderRevenueFundContractsEnsemble', () => {
             });
         });
 
-        describe('if block arguments fall within the span of two spans', () => {
+        describe('if block arguments fall within the scope of two spans', () => {
             beforeEach(() => {
                 stubbedTokenHolderRevenueFundContract.claimableAmountByBlockNumbers
                     .withArgs(wallet.address, currency.ct.toString(), currency.id, 1200000, 2000000)
@@ -496,13 +503,15 @@ describe('TokenHolderRevenueFundContractsEnsemble', () => {
 
         beforeEach(() => {
             stubbedTokenHolderRevenueFundContract.closedAccrualsByCurrency
-                .withArgs(currency.ct.toString(), currency.id, 10)
+                .withArgs(currency.ct.toString(), currency.id, 0)
+                .onFirstCall()
                 .returns(stubbedAccruals[0])
-                .withArgs(currency.ct.toString(), currency.id, 19)
+                .withArgs(currency.ct.toString(), currency.id, 9)
                 .returns(stubbedAccruals[1])
-                .withArgs(currency.ct.toString(), currency.id, 20)
+                .withArgs(currency.ct.toString(), currency.id, 0)
+                .onSecondCall()
                 .returns(stubbedAccruals[2])
-                .withArgs(currency.ct.toString(), currency.id, 39)
+                .withArgs(currency.ct.toString(), currency.id, 19)
                 .returns(stubbedAccruals[3]);
 
             ensemble = new TokenHolderRevenueFundContractsEnsemble(
@@ -531,7 +540,7 @@ describe('TokenHolderRevenueFundContractsEnsemble', () => {
             });
         });
 
-        describe('if block arguments entirely fall within the span of one span', () => {
+        describe('if block arguments entirely fall within the scope of one span', () => {
             beforeEach(() => {
                 stubbedTokenHolderRevenueFundContract.claimAndStageByBlockNumbers
                     .withArgs(currency.ct.toString(), currency.id, 1200000, 1700000)
@@ -544,7 +553,7 @@ describe('TokenHolderRevenueFundContractsEnsemble', () => {
             });
         });
 
-        describe('if block arguments fall within the span of two spans', () => {
+        describe('if block arguments fall within the scope of two spans', () => {
             beforeEach(() => {
                 stubbedTokenHolderRevenueFundContract.claimAndStageByBlockNumbers
                     .withArgs(currency.ct.toString(), currency.id, 1200000, 2000000)
@@ -616,13 +625,15 @@ describe('TokenHolderRevenueFundContractsEnsemble', () => {
 
         beforeEach(() => {
             stubbedTokenHolderRevenueFundContract.closedAccrualsByCurrency
-                .withArgs(currency.ct.toString(), currency.id, 10)
+                .withArgs(currency.ct.toString(), currency.id, 0)
+                .onFirstCall()
                 .returns(stubbedAccruals[0])
-                .withArgs(currency.ct.toString(), currency.id, 19)
+                .withArgs(currency.ct.toString(), currency.id, 9)
                 .returns(stubbedAccruals[1])
-                .withArgs(currency.ct.toString(), currency.id, 20)
+                .withArgs(currency.ct.toString(), currency.id, 0)
+                .onSecondCall()
                 .returns(stubbedAccruals[2])
-                .withArgs(currency.ct.toString(), currency.id, 39)
+                .withArgs(currency.ct.toString(), currency.id, 19)
                 .returns(stubbedAccruals[3]);
             stubbedTokenHolderRevenueFundContract.stagedBalance
                 .withArgs(wallet.address, currency.ct.toString(), currency.id)
@@ -647,13 +658,15 @@ describe('TokenHolderRevenueFundContractsEnsemble', () => {
 
         beforeEach(() => {
             stubbedTokenHolderRevenueFundContract.closedAccrualsByCurrency
-                .withArgs(currency.ct.toString(), currency.id, 10)
+                .withArgs(currency.ct.toString(), currency.id, 0)
+                .onFirstCall()
                 .returns(stubbedAccruals[0])
-                .withArgs(currency.ct.toString(), currency.id, 19)
+                .withArgs(currency.ct.toString(), currency.id, 9)
                 .returns(stubbedAccruals[1])
-                .withArgs(currency.ct.toString(), currency.id, 20)
+                .withArgs(currency.ct.toString(), currency.id, 0)
+                .onSecondCall()
                 .returns(stubbedAccruals[2])
-                .withArgs(currency.ct.toString(), currency.id, 39)
+                .withArgs(currency.ct.toString(), currency.id, 19)
                 .returns(stubbedAccruals[3]);
             stubbedTokenHolderRevenueFundContract.stagedBalance
                 .withArgs(wallet.address, currency.ct.toString(), currency.id)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nahmii-sdk",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "description": "Javascript SDK for using hubii nahmii APIs",
   "main": "index.js",
   "scripts": {
@@ -67,7 +67,7 @@
     "ethereumjs-util": "^6.1.0",
     "lodash.get": "^4.4.2",
     "nahmii-contract-abstractions": "2.2.0",
-    "nahmii-contract-abstractions-ropsten": "3.2.3",
+    "nahmii-contract-abstractions-ropsten": "3.2.4",
     "socket.io-client": "^2.2.0",
     "superagent": "^5.1.3",
     "uuid": "^3.3.2",


### PR DESCRIPTION
### Description
<!-- Enter a description of what this PR changes -->
This PR corrects a few items in the spanning of configurations of `TokenHolderRevenueFundContract` instances. Also it adjusts the claimable and withdrawable fees output from functions of `FeesClaimant`.

### Issues
<!-- Enter references to relevant github issues -->

Issues: #157

### Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->



### Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] The [Contribution Guidelines][1] has been followed
- [x] Tests for the changes have been added and all test pass (`npm test`)
- [x] JSDoc comments have been reviewed and added / updated as needed
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures
- [x] Package version number was updated according to semantic rules
- [x] Any changes to upstream dependencies have already been published


[1]: https://github.com/hubiinetwork/nahmii-sdk#contributing
