### PR TITLE
Update the handling of revert error from go-ethereum

### DIFF
--- a/lib/settlement/utils.js
+++ b/lib/settlement/utils.js
@@ -5,11 +5,13 @@ const {EthereumAddress} = require('nahmii-ethereum-address');
 
 /**
  * Checks whether it is an expected revert contract exception.
- * @param {Error} error - error object thrown by ethers contract funcion call
+ * @param {Error} error - error object thrown by ethers contract function call
  * @returns {Boolean} True if it is revert exception thrown by the contract
  */
 function isRevertContractException(error) {
-    return error.code === 'CALL_EXCEPTION' || error.code === -32000;
+    return (error.message && error.message.toLowerCase().includes('revert')) || // TODO Seek a more generic (non-geth specific) solution
+        error.code === 'CALL_EXCEPTION' ||
+        error.code === -32000;
 }
 
 /**

--- a/lib/settlement/utils.spec.js
+++ b/lib/settlement/utils.spec.js
@@ -7,6 +7,7 @@ const ethers = require('ethers');
 const {EthereumAddress} = require('nahmii-ethereum-address');
 
 const {
+    isRevertContractException,
     determineNonceFromReceipt,
     determineBalanceFromReceipt
 } = require('./utils');
@@ -28,6 +29,36 @@ describe('settlement utils', () => {
             }
         }
     };
+    describe('#isRevertContractException()', () => {
+        describe('when exception is revert', () => {
+            [
+                {message: 'execution reverted: For some reason'},
+                {code: 'CALL_EXCEPTION'},
+                {code: -32000}
+            ].forEach(error => {
+                describe(JSON.stringify(error), () => {
+                    it('returns true', () => {
+                        const revert = isRevertContractException(error);
+                        revert.should.be.true;
+                    });
+                });
+            });
+        });
+        describe('when exception is not revert', () => {
+            it('throws', () => {
+                [
+                    {}
+                ].forEach(error => {
+                    describe(JSON.stringify(error), () => {
+                        it('returns false', () => {
+                            const revert = isRevertContractException(error);
+                            revert.should.be.false;
+                        });
+                    });
+                });
+            });
+        });
+    });
     describe('#determineNonceFromReceipt()', () => {
         describe('when address matches', () => {
             ['sender', 'recipient'].forEach(party => {
@@ -44,7 +75,7 @@ describe('settlement utils', () => {
                 try {
                     determineNonceFromReceipt(receipt, EthereumAddress.from('0x0000000000000000000000000000000000000003'));
                     true.should.equal(false, 'Previous statement should have thrown');
-                } 
+                }
                 catch (error) {
                     error.message.should.match(/address.*neither.*match/ig);
                 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nahmii-sdk",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "description": "Javascript SDK for using hubii nahmii APIs",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Description
<!-- Enter a description of what this PR changes -->
As of [go-ethereum-1.9.15](https://github.com/ethereum/go-ethereum/releases/tag/v1.9.15) the JSON-RPC contract method revert error response has been altered. This issue updates the handling of revert errors to support the new schema.

### Issues
<!-- Enter references to relevant github issues -->

Issues: 


### Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->



### Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] The [Contribution Guidelines][1] has been followed
- [x] Tests for the changes have been added and all test pass (`npm test`)
- [x] JSDoc comments have been reviewed and added / updated as needed
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures
- [x] Package version number was updated according to semantic rules
- [x] Any changes to upstream dependencies have already been published


[1]: https://github.com/hubiinetwork/nahmii-sdk#contributing
