### PR TITLE
Payment sender payload

### DIFF
--- a/Docs/payment.md
+++ b/Docs/payment.md
@@ -4,7 +4,7 @@
 
 * [nahmii-sdk](#module_nahmii-sdk)
     * [Payment](#exp_module_nahmii-sdk--Payment) ⏏
-        * [new Payment(amount, sender, recipient, [walletOrProvider], [senderPayload], [senderRef])](#new_module_nahmii-sdk--Payment_new)
+        * [new Payment(amount, sender, recipient, [walletOrProvider], [senderRef], [senderPayload])](#new_module_nahmii-sdk--Payment_new)
         * _instance_
             * [.amount](#module_nahmii-sdk--Payment+amount) ⇒ <code>MonetaryAmount</code>
             * [.sender](#module_nahmii-sdk--Payment+sender) ⇒ <code>Address</code>
@@ -30,7 +30,7 @@ supply a valid Wallet or NahmiiProvider instance.
 **Kind**: Exported class  
 <a name="new_module_nahmii-sdk--Payment_new"></a>
 
-#### new Payment(amount, sender, recipient, [walletOrProvider], [senderPayload], [senderRef])
+#### new Payment(amount, sender, recipient, [walletOrProvider], [senderRef], [senderPayload])
 Constructor
 Creates a new payment with a unique sender reference.
 
@@ -41,8 +41,8 @@ Creates a new payment with a unique sender reference.
 | sender | <code>Address</code> | Senders address |
 | recipient | <code>Address</code> | Recipient address |
 | [walletOrProvider] | <code>Wallet</code> \| <code>NahmiiProvider</code> | An optional Wallet or NahmiiProvider instance |
-| [senderPayload] | <code>String</code> | Optional stringified payment sender data payload |
 | [senderRef] | <code>String</code> | Optional uuid identifying the payment. Must be unique per sender wallet. Random if undefined. |
+| [senderPayload] | <code>String</code> | Optional stringified payment sender data payload |
 
 **Example**  
 ```js

--- a/Docs/payment.md
+++ b/Docs/payment.md
@@ -4,11 +4,12 @@
 
 * [nahmii-sdk](#module_nahmii-sdk)
     * [Payment](#exp_module_nahmii-sdk--Payment) ⏏
-        * [new Payment(amount, sender, recipient, [walletOrProvider], [senderRef])](#new_module_nahmii-sdk--Payment_new)
+        * [new Payment(amount, sender, recipient, [walletOrProvider], [senderPayload], [senderRef])](#new_module_nahmii-sdk--Payment_new)
         * _instance_
             * [.amount](#module_nahmii-sdk--Payment+amount) ⇒ <code>MonetaryAmount</code>
             * [.sender](#module_nahmii-sdk--Payment+sender) ⇒ <code>Address</code>
             * [.recipient](#module_nahmii-sdk--Payment+recipient) ⇒ <code>Address</code>
+            * [.senderPayload](#module_nahmii-sdk--Payment+senderPayload) ⇒ <code>string</code>
             * [.senderRef](#module_nahmii-sdk--Payment+senderRef) ⇒ <code>string</code>
             * [.sign()](#module_nahmii-sdk--Payment+sign)
             * [.isSigned()](#module_nahmii-sdk--Payment+isSigned) ⇒ <code>Boolean</code>
@@ -29,7 +30,7 @@ supply a valid Wallet or NahmiiProvider instance.
 **Kind**: Exported class  
 <a name="new_module_nahmii-sdk--Payment_new"></a>
 
-#### new Payment(amount, sender, recipient, [walletOrProvider], [senderRef])
+#### new Payment(amount, sender, recipient, [walletOrProvider], [senderPayload], [senderRef])
 Constructor
 Creates a new payment with a unique sender reference.
 
@@ -40,21 +41,29 @@ Creates a new payment with a unique sender reference.
 | sender | <code>Address</code> | Senders address |
 | recipient | <code>Address</code> | Recipient address |
 | [walletOrProvider] | <code>Wallet</code> \| <code>NahmiiProvider</code> | An optional Wallet or NahmiiProvider instance |
+| [senderPayload] | <code>String</code> | Optional stringified payment sender data payload |
 | [senderRef] | <code>String</code> | Optional uuid identifying the payment. Must be unique per sender wallet. Random if undefined. |
 
 **Example**  
 ```js
-// Normal, random sender reference
+// Normal, no sender payload and random sender reference
 const senderWallet = new nahmii.Wallet(...);
 const recipientWallet = new nahmii.Wallet(...);
 const paymentAmount = nahmii.MonetaryAmount.from(...);
 const payment = new nahmii.Payment(paymentAmount, senderWallet.address, recipientWallet.address, senderWallet);
 
-// Advanced, semantic sender reference. See: https://github.com/uuidjs/uuid
+// Advanced, sender payload and random sender reference
 const uuidNamespace = '706ac453-2691-41af-9fde-ac5f787da1ec';
 const paymentSubject = '...';
+const senderPayload = 'some sender payload';
+const payment = new nahmii.Payment(paymentAmount, senderWallet.address, recipientWallet.address, senderWallet, senderPayload);
+
+// Advanced, sender payload and semantic sender reference. See: https://github.com/uuidjs/uuid
+const uuidNamespace = '706ac453-2691-41af-9fde-ac5f787da1ec';
+const paymentSubject = '...';
+const senderPayload = 'some sender payload';
 const senderRef = uuidv5(paymentSubject, uuidNamespace);
-const payment = new nahmii.Payment(paymentAmount, senderWallet.address, recipientWallet.address, senderWallet, senderRef);
+const payment = new nahmii.Payment(paymentAmount, senderWallet.address, recipientWallet.address, senderWallet, senderPayload, senderRef);
 ```
 <a name="module_nahmii-sdk--Payment+amount"></a>
 
@@ -72,6 +81,12 @@ The sender of the payment
 
 #### payment.recipient ⇒ <code>Address</code>
 The recipient of the payment
+
+**Kind**: instance property of [<code>Payment</code>](#exp_module_nahmii-sdk--Payment)  
+<a name="module_nahmii-sdk--Payment+senderPayload"></a>
+
+#### payment.senderPayload ⇒ <code>string</code>
+The sender's payload for the payment.
 
 **Kind**: instance property of [<code>Payment</code>](#exp_module_nahmii-sdk--Payment)  
 <a name="module_nahmii-sdk--Payment+senderRef"></a>

--- a/Docs/payment.md
+++ b/Docs/payment.md
@@ -46,24 +46,21 @@ Creates a new payment with a unique sender reference.
 
 **Example**  
 ```js
-// Normal, no sender payload and random sender reference
+// Normal, random sender reference and no sender payload
 const senderWallet = new nahmii.Wallet(...);
 const recipientWallet = new nahmii.Wallet(...);
 const paymentAmount = nahmii.MonetaryAmount.from(...);
 const payment = new nahmii.Payment(paymentAmount, senderWallet.address, recipientWallet.address, senderWallet);
 
-// Advanced, sender payload and random sender reference
+// Advanced, semantic sender reference (https://github.com/uuidjs/uuid) and no sender payload
 const uuidNamespace = '706ac453-2691-41af-9fde-ac5f787da1ec';
 const paymentSubject = '...';
-const senderPayload = 'some sender payload';
-const payment = new nahmii.Payment(paymentAmount, senderWallet.address, recipientWallet.address, senderWallet, senderPayload);
-
-// Advanced, sender payload and semantic sender reference. See: https://github.com/uuidjs/uuid
-const uuidNamespace = '706ac453-2691-41af-9fde-ac5f787da1ec';
-const paymentSubject = '...';
-const senderPayload = 'some sender payload';
 const senderRef = uuidv5(paymentSubject, uuidNamespace);
-const payment = new nahmii.Payment(paymentAmount, senderWallet.address, recipientWallet.address, senderWallet, senderPayload, senderRef);
+const payment = new nahmii.Payment(paymentAmount, senderWallet.address, recipientWallet.address, senderWallet, senderRef);
+
+// Advanced, random sender reference and stringified sender payload
+const senderPayload = 'some sender payload';
+const payment = new nahmii.Payment(paymentAmount, senderWallet.address, recipientWallet.address, senderWallet, null, senderPayload);
 ```
 <a name="module_nahmii-sdk--Payment+amount"></a>
 

--- a/lib/payment.js
+++ b/lib/payment.js
@@ -58,8 +58,8 @@ class Payment {
      * @param {Address} sender - Senders address
      * @param {Address} recipient - Recipient address
      * @param {Wallet|NahmiiProvider} [walletOrProvider] - An optional Wallet or NahmiiProvider instance
-     * @param {String} [senderPayload] - Optional stringified payment sender data payload
      * @param {String} [senderRef] - Optional uuid identifying the payment. Must be unique per sender wallet. Random if undefined.
+     * @param {String} [senderPayload] - Optional stringified payment sender data payload
      *
      * @example
      * // Normal, random sender reference and no sender payload

--- a/lib/payment.js
+++ b/lib/payment.js
@@ -69,7 +69,6 @@ class Payment {
      * const payment = new nahmii.Payment(paymentAmount, senderWallet.address, recipientWallet.address, senderWallet);
      *
      * // Advanced, sender payload and random sender reference
-     * const uuidNamespace = '706ac453-2691-41af-9fde-ac5f787da1ec';
      * const paymentSubject = '...';
      * const senderPayload = 'some sender payload';
      * const payment = new nahmii.Payment(paymentAmount, senderWallet.address, recipientWallet.address, senderWallet, senderPayload);

--- a/lib/payment.js
+++ b/lib/payment.js
@@ -62,35 +62,33 @@ class Payment {
      * @param {String} [senderRef] - Optional uuid identifying the payment. Must be unique per sender wallet. Random if undefined.
      *
      * @example
-     * // Normal, no sender payload and random sender reference
+     * // Normal, random sender reference and no sender payload
      * const senderWallet = new nahmii.Wallet(...);
      * const recipientWallet = new nahmii.Wallet(...);
      * const paymentAmount = nahmii.MonetaryAmount.from(...);
      * const payment = new nahmii.Payment(paymentAmount, senderWallet.address, recipientWallet.address, senderWallet);
      *
-     * // Advanced, sender payload and random sender reference
-     * const paymentSubject = '...';
-     * const senderPayload = 'some sender payload';
-     * const payment = new nahmii.Payment(paymentAmount, senderWallet.address, recipientWallet.address, senderWallet, senderPayload);
-     *
-     * // Advanced, sender payload and semantic sender reference. See: https://github.com/uuidjs/uuid
+     * // Advanced, semantic sender reference (https://github.com/uuidjs/uuid) and no sender payload
      * const uuidNamespace = '706ac453-2691-41af-9fde-ac5f787da1ec';
      * const paymentSubject = '...';
-     * const senderPayload = 'some sender payload';
      * const senderRef = uuidv5(paymentSubject, uuidNamespace);
-     * const payment = new nahmii.Payment(paymentAmount, senderWallet.address, recipientWallet.address, senderWallet, senderPayload, senderRef);
+     * const payment = new nahmii.Payment(paymentAmount, senderWallet.address, recipientWallet.address, senderWallet, senderRef);
+     *
+     * // Advanced, random sender reference and stringified sender payload
+     * const senderPayload = 'some sender payload';
+     * const payment = new nahmii.Payment(paymentAmount, senderWallet.address, recipientWallet.address, senderWallet, null, senderPayload);
      */
-    constructor(amount, sender, recipient, walletOrProvider, senderPayload, senderRef) {
+    constructor(amount, sender, recipient, walletOrProvider, senderRef, senderPayload) {
         if (!(amount instanceof MonetaryAmount))
             throw new TypeError('amount is not an instance of MonetaryAmount');
-
-        if (undefined !== senderPayload && null !== senderPayload && 'string' !== typeof senderPayload)
-            throw new TypeError('senderPayload is not an instance of string');
 
         senderRef = senderRef || uuidv4();
 
         if (!/^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i.test(senderRef))
             throw new TypeError('senderRef is not a uuid string');
+
+        if (senderPayload && 'string' !== typeof senderPayload)
+            throw new TypeError('senderPayload is not an instance of string');
 
         const wallet = walletOrProvider instanceof Wallet ? walletOrProvider : null;
         const provider = wallet ? wallet.provider : walletOrProvider;
@@ -102,7 +100,7 @@ class Payment {
         _sender.set(this, sender);
         _recipient.set(this, recipient);
         _senderRef.set(this, senderRef);
-        if (undefined !== senderPayload && null !== senderPayload)
+        if (senderPayload)
             _senderPayload.set(this, senderPayload);
     }
 
@@ -252,7 +250,7 @@ class Payment {
             try {
                 const senderData = JSON.parse(jsonSenderData);
                 _senderRef.set(p, senderData.ref);
-                if (null !== senderData.payload && undefined !== senderData.payload)
+                if (senderData.payload)
                     _senderPayload.set(p, senderData.payload);
             }
             catch (e) {

--- a/lib/payment.js
+++ b/lib/payment.js
@@ -18,6 +18,7 @@ const _hash = new WeakMap();
 const _signature = new WeakMap();
 const _wallet = new WeakMap();
 const _provider = new WeakMap();
+const _senderPayload = new WeakMap();
 const _senderRef = new WeakMap();
 
 const PAYMENT_REQUEST_HASH_PARTS = [
@@ -57,24 +58,35 @@ class Payment {
      * @param {Address} sender - Senders address
      * @param {Address} recipient - Recipient address
      * @param {Wallet|NahmiiProvider} [walletOrProvider] - An optional Wallet or NahmiiProvider instance
+     * @param {String} [senderPayload] - Optional stringified payment sender data payload
      * @param {String} [senderRef] - Optional uuid identifying the payment. Must be unique per sender wallet. Random if undefined.
      *
      * @example
-     * // Normal, random sender reference
+     * // Normal, no sender payload and random sender reference
      * const senderWallet = new nahmii.Wallet(...);
      * const recipientWallet = new nahmii.Wallet(...);
      * const paymentAmount = nahmii.MonetaryAmount.from(...);
      * const payment = new nahmii.Payment(paymentAmount, senderWallet.address, recipientWallet.address, senderWallet);
      *
-     * // Advanced, semantic sender reference. See: https://github.com/uuidjs/uuid
+     * // Advanced, sender payload and random sender reference
      * const uuidNamespace = '706ac453-2691-41af-9fde-ac5f787da1ec';
      * const paymentSubject = '...';
+     * const senderPayload = 'some sender payload';
+     * const payment = new nahmii.Payment(paymentAmount, senderWallet.address, recipientWallet.address, senderWallet, senderPayload);
+     *
+     * // Advanced, sender payload and semantic sender reference. See: https://github.com/uuidjs/uuid
+     * const uuidNamespace = '706ac453-2691-41af-9fde-ac5f787da1ec';
+     * const paymentSubject = '...';
+     * const senderPayload = 'some sender payload';
      * const senderRef = uuidv5(paymentSubject, uuidNamespace);
-     * const payment = new nahmii.Payment(paymentAmount, senderWallet.address, recipientWallet.address, senderWallet, senderRef);
+     * const payment = new nahmii.Payment(paymentAmount, senderWallet.address, recipientWallet.address, senderWallet, senderPayload, senderRef);
      */
-    constructor(amount, sender, recipient, walletOrProvider, senderRef) {
+    constructor(amount, sender, recipient, walletOrProvider, senderPayload, senderRef) {
         if (!(amount instanceof MonetaryAmount))
             throw new TypeError('amount is not an instance of MonetaryAmount');
+
+        if (undefined !== senderPayload && null !== senderPayload && 'string' !== typeof senderPayload)
+            throw new TypeError('senderPayload is not an instance of string');
 
         senderRef = senderRef || uuidv4();
 
@@ -91,6 +103,8 @@ class Payment {
         _sender.set(this, sender);
         _recipient.set(this, recipient);
         _senderRef.set(this, senderRef);
+        if (undefined !== senderPayload && null !== senderPayload)
+            _senderPayload.set(this, senderPayload);
     }
 
     /**
@@ -115,6 +129,14 @@ class Payment {
      */
     get recipient() {
         return _recipient.get(this);
+    }
+
+    /**
+     * The sender's payload for the payment.
+     * @returns {string}
+     */
+    get senderPayload() {
+        return _senderPayload.get(this);
     }
 
     /**
@@ -183,9 +205,13 @@ class Payment {
      */
     toJSON() {
         const amount = _amount.get(this).toJSON();
+
         const senderData = {
             ref: _senderRef.get(this)
         };
+        if (_senderPayload.has(this))
+            senderData.payload = _senderPayload.get(this);
+
         const senderDataB64 = Buffer.from(JSON.stringify(senderData)).toString('base64');
 
         const result = Object.assign({}, amount, {
@@ -227,9 +253,11 @@ class Payment {
             try {
                 const senderData = JSON.parse(jsonSenderData);
                 _senderRef.set(p, senderData.ref);
+                if (null !== senderData.payload && undefined !== senderData.payload)
+                    _senderPayload.set(p, senderData.payload);
             }
             catch (e) {
-                // Ignore parse errors and leave the _senderRef undefined.
+                // Ignore parse errors and leave the _senderPayload and _senderRef undefined.
                 // TODO: Is there an exception safe alternative to JSON.parse?
             }
         }

--- a/lib/payment.spec.js
+++ b/lib/payment.spec.js
@@ -94,16 +94,16 @@ describe('Payment', () => {
             let payment;
 
             beforeEach(() => {
-                payment = new Payment(MonetaryAmount.from(fixture.amount, fixture.currency.ct, fixture.currency.id), fixture.sender, fixture.recipient, wallet, senderPayload);
+                payment = new Payment(MonetaryAmount.from(fixture.amount, fixture.currency.ct, fixture.currency.id), fixture.sender, fixture.recipient, wallet, null, senderPayload);
             });
 
             it('can be serialized to an object literal', () => {
-                expect(payment.toJSON()).to.eql(fixture.createUnsignedPayment(payment.senderPayload, payment.senderRef));
+                expect(payment.toJSON()).to.eql(fixture.createUnsignedPayment(payment.senderRef, payment.senderPayload));
             });
 
             it('can be signed', async () => {
                 await payment.sign();
-                expect(payment.toJSON()).to.eql(await fixture.createSignedPayment(fixture.createUnsignedPayment(payment.senderPayload, payment.senderRef)));
+                expect(payment.toJSON()).to.eql(await fixture.createSignedPayment(fixture.createUnsignedPayment(payment.senderRef, payment.senderPayload)));
             });
 
             it('can be registered with the API', () => {
@@ -150,9 +150,9 @@ describe('Payment', () => {
             let payment, expectedSignedPayload;
 
             beforeEach(async () => {
-                payment = new Payment(MonetaryAmount.from(fixture.amount, fixture.currency.ct, fixture.currency.id), fixture.sender, fixture.recipient, wallet, senderPayload);
+                payment = new Payment(MonetaryAmount.from(fixture.amount, fixture.currency.ct, fixture.currency.id), fixture.sender, fixture.recipient, wallet, null, senderPayload);
                 await payment.sign();
-                expectedSignedPayload = await fixture.createSignedPayment(fixture.createUnsignedPayment(payment.senderPayload, payment.senderRef));
+                expectedSignedPayload = await fixture.createSignedPayment(fixture.createUnsignedPayment(payment.senderRef, payment.senderPayload));
             });
 
             it('can be serialized to an object literal', () => {
@@ -203,12 +203,12 @@ describe('Payment', () => {
             let payment, expectedSignedPayload;
 
             beforeEach(async () => {
-                payment = Payment.from(fixture.createUnsignedPayment(senderPayload, senderRef), wallet);
-                expectedSignedPayload = await fixture.createSignedPayment(fixture.createUnsignedPayment(payment.senderPayload, payment.senderRef));
+                payment = Payment.from(fixture.createUnsignedPayment(senderRef, senderPayload), wallet);
+                expectedSignedPayload = await fixture.createSignedPayment(fixture.createUnsignedPayment(payment.senderRef, payment.senderPayload));
             });
 
             it('can be serialized to a new object literal', async () => {
-                expect(payment.toJSON()).to.eql(fixture.createUnsignedPayment(payment.senderPayload, payment.senderRef));
+                expect(payment.toJSON()).to.eql(fixture.createUnsignedPayment(payment.senderRef, payment.senderPayload));
             });
 
             it('can be signed', async () => {
@@ -219,7 +219,7 @@ describe('Payment', () => {
             it('can be registered with the API', () => {
                 payment.register();
                 expect(stubbedProvider.registerPayment)
-                    .to.have.been.calledWith(fixture.createUnsignedPayment(payment.senderPayload, payment.senderRef));
+                    .to.have.been.calledWith(fixture.createUnsignedPayment(payment.senderRef, payment.senderPayload));
             });
 
             it('has the supplied amount', () => {
@@ -262,7 +262,7 @@ describe('Payment', () => {
             let payment, signedPayload;
 
             beforeEach(async () => {
-                signedPayload = await fixture.createSignedPayment(fixture.createUnsignedPayment(senderPayload, 'c3cc73cc-756a-11e9-957c-705ab6aee958'));
+                signedPayload = await fixture.createSignedPayment(fixture.createUnsignedPayment('c3cc73cc-756a-11e9-957c-705ab6aee958', senderPayload));
                 payment = Payment.from(signedPayload, wallet);
             });
 
@@ -316,11 +316,11 @@ describe('Payment', () => {
             let payment;
 
             beforeEach(() => {
-                payment = new Payment(MonetaryAmount.from(fixture.amount, fixture.currency.ct, fixture.currency.id), fixture.sender, fixture.recipient, stubbedProvider, senderPayload);
+                payment = new Payment(MonetaryAmount.from(fixture.amount, fixture.currency.ct, fixture.currency.id), fixture.sender, fixture.recipient, stubbedProvider, null, senderPayload);
             });
 
             it('can be serialized to an object literal', () => {
-                expect(payment.toJSON()).to.eql(fixture.createUnsignedPayment(payment.senderPayload, payment.senderRef));
+                expect(payment.toJSON()).to.eql(fixture.createUnsignedPayment(payment.senderRef, payment.senderPayload));
             });
 
             it('can not be signed', (done) => {
@@ -375,11 +375,11 @@ describe('Payment', () => {
             let payment;
 
             beforeEach(() => {
-                payment = Payment.from(fixture.createUnsignedPayment(senderPayload, senderRef), stubbedProvider);
+                payment = Payment.from(fixture.createUnsignedPayment(senderRef, senderPayload), stubbedProvider);
             });
 
             it('can be serialized to a new object literal', () => {
-                expect(payment.toJSON()).to.eql(fixture.createUnsignedPayment(senderPayload, senderRef));
+                expect(payment.toJSON()).to.eql(fixture.createUnsignedPayment(senderRef, senderPayload));
             });
 
             it('can not be signed', (done) => {
@@ -392,7 +392,7 @@ describe('Payment', () => {
 
             it('can be registered with the API', () => {
                 payment.register();
-                expect(stubbedProvider.registerPayment).to.have.been.calledWith(fixture.createUnsignedPayment(senderPayload, senderRef));
+                expect(stubbedProvider.registerPayment).to.have.been.calledWith(fixture.createUnsignedPayment(senderRef, senderPayload));
             });
 
             it('has the supplied amount', () => {
@@ -434,7 +434,7 @@ describe('Payment', () => {
             let payment, signedPayload;
 
             beforeEach(async () => {
-                signedPayload = await fixture.createSignedPayment(fixture.createUnsignedPayment(senderPayload, senderRef));
+                signedPayload = await fixture.createSignedPayment(fixture.createUnsignedPayment(senderRef, senderPayload));
                 payment = Payment.from(signedPayload, stubbedProvider);
             });
 
@@ -492,7 +492,7 @@ describe('Payment', () => {
             });
 
             it('can be serialized to an object literal', () => {
-                expect(payment.toJSON()).to.eql(fixture.createUnsignedPayment(payment.senderPayload, payment.senderRef));
+                expect(payment.toJSON()).to.eql(fixture.createUnsignedPayment(payment.senderRef, payment.senderPayload));
             });
 
             it('can not be signed', (done) => {
@@ -549,11 +549,11 @@ describe('Payment', () => {
             let payment;
 
             beforeEach(() => {
-                payment = Payment.from(fixture.createUnsignedPayment(senderPayload, senderRef));
+                payment = Payment.from(fixture.createUnsignedPayment(senderRef, senderPayload));
             });
 
             it('can be serialized to a new object literal', () => {
-                expect(payment.toJSON()).to.eql(fixture.createUnsignedPayment(senderPayload, senderRef));
+                expect(payment.toJSON()).to.eql(fixture.createUnsignedPayment(senderRef, senderPayload));
             });
 
             it('can not be signed', (done) => {
@@ -611,11 +611,11 @@ describe('Payment', () => {
             let payment;
 
             beforeEach(async () => {
-                payment = Payment.from(await fixture.createSignedPayment(fixture.createUnsignedPayment(senderPayload, senderRef)));
+                payment = Payment.from(await fixture.createSignedPayment(fixture.createUnsignedPayment(senderRef, senderPayload)));
             });
 
             it('can be serialized to a new object literal', async () => {
-                expect(payment.toJSON()).to.eql(await fixture.createSignedPayment(fixture.createUnsignedPayment(senderPayload, senderRef)));
+                expect(payment.toJSON()).to.eql(await fixture.createSignedPayment(fixture.createUnsignedPayment(senderRef, senderPayload)));
             });
 
             it('can not be registered with the API', (done) => {
@@ -672,7 +672,7 @@ describe('Payment', () => {
         let payment;
 
         beforeEach(() => {
-            const modifiedPayload = fixture.createUnsignedPayment(senderPayload, senderRef);
+            const modifiedPayload = fixture.createUnsignedPayment(senderRef, senderPayload);
             modifiedPayload.sender.data = null;
             payment = Payment.from(modifiedPayload, stubbedWallet);
         });
@@ -709,7 +709,7 @@ describe('Payment', () => {
         let payment;
 
         beforeEach(() => {
-            const modifiedPayload = fixture.createUnsignedPayment(senderPayload, senderRef);
+            const modifiedPayload = fixture.createUnsignedPayment(senderRef, senderPayload);
             modifiedPayload.sender.data = 'asdasdasdasasd';
             payment = Payment.from(modifiedPayload, stubbedWallet);
         });
@@ -741,7 +741,7 @@ describe('Payment', () => {
         let payment, modifiedPayload;
 
         beforeEach(async () => {
-            modifiedPayload = await fixture.createSignedPayment(fixture.createUnsignedPayment(senderPayload, senderRef));
+            modifiedPayload = await fixture.createSignedPayment(fixture.createUnsignedPayment(senderRef, senderPayload));
             modifiedPayload.amount = '999999';
             payment = Payment.from(modifiedPayload, stubbedWallet);
         });
@@ -759,7 +759,7 @@ describe('Payment', () => {
         let payment, modifiedPayload;
 
         beforeEach(async () => {
-            modifiedPayload = await fixture.createSignedPayment(fixture.createUnsignedPayment(senderPayload, senderRef));
+            modifiedPayload = await fixture.createSignedPayment(fixture.createUnsignedPayment(senderRef, senderPayload));
             modifiedPayload.sender.wallet = '0x0000000000000000000000000000000000000099';
             payment = Payment.from(modifiedPayload, stubbedWallet);
         });
@@ -777,7 +777,7 @@ describe('Payment', () => {
         let payment, modifiedPayload;
 
         beforeEach(async () => {
-            modifiedPayload = await fixture.createSignedPayment(fixture.createUnsignedPayment(senderPayload, senderRef));
+            modifiedPayload = await fixture.createSignedPayment(fixture.createUnsignedPayment(senderRef, senderPayload));
             modifiedPayload.seals.wallet.signature = '0xffff9e389115e663107162f9049da8ed06670a53dd6b3bb77165940b6a55eba3156f788625446d6e553dd448608445f122803556c015559b32cf66d781e7d85b18';
             payment = Payment.from(modifiedPayload, stubbedWallet);
         });
@@ -799,12 +799,12 @@ describe('Payment', () => {
 
         when('constructing Payments', () => {
             it('creates Payments with undefined senderPayload property if input senderPayload is undefined', () => {
-                const payment = new Payment(amount, sender, recipient, wallet);
+                const payment = new Payment(amount, sender, recipient, wallet, null);
                 expect(payment.senderPayload).to.be.undefined;
             });
 
             it('creates Payments with senderPayload property equal to input senderPayload if defined', () => {
-                const payment = new Payment(amount, sender, recipient, wallet, senderPayload);
+                const payment = new Payment(amount, sender, recipient, wallet, null, senderPayload);
                 expect(payment.senderPayload).to.equal(senderPayload);
             });
         });
@@ -825,7 +825,7 @@ describe('Payment', () => {
                 const refSet = new Set();
 
                 for (let i = 0; i < 10; ++i) {
-                    const payment = new Payment(amount, sender, recipient, wallet, senderPayload);
+                    const payment = new Payment(amount, sender, recipient, wallet);
                     expect(refSet.has(payment.senderRef)).to.equal(false);
                     refSet.add(payment.senderRef);
                 }
@@ -834,18 +834,18 @@ describe('Payment', () => {
             it('creates Payments with senderRef property equal to input senderRef if defined', () => {
                 for (let i = 0; i < 10; ++i) {
                     const inputSenderRef = uuidv4();
-                    const payment = new Payment(amount, sender, recipient, wallet, senderPayload, inputSenderRef);
+                    const payment = new Payment(amount, sender, recipient, wallet, inputSenderRef);
                     expect(payment.senderRef).to.equal(inputSenderRef);
                 }
             });
 
             it('creates Payments regardless of senderRef character case', () => {
-                expect(new Payment(amount, sender, recipient, wallet, senderPayload, uuidv4().toLowerCase())).to.be.instanceof(Payment);
-                expect(new Payment(amount, sender, recipient, wallet, senderPayload, uuidv4().toUpperCase())).to.be.instanceof(Payment);
+                expect(new Payment(amount, sender, recipient, wallet, uuidv4().toLowerCase())).to.be.instanceof(Payment);
+                expect(new Payment(amount, sender, recipient, wallet, uuidv4().toUpperCase())).to.be.instanceof(Payment);
             });
 
             it('throws if input input senderRef is not valid', () => {
-                expect(() => new Payment(amount, sender, recipient, wallet, senderPayload, 'something weird')).to.throw(/senderRef is not a uuid string/);
+                expect(() => new Payment(amount, sender, recipient, wallet, 'something weird')).to.throw(/senderRef is not a uuid string/);
             });
         });
     });

--- a/lib/payment.spec.js
+++ b/lib/payment.spec.js
@@ -16,13 +16,13 @@ const given = describe;
 const when = describe;
 
 const Wallet = proxyquire('./wallet/wallet', {
-    './client-fund-contract': function() {
+    './client-fund-contract': function () {
         return {};
     },
-    './balance-tracker-contract': function() {
+    './balance-tracker-contract': function () {
         return {};
     },
-    './erc20-contract': function() {
+    './erc20-contract': function () {
         return {};
     }
 });
@@ -40,7 +40,7 @@ const stubbedWallet = {
 };
 
 chai.use(_chai => {
-    _chai.Assertion.addMethod('equalMoney', function(other) {
+    _chai.Assertion.addMethod('equalMoney', function (other) {
         const obj = this._obj;
 
         new _chai.Assertion(obj).to.be.instanceOf(MonetaryAmount);
@@ -63,6 +63,7 @@ chai.use(_chai => {
 describe('Payment', () => {
     const senderRef = 'c3cc73cc-756a-11e9-957c-705ab6aee958';
     const uuidRegexp = /^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i;
+    const senderPayload = 'some sender payload';
     let fixture;
 
     beforeEach(() => {
@@ -93,16 +94,16 @@ describe('Payment', () => {
             let payment;
 
             beforeEach(() => {
-                payment = new Payment(MonetaryAmount.from(fixture.amount, fixture.currency.ct, fixture.currency.id), fixture.sender, fixture.recipient, wallet);
+                payment = new Payment(MonetaryAmount.from(fixture.amount, fixture.currency.ct, fixture.currency.id), fixture.sender, fixture.recipient, wallet, senderPayload);
             });
 
             it('can be serialized to an object literal', () => {
-                expect(payment.toJSON()).to.eql(fixture.createUnsignedPayment(payment.senderRef));
+                expect(payment.toJSON()).to.eql(fixture.createUnsignedPayment(payment.senderPayload, payment.senderRef));
             });
 
             it('can be signed', async () => {
                 await payment.sign();
-                expect(payment.toJSON()).to.eql(await fixture.createSignedPayment(fixture.createUnsignedPayment(payment.senderRef)));
+                expect(payment.toJSON()).to.eql(await fixture.createSignedPayment(fixture.createUnsignedPayment(payment.senderPayload, payment.senderRef)));
             });
 
             it('can be registered with the API', () => {
@@ -126,13 +127,20 @@ describe('Payment', () => {
                 expect(payment.isSigned()).to.be.false;
             });
 
+            it('has the supplied sender payload', () => {
+                expect(payment.senderPayload).to.eql(senderPayload);
+            });
+
             it('has a UUID as sender ref', () => {
                 expect(payment.senderRef).to.match(uuidRegexp);
             });
 
-            it('has sender data in JSON that is base64 encoding of sender ref', () => {
+            it('has sender data in JSON that is base64 encoding of sub document with ref and payload properties', () => {
                 const expectedData = Buffer
-                    .from(JSON.stringify({ref: payment.senderRef}))
+                    .from(JSON.stringify({
+                        ref: payment.senderRef,
+                        payload: payment.senderPayload
+                    }))
                     .toString('base64');
                 expect(payment.toJSON().sender.data).to.eql(expectedData);
             });
@@ -142,9 +150,9 @@ describe('Payment', () => {
             let payment, expectedSignedPayload;
 
             beforeEach(async () => {
-                payment = new Payment(MonetaryAmount.from(fixture.amount, fixture.currency.ct, fixture.currency.id), fixture.sender, fixture.recipient, wallet);
+                payment = new Payment(MonetaryAmount.from(fixture.amount, fixture.currency.ct, fixture.currency.id), fixture.sender, fixture.recipient, wallet, senderPayload);
                 await payment.sign();
-                expectedSignedPayload = await fixture.createSignedPayment(fixture.createUnsignedPayment(payment.senderRef));
+                expectedSignedPayload = await fixture.createSignedPayment(fixture.createUnsignedPayment(payment.senderPayload, payment.senderRef));
             });
 
             it('can be serialized to an object literal', () => {
@@ -172,13 +180,20 @@ describe('Payment', () => {
                 expect(payment.isSigned()).to.be.true;
             });
 
+            it('has the supplied sender payload', () => {
+                expect(payment.senderPayload).to.eql(senderPayload);
+            });
+
             it('has a UUID as sender ref', () => {
                 expect(payment.senderRef).to.match(uuidRegexp);
             });
 
-            it('has sender data in JSON that is base64 encoding of sender ref', () => {
+            it('has sender data in JSON that is base64 encoding of sub document with ref and payload properties', () => {
                 const expectedData = Buffer
-                    .from(JSON.stringify({ref: payment.senderRef}))
+                    .from(JSON.stringify({
+                        ref: payment.senderRef,
+                        payload: payment.senderPayload
+                    }))
                     .toString('base64');
                 expect(payment.toJSON().sender.data).to.eql(expectedData);
             });
@@ -188,12 +203,12 @@ describe('Payment', () => {
             let payment, expectedSignedPayload;
 
             beforeEach(async () => {
-                payment = Payment.from(fixture.createUnsignedPayment(senderRef), wallet);
-                expectedSignedPayload = await fixture.createSignedPayment(fixture.createUnsignedPayment(payment.senderRef));
+                payment = Payment.from(fixture.createUnsignedPayment(senderPayload, senderRef), wallet);
+                expectedSignedPayload = await fixture.createSignedPayment(fixture.createUnsignedPayment(payment.senderPayload, payment.senderRef));
             });
 
             it('can be serialized to a new object literal', async () => {
-                expect(payment.toJSON()).to.eql(fixture.createUnsignedPayment(payment.senderRef));
+                expect(payment.toJSON()).to.eql(fixture.createUnsignedPayment(payment.senderPayload, payment.senderRef));
             });
 
             it('can be signed', async () => {
@@ -204,7 +219,7 @@ describe('Payment', () => {
             it('can be registered with the API', () => {
                 payment.register();
                 expect(stubbedProvider.registerPayment)
-                    .to.have.been.calledWith(fixture.createUnsignedPayment(payment.senderRef));
+                    .to.have.been.calledWith(fixture.createUnsignedPayment(payment.senderPayload, payment.senderRef));
             });
 
             it('has the supplied amount', () => {
@@ -224,13 +239,20 @@ describe('Payment', () => {
                 expect(payment.isSigned()).to.be.false;
             });
 
+            it('has the supplied sender payload', () => {
+                expect(payment.senderPayload).to.eql(senderPayload);
+            });
+
             it('has a UUID as sender ref', () => {
                 expect(payment.senderRef).to.match(uuidRegexp);
             });
 
-            it('has sender data in JSON that is base64 encoding of sender ref', () => {
+            it('has sender data in JSON that is base64 encoding of sub document with ref and payload properties', () => {
                 const expectedData = Buffer
-                    .from(JSON.stringify({ref: payment.senderRef}))
+                    .from(JSON.stringify({
+                        ref: payment.senderRef,
+                        payload: payment.senderPayload
+                    }))
                     .toString('base64');
                 expect(payment.toJSON().sender.data).to.eql(expectedData);
             });
@@ -240,7 +262,7 @@ describe('Payment', () => {
             let payment, signedPayload;
 
             beforeEach(async () => {
-                signedPayload = await fixture.createSignedPayment(fixture.createUnsignedPayment('c3cc73cc-756a-11e9-957c-705ab6aee958'));
+                signedPayload = await fixture.createSignedPayment(fixture.createUnsignedPayment(senderPayload, 'c3cc73cc-756a-11e9-957c-705ab6aee958'));
                 payment = Payment.from(signedPayload, wallet);
             });
 
@@ -269,13 +291,20 @@ describe('Payment', () => {
                 expect(payment.isSigned()).to.be.true;
             });
 
+            it('has the supplied sender payload', () => {
+                expect(payment.senderPayload).to.eql(senderPayload);
+            });
+
             it('has a UUID as sender ref', () => {
                 expect(payment.senderRef).to.match(uuidRegexp);
             });
 
-            it('has sender data in JSON that is base64 encoding of sender ref', () => {
+            it('has sender data in JSON that is base64 encoding of sub document with ref and payload properties', () => {
                 const expectedData = Buffer
-                    .from(JSON.stringify({ref: payment.senderRef}))
+                    .from(JSON.stringify({
+                        ref: payment.senderRef,
+                        payload: payment.senderPayload
+                    }))
                     .toString('base64');
                 expect(payment.toJSON().sender.data).to.eql(expectedData);
             });
@@ -287,11 +316,11 @@ describe('Payment', () => {
             let payment;
 
             beforeEach(() => {
-                payment = new Payment(MonetaryAmount.from(fixture.amount, fixture.currency.ct, fixture.currency.id), fixture.sender, fixture.recipient, stubbedProvider);
+                payment = new Payment(MonetaryAmount.from(fixture.amount, fixture.currency.ct, fixture.currency.id), fixture.sender, fixture.recipient, stubbedProvider, senderPayload);
             });
 
             it('can be serialized to an object literal', () => {
-                expect(payment.toJSON()).to.eql(fixture.createUnsignedPayment(payment.senderRef));
+                expect(payment.toJSON()).to.eql(fixture.createUnsignedPayment(payment.senderPayload, payment.senderRef));
             });
 
             it('can not be signed', (done) => {
@@ -323,13 +352,20 @@ describe('Payment', () => {
                 expect(payment.isSigned()).to.be.false;
             });
 
+            it('has the supplied sender payload', () => {
+                expect(payment.senderPayload).to.eql(senderPayload);
+            });
+
             it('has a UUID as sender ref', () => {
                 expect(payment.senderRef).to.match(uuidRegexp);
             });
 
-            it('has sender data in JSON that is base64 encoding of sender ref', () => {
+            it('has sender data in JSON that is base64 encoding of sub document with ref and payload properties', () => {
                 const expectedData = Buffer
-                    .from(JSON.stringify({ref: payment.senderRef}))
+                    .from(JSON.stringify({
+                        ref: payment.senderRef,
+                        payload: payment.senderPayload
+                    }))
                     .toString('base64');
                 expect(payment.toJSON().sender.data).to.eql(expectedData);
             });
@@ -339,11 +375,11 @@ describe('Payment', () => {
             let payment;
 
             beforeEach(() => {
-                payment = Payment.from(fixture.createUnsignedPayment(senderRef), stubbedProvider);
+                payment = Payment.from(fixture.createUnsignedPayment(senderPayload, senderRef), stubbedProvider);
             });
 
             it('can be serialized to a new object literal', () => {
-                expect(payment.toJSON()).to.eql(fixture.createUnsignedPayment(senderRef));
+                expect(payment.toJSON()).to.eql(fixture.createUnsignedPayment(senderPayload, senderRef));
             });
 
             it('can not be signed', (done) => {
@@ -356,7 +392,7 @@ describe('Payment', () => {
 
             it('can be registered with the API', () => {
                 payment.register();
-                expect(stubbedProvider.registerPayment).to.have.been.calledWith(fixture.createUnsignedPayment(senderRef));
+                expect(stubbedProvider.registerPayment).to.have.been.calledWith(fixture.createUnsignedPayment(senderPayload, senderRef));
             });
 
             it('has the supplied amount', () => {
@@ -375,13 +411,20 @@ describe('Payment', () => {
                 expect(payment.isSigned()).to.be.false;
             });
 
+            it('has the supplied sender payload', () => {
+                expect(payment.senderPayload).to.eql(senderPayload);
+            });
+
             it('has a UUID as sender ref', () => {
                 expect(payment.senderRef).to.match(uuidRegexp);
             });
 
-            it('has sender data in JSON that is base64 encoding of sender ref', () => {
+            it('has sender data in JSON that is base64 encoding of sub document with ref and payload properties', () => {
                 const expectedData = Buffer
-                    .from(JSON.stringify({ref: payment.senderRef}))
+                    .from(JSON.stringify({
+                        ref: payment.senderRef,
+                        payload: payment.senderPayload
+                    }))
                     .toString('base64');
                 expect(payment.toJSON().sender.data).to.eql(expectedData);
             });
@@ -391,7 +434,7 @@ describe('Payment', () => {
             let payment, signedPayload;
 
             beforeEach(async () => {
-                signedPayload = await fixture.createSignedPayment(fixture.createUnsignedPayment(senderRef));
+                signedPayload = await fixture.createSignedPayment(fixture.createUnsignedPayment(senderPayload, senderRef));
                 payment = Payment.from(signedPayload, stubbedProvider);
             });
 
@@ -420,13 +463,20 @@ describe('Payment', () => {
                 expect(payment.isSigned()).to.be.true;
             });
 
+            it('has the supplied sender payload', () => {
+                expect(payment.senderPayload).to.eql(senderPayload);
+            });
+
             it('has a UUID as sender ref', () => {
                 expect(payment.senderRef).to.match(uuidRegexp);
             });
 
-            it('has sender data in JSON that is base64 encoding of sender ref', () => {
+            it('has sender data in JSON that is base64 encoding of sub document with ref and payload properties', () => {
                 const expectedData = Buffer
-                    .from(JSON.stringify({ref: payment.senderRef}))
+                    .from(JSON.stringify({
+                        ref: payment.senderRef,
+                        payload: payment.senderPayload
+                    }))
                     .toString('base64');
                 expect(payment.toJSON().sender.data).to.eql(expectedData);
             });
@@ -442,7 +492,7 @@ describe('Payment', () => {
             });
 
             it('can be serialized to an object literal', () => {
-                expect(payment.toJSON()).to.eql(fixture.createUnsignedPayment(payment.senderRef));
+                expect(payment.toJSON()).to.eql(fixture.createUnsignedPayment(payment.senderPayload, payment.senderRef));
             });
 
             it('can not be signed', (done) => {
@@ -477,13 +527,19 @@ describe('Payment', () => {
                 expect(payment.isSigned()).to.be.false;
             });
 
+            it('has the supplied sender payload', () => {
+                expect(payment.senderPayload).to.be.undefined;
+            });
+
             it('has a UUID as sender ref', () => {
                 expect(payment.senderRef).to.match(uuidRegexp);
             });
 
-            it('has sender data in JSON that is base64 encoding of sender ref', () => {
+            it('has sender data in JSON that is base64 encoding of sub document with ref property', () => {
                 const expectedData = Buffer
-                    .from(JSON.stringify({ref: payment.senderRef}))
+                    .from(JSON.stringify({
+                        ref: payment.senderRef
+                    }))
                     .toString('base64');
                 expect(payment.toJSON().sender.data).to.eql(expectedData);
             });
@@ -493,11 +549,11 @@ describe('Payment', () => {
             let payment;
 
             beforeEach(() => {
-                payment = Payment.from(fixture.createUnsignedPayment(senderRef));
+                payment = Payment.from(fixture.createUnsignedPayment(senderPayload, senderRef));
             });
 
             it('can be serialized to a new object literal', () => {
-                expect(payment.toJSON()).to.eql(fixture.createUnsignedPayment(senderRef));
+                expect(payment.toJSON()).to.eql(fixture.createUnsignedPayment(senderPayload, senderRef));
             });
 
             it('can not be signed', (done) => {
@@ -532,13 +588,20 @@ describe('Payment', () => {
                 expect(payment.isSigned()).to.be.false;
             });
 
+            it('has the supplied sender payload', () => {
+                expect(payment.senderPayload).to.eql(senderPayload);
+            });
+
             it('has a UUID as sender ref', () => {
                 expect(payment.senderRef).to.match(uuidRegexp);
             });
 
-            it('has sender data in JSON that is base64 encoding of sender ref', () => {
+            it('has sender data in JSON that is base64 encoding of sub document with ref and payload properties', () => {
                 const expectedData = Buffer
-                    .from(JSON.stringify({ref: payment.senderRef}))
+                    .from(JSON.stringify({
+                        ref: payment.senderRef,
+                        payload: payment.senderPayload
+                    }))
                     .toString('base64');
                 expect(payment.toJSON().sender.data).to.eql(expectedData);
             });
@@ -548,11 +611,11 @@ describe('Payment', () => {
             let payment;
 
             beforeEach(async () => {
-                payment = Payment.from(await fixture.createSignedPayment(fixture.createUnsignedPayment(senderRef)));
+                payment = Payment.from(await fixture.createSignedPayment(fixture.createUnsignedPayment(senderPayload, senderRef)));
             });
 
             it('can be serialized to a new object literal', async () => {
-                expect(payment.toJSON()).to.eql(await fixture.createSignedPayment(fixture.createUnsignedPayment(senderRef)));
+                expect(payment.toJSON()).to.eql(await fixture.createSignedPayment(fixture.createUnsignedPayment(senderPayload, senderRef)));
             });
 
             it('can not be registered with the API', (done) => {
@@ -579,13 +642,20 @@ describe('Payment', () => {
                 expect(payment.isSigned()).to.be.true;
             });
 
+            it('has the supplied sender payload', () => {
+                expect(payment.senderPayload).to.eql(senderPayload);
+            });
+
             it('has a UUID as sender ref', () => {
                 expect(payment.senderRef).to.match(uuidRegexp);
             });
 
-            it('has sender data in JSON that is base64 encoding of sender ref', () => {
+            it('has sender data in JSON that is base64 encoding of sub document with ref and payload properties', () => {
                 const expectedData = Buffer
-                    .from(JSON.stringify({ref: payment.senderRef}))
+                    .from(JSON.stringify({
+                        ref: payment.senderRef,
+                        payload: payment.senderPayload
+                    }))
                     .toString('base64');
                 expect(payment.toJSON().sender.data).to.eql(expectedData);
             });
@@ -602,9 +672,14 @@ describe('Payment', () => {
         let payment;
 
         beforeEach(() => {
-            const modifiedPayload = fixture.createUnsignedPayment(senderRef);
+            const modifiedPayload = fixture.createUnsignedPayment(senderPayload, senderRef);
             modifiedPayload.sender.data = null;
             payment = Payment.from(modifiedPayload, stubbedWallet);
+        });
+
+        it('has a new sender payload', () => {
+            expect(payment.senderPayload).to.not.eql('');
+            expect(payment.senderPayload).to.not.eql(senderPayload);
         });
 
         it('has a new sender reference', () => {
@@ -612,13 +687,19 @@ describe('Payment', () => {
             expect(payment.senderRef).to.not.eql(senderRef);
         });
 
+        it('has an undefined sender payload', () => {
+            expect(payment.senderPayload).to.be.undefined;
+        });
+
         it('has a UUID as sender ref', () => {
             expect(payment.senderRef).to.match(uuidRegexp);
         });
 
-        it('has sender data in JSON that is base64 encoding of sender ref', () => {
+        it('has sender data in JSON that is base64 encoding of sub document with ref property', () => {
             const expectedData = Buffer
-                .from(JSON.stringify({ref: payment.senderRef}))
+                .from(JSON.stringify({
+                    ref: payment.senderRef
+                }))
                 .toString('base64');
             expect(payment.toJSON().sender.data).to.eql(expectedData);
         });
@@ -628,7 +709,7 @@ describe('Payment', () => {
         let payment;
 
         beforeEach(() => {
-            const modifiedPayload = fixture.createUnsignedPayment(senderRef);
+            const modifiedPayload = fixture.createUnsignedPayment(senderPayload, senderRef);
             modifiedPayload.sender.data = 'asdasdasdasasd';
             payment = Payment.from(modifiedPayload, stubbedWallet);
         });
@@ -638,13 +719,19 @@ describe('Payment', () => {
             expect(payment.senderRef).to.not.eql(senderRef);
         });
 
+        it('has an undefined sender payload', () => {
+            expect(payment.senderPayload).to.be.undefined;
+        });
+
         it('has a UUID as sender ref', () => {
             expect(payment.senderRef).to.match(uuidRegexp);
         });
 
-        it('has sender data in JSON that is base64 encoding of sender ref', () => {
+        it('has sender data in JSON that is base64 encoding of sub document with ref property', () => {
             const expectedData = Buffer
-                .from(JSON.stringify({ref: payment.senderRef}))
+                .from(JSON.stringify({
+                    ref: payment.senderRef
+                }))
                 .toString('base64');
             expect(payment.toJSON().sender.data).to.eql(expectedData);
         });
@@ -654,7 +741,7 @@ describe('Payment', () => {
         let payment, modifiedPayload;
 
         beforeEach(async () => {
-            modifiedPayload = await fixture.createSignedPayment(fixture.createUnsignedPayment(senderRef));
+            modifiedPayload = await fixture.createSignedPayment(fixture.createUnsignedPayment(senderPayload, senderRef));
             modifiedPayload.amount = '999999';
             payment = Payment.from(modifiedPayload, stubbedWallet);
         });
@@ -672,7 +759,7 @@ describe('Payment', () => {
         let payment, modifiedPayload;
 
         beforeEach(async () => {
-            modifiedPayload = await fixture.createSignedPayment(fixture.createUnsignedPayment(senderRef));
+            modifiedPayload = await fixture.createSignedPayment(fixture.createUnsignedPayment(senderPayload, senderRef));
             modifiedPayload.sender.wallet = '0x0000000000000000000000000000000000000099';
             payment = Payment.from(modifiedPayload, stubbedWallet);
         });
@@ -690,13 +777,36 @@ describe('Payment', () => {
         let payment, modifiedPayload;
 
         beforeEach(async () => {
-            modifiedPayload = await fixture.createSignedPayment(fixture.createUnsignedPayment(senderRef));
+            modifiedPayload = await fixture.createSignedPayment(fixture.createUnsignedPayment(senderPayload, senderRef));
             modifiedPayload.seals.wallet.signature = '0xffff9e389115e663107162f9049da8ed06670a53dd6b3bb77165940b6a55eba3156f788625446d6e553dd448608445f122803556c015559b32cf66d781e7d85b18';
             payment = Payment.from(modifiedPayload, stubbedWallet);
         });
 
         it('does not have a valid signature', () => {
             expect(payment.isSigned()).to.be.false;
+        });
+    });
+
+    given('a Payment constructor that optionally accepts a senderPayload', () => {
+        let amount, sender, recipient, wallet;
+
+        beforeEach(() => {
+            amount = MonetaryAmount.from(fixture.amount, fixture.currency.ct, fixture.currency.id);
+            sender = fixture.sender;
+            recipient = fixture.recipient;
+            wallet = new Wallet(fixture.senderPrivateKey, stubbedProvider);
+        });
+
+        when('constructing Payments', () => {
+            it('creates Payments with undefined senderPayload property if input senderPayload is undefined', () => {
+                const payment = new Payment(amount, sender, recipient, wallet);
+                expect(payment.senderPayload).to.be.undefined;
+            });
+
+            it('creates Payments with senderPayload property equal to input senderPayload if defined', () => {
+                const payment = new Payment(amount, sender, recipient, wallet, senderPayload);
+                expect(payment.senderPayload).to.equal(senderPayload);
+            });
         });
     });
 
@@ -711,31 +821,31 @@ describe('Payment', () => {
         });
 
         when('constructing Payments', () => {
-            it ('creates Payments with random senderRef property if input senderRef is undefined', () => {
+            it('creates Payments with random senderRef property if input senderRef is undefined', () => {
                 const refSet = new Set();
 
                 for (let i = 0; i < 10; ++i) {
-                    const payment = new Payment(amount, sender, recipient, wallet);
+                    const payment = new Payment(amount, sender, recipient, wallet, senderPayload);
                     expect(refSet.has(payment.senderRef)).to.equal(false);
                     refSet.add(payment.senderRef);
                 }
             });
 
-            it ('creates Payments with senderRef property equal to input senderRef if defined', () => {
+            it('creates Payments with senderRef property equal to input senderRef if defined', () => {
                 for (let i = 0; i < 10; ++i) {
                     const inputSenderRef = uuidv4();
-                    const payment = new Payment(amount, sender, recipient, wallet, inputSenderRef);
+                    const payment = new Payment(amount, sender, recipient, wallet, senderPayload, inputSenderRef);
                     expect(payment.senderRef).to.equal(inputSenderRef);
                 }
             });
 
-            it ('creates Payments regardless of senderRef character case', () => {
-                expect(new Payment(amount, sender, recipient, wallet, uuidv4().toLowerCase())).to.be.instanceof(Payment);
-                expect(new Payment(amount, sender, recipient, wallet, uuidv4().toUpperCase())).to.be.instanceof(Payment);
+            it('creates Payments regardless of senderRef character case', () => {
+                expect(new Payment(amount, sender, recipient, wallet, senderPayload, uuidv4().toLowerCase())).to.be.instanceof(Payment);
+                expect(new Payment(amount, sender, recipient, wallet, senderPayload, uuidv4().toUpperCase())).to.be.instanceof(Payment);
             });
 
-            it ('throws if input input senderRef is not valid', () => {
-                expect(() => new Payment(amount, sender, recipient, wallet, 'something weird')).to.throw(/senderRef is not a uuid string/);
+            it('throws if input input senderRef is not valid', () => {
+                expect(() => new Payment(amount, sender, recipient, wallet, senderPayload, 'something weird')).to.throw(/senderRef is not a uuid string/);
             });
         });
     });

--- a/lib/receipt.spec.js
+++ b/lib/receipt.spec.js
@@ -36,11 +36,12 @@ const Receipt = proxyquire('./receipt', {
 describe('Receipt', () => {
     let receipt, fixture, stubbedProvider;
     const senderRef = '3f527f36-76e3-11e9-bcfb-705ab6aee958';
+    const senderPayload = '3f527f36-76e3-11e9-bcfb-705ab6aee958';
 
     async function createUnsignedReceiptPayload() {
         return fixture.createUnsignedReceipt(
             await fixture.createSignedPayment(
-                fixture.createUnsignedPayment(senderRef)
+                fixture.createUnsignedPayment(senderPayload, senderRef)
             )
         );
     }

--- a/lib/receipt.spec.js
+++ b/lib/receipt.spec.js
@@ -36,7 +36,7 @@ const Receipt = proxyquire('./receipt', {
 describe('Receipt', () => {
     let receipt, fixture, stubbedProvider;
     const senderRef = '3f527f36-76e3-11e9-bcfb-705ab6aee958';
-    const senderPayload = '3f527f36-76e3-11e9-bcfb-705ab6aee958';
+    const senderPayload = 'some sender payload';
 
     async function createUnsignedReceiptPayload() {
         return fixture.createUnsignedReceipt(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nahmii-sdk",
-  "version": "4.5.2",
+  "version": "5.0.0",
   "description": "Javascript SDK for using hubii nahmii APIs",
   "main": "index.js",
   "scripts": {
@@ -20,6 +20,7 @@
     "build:docs:utils": "jsdoc2md lib/utils.js > Docs/utils.md",
     "build:docs:wallet": "jsdoc2md lib/wallet/wallet.js > Docs/wallet.md",
     "test": "NODE_PATH=$npm_package_peerInstallOptions_prefix/node_modules nyc mocha 'lib/**/*.spec.js' --exit",
+    "test:no-coverage": "NODE_PATH=$npm_package_peerInstallOptions_prefix/node_modules mocha 'lib/**/*.spec.js' --exit",
     "test:watch": "npm run test -- --watch",
     "lint": "eslint --ignore-path .gitignore .",
     "lint:fix": "npm run lint -- --fix",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nahmii-sdk",
-  "version": "5.0.0",
+  "version": "4.6.0",
   "description": "Javascript SDK for using hubii nahmii APIs",
   "main": "index.js",
   "scripts": {

--- a/test-utils/index.js
+++ b/test-utils/index.js
@@ -34,8 +34,13 @@ class ApiPayloadFactory {
             undefined;
     }
 
-    static createSenderData(senderPayload, senderRef) {
-        return this.encodeLiteral({ref: senderRef, payload: senderPayload});
+    static createSenderData(senderRef, senderPayload) {
+        const data = {ref: senderRef};
+
+        if (senderPayload)
+            data.payload = senderPayload;
+
+        return this.encodeLiteral(data);
     }
 
     static encodeLiteral(data) {
@@ -47,8 +52,8 @@ class ApiPayloadFactory {
             .toString('base64');
     }
 
-    createUnsignedPayment(senderPayload, senderRef) {
-        const senderData = ApiPayloadFactory.createSenderData(senderPayload, senderRef);
+    createUnsignedPayment(senderRef, senderPayload) {
+        const senderData = ApiPayloadFactory.createSenderData(senderRef, senderPayload);
 
         return {
             amount: this.amount,

--- a/test-utils/index.js
+++ b/test-utils/index.js
@@ -34,8 +34,8 @@ class ApiPayloadFactory {
             undefined;
     }
 
-    static createSenderData(senderRef) {
-        return this.encodeLiteral({ref: senderRef});
+    static createSenderData(senderPayload, senderRef) {
+        return this.encodeLiteral({ref: senderRef, payload: senderPayload});
     }
 
     static encodeLiteral(data) {
@@ -47,8 +47,8 @@ class ApiPayloadFactory {
             .toString('base64');
     }
 
-    createUnsignedPayment(senderRef) {
-        const senderData = ApiPayloadFactory.createSenderData(senderRef);
+    createUnsignedPayment(senderPayload, senderRef) {
+        const senderData = ApiPayloadFactory.createSenderData(senderPayload, senderRef);
 
         return {
             amount: this.amount,


### PR DESCRIPTION
### Description
<!-- Enter a description of what this PR changes -->
This PR adds support for sender payload embedded into the encoded `sender.data` property. Only string type value of sender payload is allowed. Falsy values are omitted and not embedded into `sender.data`.

### Issues
<!-- Enter references to relevant github issues -->

Issues: 


### Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->



### Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] The [Contribution Guidelines][1] has been followed
- [x] Tests for the changes have been added and all test pass (`npm test`)
- [x] JSDoc comments have been reviewed and added / updated as needed
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures
- [x] Package version number was updated according to semantic rules
- [x] Any changes to upstream dependencies have already been published


[1]: https://github.com/hubiinetwork/nahmii-sdk#contributing
